### PR TITLE
Discoverable host controls + Disconnected tier + \n unescape

### DIFF
--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -17,7 +17,7 @@ import {
   removeParticipant,
   type UpstashEnv,
 } from '@agent-room/upstash-client';
-import { generateCode, AVATAR_PALETTE, roleBriefFor } from '@agent-room/shared';
+import { generateCode, AVATAR_PALETTE, roleBriefFor, normalizeEscapedWhitespace } from '@agent-room/shared';
 import type { Message, Participant } from '@agent-room/shared';
 import { setRoom, removeRoom, updateCursor, markSent, readState } from './state.js';
 
@@ -313,6 +313,16 @@ export function registerTools(server: Server, env: UpstashEnv) {
           role = room.participants.find((p: Participant) => p.name === a.name)?.role ?? '';
         } catch { /* fall through */ }
       }
+      // Cursor's Composer agent (and probably other client subsystems we
+      // haven't seen yet) sometimes JSON.stringify's its own message body
+      // before passing it as the `text` arg, so a real newline arrives as
+      // the 2-character literal "\\n". Without normalization the chat
+      // bubble renders the backslash-n verbatim and the message looks
+      // unformatted. The helper is no-op for well-formed text — it only
+      // unescapes when the input has zero real newlines AND at least one
+      // suspicious escape, so legitimate `\n` literals (e.g. someone
+      // explaining a regex inside a multi-paragraph message) survive.
+      const text = normalizeEscapedWhitespace(a.text);
       const msg: Message = {
         id: Date.now(),
         type: 'msg',
@@ -320,7 +330,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
         initials: initialsFor(a.name),
         color: colorForName(a.name),
         role,
-        text: a.text,
+        text,
         client: 'cc',
         time: Date.now(),
       };

--- a/apps/web/src/components/Bubble.tsx
+++ b/apps/web/src/components/Bubble.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from './Avatar.js';
 import { useMemo, type ReactNode } from 'react';
 import type { Message, MessageAttachment } from '@agent-room/shared';
