### PR TITLE
Fix LTRIM cursor drift + keep Cursor agents in room_listen loop

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -16,18 +16,46 @@ const POLL_MAX_MS = 30_000;
 const POLL_INTERVAL_MS = 1_500;
 
 // How many CONSECUTIVE no-message blocks we issue before letting the agent
-// actually stop. Each block runs for up to POLL_MAX_MS, so 12 × 30s = 6 min
+// actually stop. Each block runs for up to POLL_MAX_MS, so 60 × 30s = 30 min
 // of guaranteed presence after the agent's last meaningful action. The
 // streak resets whenever a real message arrives (productive activity is
 // not penalized) and on UserPromptSubmit. This is the practical bound on
 // how long an idle agent stays "listening" after a quiet stretch.
-const MAX_BLOCKS_PER_CYCLE = 12;
+//
+// Was 12 (= 6 min). Raised to 60 because users running long meetings
+// reported agents disappearing 6 minutes in during a natural pause; the
+// fixed cap was the bottleneck, not the user's instruction. Override by
+// setting AGENT_ROOM_MAX_BLOCKS in the environment.
+const MAX_BLOCKS_PER_CYCLE = (() => {
+  const fromEnv = parseInt(process.env.AGENT_ROOM_MAX_BLOCKS ?? '', 10);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : 60;
+})();
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// Two clients funnel into this hook today:
+//
+// - Claude Code / Codex CLI: send `hook_event_name` ∈ { Stop, UserPromptSubmit,
+//   SessionStart } and expect `{ decision: "block", reason }` to keep the
+//   turn open, or `{ hookSpecificOutput: { ... } }` for context injection.
+//
+// - Cursor 1.7+: sends `{ status, loop_count }` (no `hook_event_name`) on
+//   the `stop` event and expects `{ followup_message }` to enqueue the next
+//   user message; an empty/omitted body means "let the turn end".
+//
+// We detect the shape and emit the right response per client.
 interface HookInput {
+  // Claude Code / Codex CLI
   hook_event_name?: string;
   stop_hook_active?: boolean;
+  // Cursor 1.7+ stop hook
+  status?: 'completed' | 'aborted' | 'error';
+  loop_count?: number;
+  conversation_id?: string;
+}
+
+function isCursorStopInput(input: HookInput): boolean {
+  return input.hook_event_name === undefined && typeof input.status === 'string';
 }
 
 interface PendingRoom {
@@ -128,7 +156,22 @@ async function readStdin(): Promise<HookInput> {
 
 export async function runHook(env: UpstashEnv): Promise<void> {
   const input = await readStdin();
-  const event = input.hook_event_name ?? 'Stop';
+  const cursorMode = isCursorStopInput(input);
+  // Normalize the event name across clients. Cursor only fires the stop
+  // hook (no UserPromptSubmit / SessionStart equivalent today), so we
+  // collapse its `status` into our internal "Stop" event for the rest of
+  // the pipeline. Claude Code / Codex still send their own event name.
+  // An empty stdin payload (e.g. manual test invocation) falls through to
+  // a no-op — we used to default to 'Stop' which could trigger phantom
+  // long-polls; now we only act when we actually got an event.
+  let event: string;
+  if (cursorMode) {
+    event = 'Stop';
+  } else if (input.hook_event_name) {
+    event = input.hook_event_name;
+  } else {
+    process.exit(0);
+  }
 
   // User typed something — fresh turn cycle. Reset the block streak so the
   // next Stop hook can block fresh up to MAX_BLOCKS_PER_CYCLE times.
@@ -139,12 +182,18 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   // Cap the autonomous block-continue chain. We DO allow continuing past
   // stop_hook_active=true (so two agents can chat back-and-forth without the
   // user having to retype), but we cap at MAX_BLOCKS_PER_CYCLE to ensure
-  // there's always an exit. UserPromptSubmit resets the counter.
-  if (event === 'Stop' && input.stop_hook_active === true) {
+  // there's always an exit. UserPromptSubmit (Claude Code) and the Cursor
+  // loop_count reset on user input both feed into the same logic.
+  // For Cursor, `loop_count` is server-side; we still respect our own
+  // streak cap as the durable backstop. (Cursor's own `loop_limit: null`
+  // makes it unlimited from Cursor's side, so this cap is what actually
+  // bounds the chain.)
+  if (event === 'Stop' && (input.stop_hook_active === true || cursorMode)) {
     const state = await readState();
     if ((state.blockStreak ?? 0) >= MAX_BLOCKS_PER_CYCLE) {
-      // Reached the cap — let Claude actually stop. Future user input
-      // resets the counter via the UserPromptSubmit branch above.
+      // Reached the cap — let the agent actually stop. Future user input
+      // resets the counter via the UserPromptSubmit branch above (CC) or
+      // the next user message in Cursor (loop_count resets to 0).
       try { await resetBlockStreak(); } catch { /* non-essential */ }
       process.exit(0);
     }
@@ -188,7 +237,15 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   if (withMessages.length > 0 && event === 'Stop') {
     try { await resetBlockStreak(); } catch { /* non-essential */ }
     const text = formatMessages(withMessages);
-    process.stdout.write(JSON.stringify({ decision: 'block', reason: text }));
+    if (cursorMode) {
+      // Cursor expects `{ followup_message }` and submits it as the next
+      // user message. The text already explains the messages and asks the
+      // agent to call room_send / room_listen, which is exactly what we
+      // want as a follow-up.
+      process.stdout.write(JSON.stringify({ followup_message: text }));
+    } else {
+      process.stdout.write(JSON.stringify({ decision: 'block', reason: text }));
+    }
     process.exit(0);
   }
 
@@ -235,7 +292,12 @@ export async function runHook(env: UpstashEnv): Promise<void> {
       }
       lines.push('');
       lines.push('After the listen returns, decide: reply with room_send (and queue another room_listen), or call room_listen again to keep waiting. The only valid reasons to stop are: room ended, you were removed from participants, or the host explicitly said you can leave.');
-      process.stdout.write(JSON.stringify({ decision: 'block', reason: lines.join('\n') }));
+      const text = lines.join('\n');
+      if (cursorMode) {
+        process.stdout.write(JSON.stringify({ followup_message: text }));
+      } else {
+        process.stdout.write(JSON.stringify({ decision: 'block', reason: text }));
+      }
       process.exit(0);
     }
     process.exit(0);

--- a/apps/mcp/src/init.ts
+++ b/apps/mcp/src/init.ts
@@ -153,18 +153,53 @@ async function installClaudeDesktop(): Promise<InstallResult> {
   return result;
 }
 
-async function installCursor(): Promise<InstallResult> {
-  const path = join(homedir(), '.cursor', 'mcp.json');
-  const data = (await readJson(path)) ?? {};
+async function installCursor(opts: { hooks: boolean }): Promise<InstallResult> {
+  const result: InstallResult = { changes: [], unchanged: [] };
+
+  // Step 1: register the MCP server in ~/.cursor/mcp.json (same shape as
+  // Claude Code / Claude Desktop / Cline).
+  const mcpPath = join(homedir(), '.cursor', 'mcp.json');
+  const data = (await readJson(mcpPath)) ?? {};
   const servers = ((data.mcpServers as Record<string, unknown>) ?? {});
-  const before = JSON.stringify(servers['agent-room']);
+  const beforeServers = JSON.stringify(servers['agent-room']);
   servers['agent-room'] = MCP_ENTRY;
   data.mcpServers = servers;
-  if (JSON.stringify(servers['agent-room']) !== before) {
-    await writeJsonAtomic(path, data);
-    return { changes: [`wrote ${path} (agent-room MCP server)`], unchanged: [] };
+  if (JSON.stringify(servers['agent-room']) !== beforeServers) {
+    await writeJsonAtomic(mcpPath, data);
+    result.changes.push(`wrote ${mcpPath} (agent-room MCP server)`);
+  } else {
+    result.unchanged.push(`${mcpPath} (already configured)`);
   }
-  return { changes: [], unchanged: [`${path} (already configured)`] };
+
+  // Step 2: optionally install the Cursor 1.7+ `stop` hook in
+  // ~/.cursor/hooks.json. Cursor's stop-hook schema is shaped:
+  //   { "version": 1, "hooks": { "stop": [{ command, loop_limit }, ...] } }
+  // where the hook command receives `{ status, loop_count }` on stdin and
+  // can write `{ followup_message }` to stdout to enqueue the next user
+  // message — that's what keeps the agent in the room_listen loop. Without
+  // this hook, Cursor agents drop out of rooms the moment their turn ends.
+  // `loop_limit: null` lets our own MAX_BLOCKS_PER_CYCLE cap (in hook.ts)
+  // be the durable backstop.
+  if (opts.hooks) {
+    const hooksPath = join(homedir(), '.cursor', 'hooks.json');
+    const existing = (await readJson(hooksPath)) ?? {};
+    const hooksObj = ((existing.hooks as Record<string, unknown>) ?? {});
+    const stopList = Array.isArray(hooksObj.stop) ? [...(hooksObj.stop as unknown[])] : [];
+    const alreadyInstalled = stopList.some((h: any) => h?.command === HOOK_COMMAND);
+    if (!alreadyInstalled) {
+      stopList.push({ command: HOOK_COMMAND, loop_limit: null });
+      hooksObj.stop = stopList;
+      existing.hooks = hooksObj;
+      // Cursor docs require `version: 1` at the top level.
+      if (existing.version !== 1) existing.version = 1;
+      await writeJsonAtomic(hooksPath, existing);
+      result.changes.push(`wrote ${hooksPath} (stop hook for autonomous chat)`);
+    } else {
+      result.unchanged.push(`${hooksPath} (stop hook already installed)`);
+    }
+  }
+
+  return result;
 }
 
 // Gemini CLI uses ~/.gemini/settings.json with the same `mcpServers` shape
@@ -288,8 +323,17 @@ function printConfigs() {
   console.log(mcp);
   console.log('\nNote: Claude Desktop supports MCP tools, but not Claude Code hooks. Use room_listen for live room messages.');
 
-  console.log('\n--- Cursor / Windsurf / Cline ---');
-  console.log('~/.cursor/mcp.json (or equivalent):');
+  console.log('\n--- Cursor (1.7+) ---');
+  console.log('~/.cursor/mcp.json:');
+  console.log(mcp);
+  console.log('\n~/.cursor/hooks.json (for autonomous chat — keeps agent in room_listen loop):');
+  console.log(JSON.stringify({
+    version: 1,
+    hooks: { stop: [{ command: HOOK_COMMAND, loop_limit: null }] },
+  }, null, 2));
+
+  console.log('\n--- Windsurf ---');
+  console.log('~/.codeium/windsurf/mcp_config.json (or equivalent):');
   console.log(mcp);
 
   console.log('\n--- Gemini CLI ---');
@@ -350,7 +394,7 @@ export async function runInit(argv: string[]): Promise<void> {
     console.log('Where to install?');
     console.log('  1. Claude Code   (default — adds MCP server + autonomous-chat hooks)');
     console.log('  2. Claude Desktop (MCP server only — use room_listen for live chat)');
-    console.log('  3. Cursor');
+    console.log('  3. Cursor          (Cursor 1.7+: adds MCP server + stop hook)');
     console.log('  4. Codex CLI     (adds MCP server + hooks)');
     console.log('  5. Gemini CLI');
     console.log('  6. Cline (VS Code extension)');
@@ -373,8 +417,11 @@ export async function runInit(argv: string[]): Promise<void> {
   }
 
   if (target === 'cursor') {
-    const result = await installCursor();
+    const result = await installCursor({ hooks: !noHooks });
     reportResult('Cursor', result);
+    if (noHooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat — Cursor 1.7+ required)');
+    }
     nextSteps('Cursor');
     return;
   }

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -123,7 +123,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
       {
         name: 'room_listen',
         description:
-          'Block up to timeoutMs (default 30000ms = 30s) waiting for new messages, returning as soon as any arrive. ' +
+          'Block up to timeoutMs (default 240000ms = 4min) waiting for new messages, returning as soon as any arrive. ' +
           'THIS IS THE PRIMARY LOOP PRIMITIVE FOR BEING PRESENT IN A CHAT. After room_create / room_join / room_send, call room_listen with the returned cursor, then either reply (room_send) or call room_listen again with the new cursor to keep waiting. ' +
           'An empty return after timeout means nobody spoke during the window — this is normal, just call room_listen again. ' +
           'STAY IN THE LOOP until you observe one of these termination signals: (a) the room status becomes "ended", (b) the host says something like "you can leave" / "退出会议" / "exit", (c) you are removed from participants. Until then, every turn must end with another room_listen call queued up — do not silently stop listening.',
@@ -133,7 +133,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
           properties: {
             code: { type: 'string' },
             since: { type: 'number', description: 'Cursor from previous call' },
-            timeoutMs: { type: 'number', description: 'Max wait time in ms (default 30000). Use higher (60000-300000) for human-in-the-loop conversations.' },
+            timeoutMs: { type: 'number', description: 'Max wait time in ms (default 240000 = 4min). Long default keeps clients without Stop hooks (Cursor, Claude Desktop, Gemini) present in the room across model turns. Cap at ~270000 to stay under the typical 5-min tool-call timeout.' },
           },
         },
       },
@@ -374,7 +374,14 @@ export function registerTools(server: Server, env: UpstashEnv) {
 
     if (name === 'room_listen') {
       const since = a.since ?? 0;
-      const timeoutMs = a.timeoutMs ?? 30000;
+      // Default 4 minutes (was 30s). 30s is too short for clients without a
+      // Stop hook (Cursor, Claude Desktop, Gemini, Cline) — the agent ends
+      // its turn and never gets nudged back into the listen loop, so it
+      // silently drops out of the room. 240s keeps the agent present for
+      // most natural conversation pauses while staying under the typical
+      // 5-min MCP tool-call timeout. Hooked clients (Claude Code, Codex,
+      // and now Cursor 1.7+) layer their own keep-alive on top of this.
+      const timeoutMs = a.timeoutMs ?? 240000;
       const start = Date.now();
       // Best-effort presence stamp: tells other participants this agent is
       // actively listening until `start + timeoutMs`. Name comes from the

--- a/packages/upstash-client/src/messages.ts
+++ b/packages/upstash-client/src/messages.ts
@@ -4,6 +4,17 @@ import type { UpstashClient } from './client.js';
 import { findSpeaker, MutedError, getRoom } from './rooms.js';
 
 function msgsKey(code: string): string { return `room-msgs:${code}`; }
+// Tracks the absolute count of messages ever appended to this room. Used by
+// listMessages to translate an agent's logical cursor (= "I've consumed N
+// messages so far") into the right LRANGE start position even after LTRIM has
+// dropped the oldest entries. Without this, once the list crosses
+// MAX_MESSAGES_PER_ROOM the index stored in the cursor stops mapping to the
+// list slot the agent thinks it does, and agents silently MISS messages
+// (witnessed: 499 in list, +2 RPUSH, LTRIM keeps last 500 → first new
+// message is now at index 498, but cursor=499 LRANGEs from 499 and only
+// returns the second new message). The counter key is INCRed in the same
+// pipeline as RPUSH/LTRIM so it can never drift relative to the list.
+function msgCountKey(code: string): string { return `room-msg-count:${code}`; }
 
 // Append a message. Server-side gate: the (name, client) in the message
 // must correspond to a participant whose `canSpeak` is not false. New
@@ -23,18 +34,61 @@ export async function appendMessage(
   }
   // Refresh TTL on every append so the message list expires alongside the room key
   // (spec §3.2). Without EXPIRE, the list key would orphan after room:{code} TTLs out.
+  // INCR on the count key MUST sit in the same pipeline as RPUSH so the count
+  // stays in lock-step with the list — listMessages relies on the invariant
+  // `totalCount - listLen = number of LTRIMmed entries` to compensate cursors.
   await client.pipeline([
     ['RPUSH', msgsKey(code), JSON.stringify(message)],
+    ['INCR', msgCountKey(code)],
     ['LTRIM', msgsKey(code), -MAX_MESSAGES_PER_ROOM, -1],
     ['EXPIRE', msgsKey(code), ROOM_TTL_SECONDS],
+    ['EXPIRE', msgCountKey(code), ROOM_TTL_SECONDS],
   ]);
 }
 
+// Cursor semantics: `fromIndex` is the absolute count of messages the caller
+// has already consumed (0 on first call, advanced by `msgs.length` after
+// each call). It is NOT a list-index — the on-disk list shifts whenever
+// LTRIM trims the head, so a list-index cursor would skip messages past
+// MAX_MESSAGES_PER_ROOM. The counter key + LLEN let us reconstruct where the
+// caller's next unread message actually lives in the (possibly trimmed) list.
 export async function listMessages(
   client: UpstashClient,
   code: string,
   fromIndex: number
 ): Promise<Message[]> {
-  const raw = await client.command<string[]>(['LRANGE', msgsKey(code), fromIndex, -1]);
+  // One pipeline: ask for both the absolute count and the current list length.
+  // count===null means this is a legacy room created before the counter was
+  // introduced — fall back to treating fromIndex as a list-index (matches
+  // pre-fix behavior; still buggy past 500 messages but no worse than before
+  // and avoids breaking in-flight conversations during the rollout).
+  const meta = await client.pipeline<unknown>([
+    ['GET', msgCountKey(code)],
+    ['LLEN', msgsKey(code)],
+  ]);
+  const countRaw = meta[0] as string | number | null;
+  const listLen = Number(meta[1] ?? 0);
+  if (listLen === 0) return [];
+
+  let start: number;
+  if (countRaw === null || countRaw === undefined) {
+    start = fromIndex;
+  } else {
+    const totalCount = typeof countRaw === 'number' ? countRaw : parseInt(countRaw, 10);
+    // `trimmed` is the number of head entries LTRIM has dropped over this
+    // room's lifetime. Subtracting it from the agent's absolute cursor
+    // gives the right list-index for the next unread message.
+    const trimmed = totalCount - listLen;
+    start = fromIndex - trimmed;
+    // If the agent's cursor lags so far that messages it never saw have
+    // already been LTRIMmed away, the best we can do is hand back the
+    // surviving prefix from index 0 — those older messages are gone for
+    // good (LTRIM is destructive; the report/minutes export is the only
+    // way to recover full transcripts past the cap).
+    if (start < 0) start = 0;
+  }
+
+  if (start >= listLen) return [];
+  const raw = await client.command<string[]>(['LRANGE', msgsKey(code), start, -1]);
   return raw.map(line => JSON.parse(line) as Message);
 }

--- a/packages/upstash-client/test/messages.test.ts
+++ b/packages/upstash-client/test/messages.test.ts
@@ -21,12 +21,14 @@ const APPROVED_ROOM: Room = {
 describe('appendMessage', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('RPUSHes the message, LTRIMs to the cap, and refreshes TTL when sender is approved', async () => {
+  it('RPUSHes + INCRs the absolute counter, LTRIMs to the cap, and refreshes TTL on both keys', async () => {
     const fetchMock = vi.fn()
       // First call: getRoom (speak gate check)
       .mockResolvedValueOnce(mockResp({ result: JSON.stringify(APPROVED_ROOM) }))
-      // Second call: pipeline (RPUSH+LTRIM+EXPIRE)
-      .mockResolvedValueOnce(mockResp([{ result: 1 }, { result: 'OK' }, { result: 1 }]));
+      // Second call: pipeline (RPUSH+INCR+LTRIM+EXPIRE×2)
+      .mockResolvedValueOnce(mockResp([
+        { result: 1 }, { result: 1 }, { result: 'OK' }, { result: 1 }, { result: 1 },
+      ]));
     vi.stubGlobal('fetch', fetchMock);
 
     const client = createClient(ENV);
@@ -35,16 +37,21 @@ describe('appendMessage', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const [, init] = fetchMock.mock.calls[1]!; // pipeline call
     const cmds = JSON.parse((init as any).body);
-    expect(cmds).toHaveLength(3);
+    expect(cmds).toHaveLength(5);
     expect(cmds[0][0]).toBe('RPUSH');
     expect(cmds[0][1]).toBe('room-msgs:ABC-DEF-GHJ');
     expect(JSON.parse(cmds[0][2])).toEqual(MSG);
-    expect(cmds[1][0]).toBe('LTRIM');
-    expect(cmds[1][2]).toBe(-MAX_MESSAGES_PER_ROOM);
-    expect(cmds[1][3]).toBe(-1);
-    expect(cmds[2][0]).toBe('EXPIRE');
-    expect(cmds[2][1]).toBe('room-msgs:ABC-DEF-GHJ');
-    expect(cmds[2][2]).toBe(ROOM_TTL_SECONDS);
+    expect(cmds[1][0]).toBe('INCR');
+    expect(cmds[1][1]).toBe('room-msg-count:ABC-DEF-GHJ');
+    expect(cmds[2][0]).toBe('LTRIM');
+    expect(cmds[2][2]).toBe(-MAX_MESSAGES_PER_ROOM);
+    expect(cmds[2][3]).toBe(-1);
+    expect(cmds[3][0]).toBe('EXPIRE');
+    expect(cmds[3][1]).toBe('room-msgs:ABC-DEF-GHJ');
+    expect(cmds[3][2]).toBe(ROOM_TTL_SECONDS);
+    expect(cmds[4][0]).toBe('EXPIRE');
+    expect(cmds[4][1]).toBe('room-msg-count:ABC-DEF-GHJ');
+    expect(cmds[4][2]).toBe(ROOM_TTL_SECONDS);
   });
 
   it('throws NotApprovedError when the sender is pending host approval', async () => {
@@ -70,29 +77,122 @@ describe('appendMessage', () => {
 describe('listMessages', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('LRANGEs from the given index and parses each entry', async () => {
+  // Helper: mock the GET-count + LLEN pipeline that listMessages issues first,
+  // then the LRANGE that follows.
+  function mockListMessagesFlow(opts: {
+    countRaw: string | number | null;
+    listLen: number;
+    rangeResult: string[];
+  }) {
+    return vi.fn()
+      .mockResolvedValueOnce(mockResp([
+        { result: opts.countRaw },
+        { result: opts.listLen },
+      ]))
+      .mockResolvedValueOnce(mockResp({ result: opts.rangeResult }));
+  }
+
+  it('uses GET-count + LLEN to compute LRANGE start, then parses the range', async () => {
     const msg1: Message = { id: 1, type: 'msg', name: 'A', initials: 'AA', color: '#111', role: '', text: 'hi', client: 'web', time: 1 };
     const msg2: Message = { ...msg1, id: 2, text: 'yo' };
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResp({ result: [JSON.stringify(msg1), JSON.stringify(msg2)] })));
+    // Room has 7 messages ever appended, list currently holds 7 (no LTRIM yet).
+    // Caller's cursor=5 → start = 5 - (7 - 7) = 5.
+    const fetchMock = mockListMessagesFlow({
+      countRaw: '7',
+      listLen: 7,
+      rangeResult: [JSON.stringify(msg1), JSON.stringify(msg2)],
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const client = createClient(ENV);
     const got = await listMessages(client, 'ABC-DEF-GHJ', 5);
     expect(got).toEqual([msg1, msg2]);
+
+    // Sanity: the LRANGE call we issued used start=5, end=-1.
+    const [, rangeInit] = fetchMock.mock.calls[1]!;
+    expect(JSON.parse((rangeInit as any).body)).toEqual(['LRANGE', 'room-msgs:ABC-DEF-GHJ', 5, -1]);
   });
 
-  it('returns [] when list is empty', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResp({ result: [] })));
-    const client = createClient(ENV);
-    expect(await listMessages(client, 'ABC-DEF-GHJ', 0)).toEqual([]);
-  });
-
-  it('passes the LRANGE command with correct key, fromIndex, and -1 endIndex', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(mockResp({ result: [] }));
+  it('returns [] when the list is empty (skips LRANGE entirely)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResp([{ result: null }, { result: 0 }]));
     vi.stubGlobal('fetch', fetchMock);
     const client = createClient(ENV);
+    expect(await listMessages(client, 'ABC-DEF-GHJ', 0)).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // metadata only, no LRANGE
+  });
+
+  it('legacy room (no count key): falls back to using fromIndex as a list-index', async () => {
+    // Pre-fix room — counter never INCRed. listMessages must not break, just
+    // behave like the old code would (LRANGE fromIndex -1).
+    const fetchMock = mockListMessagesFlow({
+      countRaw: null,
+      listLen: 100,
+      rangeResult: [],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
     await listMessages(client, 'XYZ-123-ABC', 42);
-    const [, init] = fetchMock.mock.calls[0]!;
-    const cmd = JSON.parse((init as any).body);
-    expect(cmd).toEqual(['LRANGE', 'room-msgs:XYZ-123-ABC', 42, -1]);
+
+    const [, rangeInit] = fetchMock.mock.calls[1]!;
+    expect(JSON.parse((rangeInit as any).body)).toEqual(['LRANGE', 'room-msgs:XYZ-123-ABC', 42, -1]);
+  });
+
+  // Regression test for the LTRIM cursor-drift bug. Before the fix:
+  //   list had 499 entries → +2 RPUSH → list=501 → LTRIM keeps last 500
+  //   → first new message is now at index 498, second at 499
+  //   → an agent at cursor=499 LRANGE 499 -1 returns ONE message instead of two
+  //   → first new message silently lost
+  // After the fix the counter compensates the offset and the agent gets BOTH.
+  it('LTRIM cursor-drift regression: returns ALL unread messages even after head was trimmed', async () => {
+    const newMsg1: Message = { id: 9001, type: 'msg', name: 'A', initials: 'AA', color: '#111', role: '', text: 'first-new', client: 'web', time: 9001 };
+    const newMsg2: Message = { ...newMsg1, id: 9002, text: 'second-new', time: 9002 };
+
+    // totalCount = 501 (499 old + 2 new), listLen = 500 (LTRIM dropped 1 head entry).
+    // Caller's cursor = 499 (had read all 499 originals).
+    // Correct start = 499 - (501 - 500) = 498. LRANGE 498 -1 → both new messages.
+    const fetchMock = mockListMessagesFlow({
+      countRaw: '501',
+      listLen: 500,
+      rangeResult: [JSON.stringify(newMsg1), JSON.stringify(newMsg2)],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
+    const got = await listMessages(client, 'ABC-DEF-GHJ', 499);
+
+    expect(got).toEqual([newMsg1, newMsg2]); // would have been [newMsg2] under the old code
+
+    const [, rangeInit] = fetchMock.mock.calls[1]!;
+    expect(JSON.parse((rangeInit as any).body)).toEqual(['LRANGE', 'room-msgs:ABC-DEF-GHJ', 498, -1]);
+  });
+
+  it('cursor far behind LTRIM horizon: clamps start to 0 and hands back surviving prefix', async () => {
+    // Cursor 50 but 200 head entries have already been LTRIMmed away. start
+    // would be 50 - 200 = -150, which we clamp to 0. The very-old messages
+    // are unrecoverable (LTRIM is destructive — see msgsKey comment).
+    const fetchMock = mockListMessagesFlow({
+      countRaw: '700',
+      listLen: 500,
+      rangeResult: [],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
+    await listMessages(client, 'ABC-DEF-GHJ', 50);
+
+    const [, rangeInit] = fetchMock.mock.calls[1]!;
+    expect(JSON.parse((rangeInit as any).body)).toEqual(['LRANGE', 'room-msgs:ABC-DEF-GHJ', 0, -1]);
+  });
+
+  it('cursor at or past totalCount: skips LRANGE and returns []', async () => {
+    // start = 700 - (700 - 500) = 500; listLen = 500 → start >= listLen → [].
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResp([{ result: '700' }, { result: 500 }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = createClient(ENV);
+    expect(await listMessages(client, 'ABC-DEF-GHJ', 700)).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no LRANGE issued
   });
 });


### PR DESCRIPTION
## Summary
- Fix LTRIM cursor drift: agents silently skipped messages once a room crossed 500 msgs. New \`room-msg-count:{code}\` counter (INCRed in the same pipeline as RPUSH) lets \`listMessages\` compensate the offset. Legacy rooms fall back to old behaviour.
- Keep Cursor agents in the room: bump \`room_listen\` default timeout 30s → 240s, and add Cursor 1.7+ stop-hook support — \`init cursor\` now writes \`~/.cursor/hooks.json\` with a stop hook that emits \`{ followup_message }\` to bounce the agent back into \`room_listen\`.
- Raise \`MAX_BLOCKS_PER_CYCLE\` 12 → 60 (6 min → 30 min of guaranteed presence after the agent's last message), with \`AGENT_ROOM_MAX_BLOCKS\` env override. Empty stdin no longer phantom-triggers the Stop branch.
- Bump \`agent-room-mcp\` 0.15.0 → 0.16.0.

## Test plan
- [x] \`npm test\` — 39 passed (4 new \`listMessages\` cases, including a 501-message LTRIM regression)
- [x] \`npm run build\` — all packages
- [x] Smoke test: hook reads Cursor stdin (\`{status, loop_count}\`) and emits \`{followup_message}\`
- [x] Smoke test: hook reads Claude Code stdin (\`{hook_event_name: "Stop"}\`) and still emits \`{decision: "block", reason}\`
- [x] Smoke test: empty stdin → exits 0 (no phantom Stop)
- [x] \`init print\` shows the new \`~/.cursor/hooks.json\` snippet
- [ ] After publish: install in a real Cursor 1.7+ instance and verify the agent stays in \`room_listen\` across a natural 5-min pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)