+import { normalizeEscapedWhitespace } from '@agent-room/shared';
 
 interface Props {
   message: Message;
@@ -80,7 +81,14 @@ function formatBytes(size: number): string {
 }
 
 function MessageText({ text }: { text: string }) {
-  const blocks = useMemo(() => parseBlocks(text), [text]);
+  // Defensively unescape literal `\n` / `\t` sequences before parsing —
+  // some agent clients (Cursor's Composer is the documented offender)
+  // double-escape multi-line bodies before passing them as the `text` arg
+  // to room_send. The MCP server now normalizes on the way in, but
+  // historical messages in active rooms predate that fix; running the
+  // same normalization here at render time makes them readable too.
+  // No-op for well-formed text, see normalizeEscapedWhitespace JSDoc.
+  const blocks = useMemo(() => parseBlocks(normalizeEscapedWhitespace(text)), [text]);
 
   return (
     <div className="space-y-2">

--- a/apps/web/src/screens/Report.tsx
+++ b/apps/web/src/screens/Report.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { artifactLabel, extractArtifacts, type ArtifactKind, type RoomArtifact, type RoomReport } from '@agent-room/shared';
+import { artifactLabel, extractArtifacts, normalizeEscapedWhitespace, type ArtifactKind, type RoomArtifact, type RoomReport } from '@agent-room/shared';
 import { createClient, createRoomReport, getRoom, getRoomReport, listMessages } from '@agent-room/upstash-client';
 import { ENV } from '../env.js';
 
@@ -171,7 +171,7 @@ export function Report() {
                   {m.role && <span> · {m.role}</span>}
                   <span> · {new Date(m.time).toLocaleString()}</span>
                 </div>
-                <p className="whitespace-pre-wrap text-sm leading-relaxed">{m.text}</p>
+                <p className="whitespace-pre-wrap text-sm leading-relaxed">{normalizeEscapedWhitespace(m.text)}</p>
               </article>
             ))}
           </div>

--- a/apps/web/src/screens/Room.tsx
+++ b/apps/web/src/screens/Room.tsx
@@ -7,7 +7,7 @@ import { MeetingCodePill } from '../components/MeetingCodePill.js';
 import { Avatar } from '../components/Avatar.js';
 import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
 import { colorForName, initialsFor } from '../lib/colors.js';
-import { PRESENCE_STALE_MS, artifactLabel, extractArtifacts, type ArtifactKind, type Message, type MessageAttachment, type Participant, type RoomArtifact } from '@agent-room/shared';
+import { PRESENCE_STALE_MS, PRESENCE_DISCONNECTED_MS, artifactLabel, extractArtifacts, type ArtifactKind, type Message, type MessageAttachment, type Participant, type RoomArtifact } from '@agent-room/shared';
 import { setMuted, createClient, createRoomReport, endRoom as endRoomApi, reactivateRoom as reactivateRoomApi, removeParticipant } from '@agent-room/upstash-client';
 import { ENV } from '../env.js';
 import { copyText } from '../lib/copy.js';
@@ -449,7 +449,7 @@ export function Room() {
             <div className="flex-1 overflow-y-auto p-4">
               <div className="text-[10px] font-semibold uppercase text-ink-faint mb-1">Participants</div>
               <p className="mb-3 text-[10px] leading-relaxed text-ink-soft">
-                Listening means the agent is inside a current listen window. Other agent states may still depend on local hooks.
+                Listening = inside an active listen window. Disconnected = no heartbeat for 5+ min, likely the CLI session was killed without leaving cleanly — host can remove with the × button.
               </p>
               <div className="space-y-2">
                 {room.participants.map(p => {
@@ -459,11 +459,20 @@ export function Room() {
                   const isMuted = p.canSpeak === false;
                   const canMuteToggle = isMeHost && !isSelf && !ended;
                   const presence = participantPresence(p, now);
+                  // Whole-row visual fade for participants who haven't been
+                  // seen in a while — keeps the row legible but signals
+                  // "probably gone" without screaming about it.
+                  const rowFade = presence.kind === 'idle'
+                    ? 'opacity-65'
+                    : presence.kind === 'disconnected'
+                      ? 'opacity-50'
+                      : '';
                   return (
-                    <div key={`${p.name}-${p.client}`} className={`group flex items-center gap-2 rounded-lg border px-2.5 py-2 ${isMuted ? 'border-amber-300 bg-amber-50/60' : 'border-border-faint bg-surface-softer'}`}>
-                      <div className={presence.kind === 'idle' ? 'opacity-45' : ''}>
-                        <Avatar initials={p.initials} color={p.color} size="sm" />
-                      </div>
+                    <div
+                      key={`${p.name}-${p.client}`}
+                      className={`flex items-center gap-2 rounded-lg border px-2.5 py-2 transition ${rowFade} ${isMuted ? 'border-amber-300 bg-amber-50/60' : 'border-border-faint bg-surface-softer'}`}
+                    >
+                      <Avatar initials={p.initials} color={p.color} size="sm" />
                       <div className="min-w-0 flex-1">
                         <div className="text-xs font-semibold truncate flex items-center gap-1 flex-wrap">
                           {p.name}
@@ -479,25 +488,53 @@ export function Room() {
                           {presence.detail && <span className="text-ink-faint">· {presence.detail}</span>}
                         </div>
                       </div>
-                      {canMuteToggle && (
-                        <button
-                          onClick={() => handleToggleMute({ name: p.name, client: p.client, canSpeak: p.canSpeak })}
-                          title={isMuted ? `Unmute ${p.name}` : `Mute ${p.name}`}
-                          className={`text-[10px] font-semibold px-2 h-6 rounded transition ${isMuted
-                            ? 'text-emerald-700 bg-emerald-100 hover:bg-emerald-200'
-                            : 'opacity-0 group-hover:opacity-100 focus:opacity-100 text-amber-700 bg-amber-100 hover:bg-amber-200'}`}
-                        >
-                          {isMuted ? '🔊 Unmute' : '🔇 Mute'}
-                        </button>
-                      )}
-                      {canKick && (
-                        <button
-                          onClick={() => handleKick({ name: p.name, client: p.client })}
-                          title={`Remove ${p.name}`}
-                          className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] font-semibold text-red-600 hover:bg-red-50 w-6 h-6 rounded transition"
-                        >
-                          ×
-                        </button>
+                      {/*
+                        Host controls — always visible (no hover-to-reveal).
+                        Hover-only buttons hid the kick action so badly that
+                        a user reported "the delete agent button isn't
+                        obvious" and "the mute button feels cramped". Keep
+                        them quiet visually (low contrast, neutral border)
+                        but always discoverable, and only render at all when
+                        the viewer is actually the host.
+                      */}
+                      {(canMuteToggle || canKick) && (
+                        <div className="flex items-center gap-1">
+                          {canMuteToggle && (
+                            <button
+                              onClick={() => handleToggleMute({ name: p.name, client: p.client, canSpeak: p.canSpeak })}
+                              title={isMuted ? `Unmute ${p.name}` : `Mute ${p.name}`}
+                              aria-label={isMuted ? `Unmute ${p.name}` : `Mute ${p.name}`}
+                              className={`flex h-7 w-7 items-center justify-center rounded-md border text-[11px] transition ${isMuted
+                                ? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                                : 'border-border-faint bg-surface text-ink-soft hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700'}`}
+                            >
+                              {/* Speaker glyph: solid when can speak, slashed when muted. */}
+                              {isMuted ? (
+                                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                  <path d="M8 3.5 4.5 6.25H2.5v3.5h2L8 12.5z" />
+                                  <path d="m11 6 3 4M14 6l-3 4" />
+                                </svg>
+                              ) : (
+                                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                  <path d="M8 3.5 4.5 6.25H2.5v3.5h2L8 12.5z" />
+                                  <path d="M11 5.75c.75.6 1.25 1.4 1.25 2.25s-.5 1.65-1.25 2.25" />
+                                </svg>
+                              )}
+                            </button>
+                          )}
+                          {canKick && (
+                            <button
+                              onClick={() => handleKick({ name: p.name, client: p.client })}
+                              title={`Remove ${p.name}`}
+                              aria-label={`Remove ${p.name}`}
+                              className="flex h-7 w-7 items-center justify-center rounded-md border border-border-faint bg-surface text-ink-soft transition hover:border-red-300 hover:bg-red-50 hover:text-red-600"
+                            >
+                              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" aria-hidden="true">
+                                <path d="m4 4 8 8M12 4l-8 8" />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
                       )}
                     </div>
                   );
@@ -802,7 +839,7 @@ function artifactTone(kind: ArtifactKind): string {
 function participantPresence(p: Participant, now: number) {
   if (p.listenUntil && p.listenUntil > now) {
     return {
-      kind: 'listening',
+      kind: 'listening' as const,
       label: 'Listening now',
       detail: '',
       className: 'text-emerald-700',
@@ -812,7 +849,7 @@ function participantPresence(p: Participant, now: number) {
 
   if (now - p.lastSeenAt <= PRESENCE_STALE_MS) {
     return {
-      kind: 'online',
+      kind: 'online' as const,
       label: 'Online',
       detail: p.client === 'cc' ? 'hook unknown' : '',
       className: 'text-blue-700',
@@ -820,8 +857,24 @@ function participantPresence(p: Participant, now: number) {
     };
   }
 
+  // Past 5 minutes silent → almost certainly disconnected. Most common cause:
+  // a CLI agent (Cursor / Claude Code / Codex) was terminated by the user
+  // without calling room_leave, so the participant row stays in the room
+  // forever. The "Disconnected" label is a hint to the host that this
+  // participant is unlikely to come back, paired with the always-visible
+  // kick button so they can clean up in one click.
+  if (now - p.lastSeenAt > PRESENCE_DISCONNECTED_MS) {
+    return {
+      kind: 'disconnected' as const,
+      label: 'Disconnected',
+      detail: p.client === 'cc' ? 'host can remove' : '',
+      className: 'text-ink-faint',
+      dotClassName: 'bg-slate-400',
+    };
+  }
+
   return {
-    kind: 'idle',
+    kind: 'idle' as const,
     label: 'Idle',
     detail: p.client === 'cc' ? 'not listening' : '',
     className: 'text-ink-faint',

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,6 +15,12 @@ export const MESSAGE_POLL_MS = 3000;
 export const ROOM_POLL_MS = 5000;
 export const HEARTBEAT_MS = 30000;
 export const PRESENCE_STALE_MS = 60000;
+// Past this many ms with no heartbeat AND no active listen window we treat
+// the participant as disconnected — most likely they got killed mid-session
+// without calling room_leave (Cursor / Codex sessions terminated by user
+// just exit, never tell the room they're gone). UI surfaces this so the
+// host can manually remove them.
+export const PRESENCE_DISCONNECTED_MS = 5 * 60 * 1000;
 
 // Avatar palette — indigo/pink/amber/violet/emerald/rose/sky/fuchsia
 export const AVATAR_PALETTE: readonly string[] = [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from './constants.js';
 export * from './codeGen.js';
 export * from './roles.js';
 export * from './artifacts.js';
+export * from './text.js';

--- a/packages/shared/src/text.ts
+++ b/packages/shared/src/text.ts
@@ -1,0 +1,30 @@
+// Defensive normalization for message text bodies coming in from clients
+// that sometimes escape their own whitespace before passing it through
+// `room_send`. Witnessed: Cursor's Composer agent occasionally JSON.stringify's
+// its outgoing message body, so a real newline ('\n', 0x0A) gets stored as
+// the two-character sequence backslash-n ("\\n"). The chat renderer then
+// shows the user "\n" verbatim instead of a paragraph break.
+//
+// We can't fix this in Cursor, so we defend on both ends: the MCP `room_send`
+// handler runs this on incoming text before append (so new messages are
+// stored correctly), and the web Bubble component runs this on display
+// (so messages already in Redis from before the fix landed render correctly
+// too). Same function; safe to apply twice.
+//
+// Heuristic: if the text contains ANY real newline, we trust the sender —
+// a legitimate `\n` literal (e.g. someone explaining a regex) inside a
+// multi-paragraph message must not be molested. We only act when the text
+// has zero real newlines AND at least one whitespace-style escape, which
+// is the unambiguous "double-encoded" signal.
+export function normalizeEscapedWhitespace(text: string): string {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  // Real newline anywhere → trust the sender.
+  if (text.includes('\n') || text.includes('\r')) return text;
+  // No suspicious escapes → nothing to do (fast path for short messages).
+  if (!/\\[nrt]/.test(text)) return text;
+  return text
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\n')
+    .replace(/\\t/g, '\t');
+}

--- a/packages/shared/test/text.test.ts
+++ b/packages/shared/test/text.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeEscapedWhitespace } from '../src/text.js';
+
+describe('normalizeEscapedWhitespace', () => {
+  it('returns plain single-line text untouched', () => {
+    expect(normalizeEscapedWhitespace('hello world')).toBe('hello world');
+  });
+
+  it('returns empty string untouched', () => {
+    expect(normalizeEscapedWhitespace('')).toBe('');
+  });
+
+  it('returns multi-line text with real newlines untouched (trusts the sender)', () => {
+    const real = 'line1\nline2\n\nline3';
+    expect(normalizeEscapedWhitespace(real)).toBe(real);
+  });
+
+  it('preserves a literal `\\n` inside a message that ALSO has real newlines', () => {
+    // Sender intentionally referenced `\n` (e.g. explaining a regex). Real
+    // newlines are present, so the escape is legitimate — leave it alone.
+    const input = 'use the regex \\n to match newlines\n\nthat is the trick';
+    expect(normalizeEscapedWhitespace(input)).toBe(input);
+  });
+
+  it('unescapes `\\n` when the body has zero real newlines (Cursor Composer regression)', () => {
+    // The exact shape we observed in production: Composer JSON.stringify'd
+    // its own message body before passing it as `text`, so a paragraph
+    // break became the 2-character sequence backslash-n.
+    const input = '@robin 抱歉，我按日文场景回了。\\n\\n前面 Claude 卡在等你选：A/B/C/D。';
+    const expected = '@robin 抱歉，我按日文场景回了。\n\n前面 Claude 卡在等你选：A/B/C/D。';
+    expect(normalizeEscapedWhitespace(input)).toBe(expected);
+  });
+
+  it('unescapes `\\r\\n` first so Windows-style escapes collapse to a single newline', () => {
+    expect(normalizeEscapedWhitespace('a\\r\\nb')).toBe('a\nb');
+  });
+
+  it('unescapes `\\t` alongside `\\n` when both appear and no real newlines are present', () => {
+    expect(normalizeEscapedWhitespace('header\\tvalue\\nrow2')).toBe('header\tvalue\nrow2');
+  });
+
+  it('does NOT unescape `\\t` alone in single-line text (only kicks in when whitespace escapes coexist)', () => {
+    // We unescape any of `\\n` / `\\r` / `\\t` once the no-real-newline gate
+    // passes — but the gate requires at least one of those escapes to appear.
+    // A pure single-line message with one `\t` is technically caught; this
+    // test pins the current behavior so future tightening is intentional.
+    expect(normalizeEscapedWhitespace('col1\\tcol2')).toBe('col1\tcol2');
+  });
+
+  it('handles non-string input defensively (returns it unchanged)', () => {
+    // `text` is typed string but the renderer uses normalizeEscapedWhitespace
+    // on raw message data, so guard against an unexpected non-string slipping
+    // through (e.g. a future schema migration).
+    expect(normalizeEscapedWhitespace(undefined as unknown as string)).toBe(undefined);
+    expect(normalizeEscapedWhitespace(null as unknown as string)).toBe(null);
+  });
+});


### PR DESCRIPTION
Two follow-ups to PR #1, plus a fix for a Cursor regression spotted in production room SJQ-45T-9KF.

## Summary
1. **Always-visible host controls** — kick (×) and mute buttons used to be hover-only via \`opacity-0 group-hover:opacity-100\`, so a user reported "the delete agent button isn't obvious" and "the mute button feels cramped". Drop the hover-only reveal, replace the loud emoji + amber bg with a quiet icon-only button (clean SVG glyph, neutral border). Only renders for hosts.
2. **\`Disconnected\` presence tier** — when a CLI agent (Cursor / Codex / Claude Code) gets killed by the user without calling \`room_leave\`, its participant row stays in the list forever. Old code labeled it just "Idle · not listening" which was easy to miss. New 4th tier kicks in after 5 min of silence, fades the row to 50%, and surfaces "host can remove" — pairs with the now always-visible kick button.
3. **\\n unescape** — Cursor's Composer agent sometimes JSON.stringify's its own message body before passing it as the \`text\` arg, so real newlines arrive as the 2-character literal \`\\n\`. Cursor confirmed it in-room. New shared helper \`normalizeEscapedWhitespace\` runs in MCP \`room_send\` (new messages stored correctly) and in Bubble/Report rendering (historical messages in Redis become readable). Heuristic only fires when the body has zero real newlines AND a suspicious escape, so legitimate \`\\n\` literals (regex examples, etc.) survive.

## Test plan
- [x] \`npm test\` — 48 passed (9 new \`normalizeEscapedWhitespace\` cases including the exact production string)
- [x] \`npm run build\` — all packages green
- [x] Production room SJQ-45T-9KF inspected to confirm Composer is the offender, not Bubble.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)