### PR TITLE
feat: detect agent harness, persistence-setup hint, /j Quickstart

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {
@@ -14,6 +14,7 @@
     "build": "tsup",
     "prepublishOnly": "tsup",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
     "start": "node dist/index.js"
   },
   "keywords": [
@@ -37,6 +38,7 @@
     "@types/node": "^20.12.0",
     "tsup": "^8.5.1",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/apps/mcp/src/harness.ts
+++ b/apps/mcp/src/harness.ts
@@ -1,0 +1,80 @@
+// Detect which agent harness is running this MCP process. Used to
+// conditionally append a persistence-setup nudge to room_join /
+// room_create hints — harnesses that don't auto-loop tool calls
+// (Cursor without 1.7+ stop hooks, Claude Desktop, Gemini CLI, etc.)
+// silently drop out of rooms unless the user has run
+// `npx agent-room-mcp init`.
+
+export type ClientKind =
+  | 'claude-code'
+  | 'cursor'
+  | 'codex'
+  | 'gemini-cli'
+  | 'claude-desktop'
+  | 'cline'
+  | 'windsurf'
+  | 'unknown';
+
+export interface HarnessInfo {
+  kind: ClientKind;
+  /** True when the harness is known NOT to auto-loop tool calls and
+   *  therefore needs the agent-room-mcp stop hook installed for
+   *  persistent listening. Conservative default for unknown clients
+   *  is `true` — better to over-nudge than have an agent silently
+   *  drop out of every room. */
+  needsPersistenceSetup: boolean;
+  /** Human-readable harness label to splice into hints. */
+  label: string;
+}
+
+const KNOWN_STRONG_LOOP: HarnessInfo[] = [
+  { kind: 'claude-code', needsPersistenceSetup: false, label: 'Claude Code' },
+  { kind: 'codex', needsPersistenceSetup: false, label: 'Codex CLI' },
+];
+
+export function detectHarness(env: NodeJS.ProcessEnv = process.env): HarnessInfo {
+  // Order matters: most specific signals first. Each branch keys off a
+  // single env var the host harness is documented to set. Conservative
+  // by design — when in doubt we return 'unknown', which is treated as
+  // weak-loop (user gets a setup nudge, low downside).
+
+  if (env.CLAUDECODE === '1' || env.CLAUDE_CODE_ENTRYPOINT) {
+    return KNOWN_STRONG_LOOP[0]!;
+  }
+  if (env.CODEX_RUN_ID || (env.CODEX_HOME && !env.CLAUDECODE)) {
+    return KNOWN_STRONG_LOOP[1]!;
+  }
+  if (env.CURSOR_TRACE_ID || env.CURSOR_AGENT || env.TERM_PROGRAM === 'Cursor') {
+    return { kind: 'cursor', needsPersistenceSetup: true, label: 'Cursor' };
+  }
+  if (env.GEMINI_CLI || env.GOOGLE_GEMINI_CLI) {
+    return { kind: 'gemini-cli', needsPersistenceSetup: true, label: 'Gemini CLI' };
+  }
+  if (env.CLAUDE_DESKTOP_VERSION || env.__CFBundleIdentifier === 'com.anthropic.claudefordesktop') {
+    return { kind: 'claude-desktop', needsPersistenceSetup: true, label: 'Claude Desktop' };
+  }
+  if (env.CLINE_VERSION) {
+    return { kind: 'cline', needsPersistenceSetup: true, label: 'Cline' };
+  }
+  if (env.WINDSURF_VERSION || env.TERM_PROGRAM === 'Windsurf') {
+    return { kind: 'windsurf', needsPersistenceSetup: true, label: 'Windsurf' };
+  }
+  return { kind: 'unknown', needsPersistenceSetup: true, label: 'this client' };
+}
+
+/**
+ * Build the persistence-setup nudge appended to room_join / room_create hints
+ * for harnesses that don't auto-loop. Returns empty string for strong-loop
+ * harnesses (Claude Code, Codex CLI) so we don't add noise where it isn't
+ * needed.
+ */
+export function persistenceSetupHint(info: HarnessInfo): string {
+  if (!info.needsPersistenceSetup) return '';
+  return (
+    ` PERSISTENCE NOTE (${info.label}): if you cannot keep room_listen ` +
+    `chained between turns, exit and run \`npx agent-room-mcp init\` ` +
+    `(without --no-hooks) to install the stop hook, then rejoin. ` +
+    `Without the hook your turn will end after each tool call and you'll ` +
+    `silently drop out of the room.`
+  );
+}

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -20,6 +20,7 @@ import {
 import { generateCode, AVATAR_PALETTE, roleBriefFor, normalizeEscapedWhitespace } from '@agent-room/shared';
 import type { Message, Participant } from '@agent-room/shared';
 import { setRoom, removeRoom, updateCursor, markSent, readState } from './state.js';
+import { detectHarness, persistenceSetupHint } from './harness.js';
 
 function initialsFor(name: string): string {
   const parts = name.trim().split(/\s+/);
@@ -137,6 +138,14 @@ function resolvedListenTimeoutMs(raw: unknown): number {
 
 export function registerTools(server: Server, env: UpstashEnv) {
   const client = createClient(env);
+  // Snapshot the host harness once at boot. This drives the persistence-setup
+  // nudge in room_join / room_create — agents on harnesses that don't
+  // auto-loop tool calls (Cursor without 1.7+ stop hook, Claude Desktop,
+  // Gemini CLI, etc.) get an extra line telling them to run
+  // `npx agent-room-mcp init`. Snapshotted because env vars don't change
+  // mid-process and detection runs in O(branches).
+  const harness = detectHarness();
+  const persistenceNudge = persistenceSetupHint(harness);
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
@@ -355,8 +364,9 @@ export function registerTools(server: Server, env: UpstashEnv) {
           joinUrl: `https://www.agent-room.com/j/${code}`,
           roleBrief: roleBriefFor(a.role ?? ''),
           initialListenMs: listenMs,
+          clientKind: harness.kind,
           hint:
-            `Room created; first listen window ran in this same call (${listenMs}ms). ${first.hint} ${sendHint}`,
+            `Room created; first listen window ran in this same call (${listenMs}ms). ${first.hint} ${sendHint}${persistenceNudge}`,
         });
       }
 
@@ -366,7 +376,8 @@ export function registerTools(server: Server, env: UpstashEnv) {
         cursor: msgs.length,
         joinUrl: `https://www.agent-room.com/j/${code}`,
         roleBrief: roleBriefFor(a.role ?? ''),
-        hint: `Room created. PRESENCE CONTRACT: your next tool call MUST be room_listen with code="${code}" and since=${msgs.length}. After every room_send, queue another room_listen. Stay in the loop until the room ends, the host removes you, or you announce you're leaving. Do NOT end your turn without a pending room_listen.`,
+        clientKind: harness.kind,
+        hint: `Room created. PRESENCE CONTRACT: your next tool call MUST be room_listen with code="${code}" and since=${msgs.length}. After every room_send, queue another room_listen. Stay in the loop until the room ends, the host removes you, or you announce you're leaving. Do NOT end your turn without a pending room_listen.${persistenceNudge}`,
       });
     }
 
@@ -447,7 +458,8 @@ export function registerTools(server: Server, env: UpstashEnv) {
           recentMessages,
           roleBrief: roleBriefFor(a.role ?? ''),
           initialListenMs: listenMs,
-          hint: `${joinLine} First listen window ran in this same call (${listenMs}ms). ${first.hint} ${sendLoopHint}`,
+          clientKind: harness.kind,
+          hint: `${joinLine} First listen window ran in this same call (${listenMs}ms). ${first.hint} ${sendLoopHint}${persistenceNudge}`,
         });
       }
 
@@ -467,9 +479,10 @@ export function registerTools(server: Server, env: UpstashEnv) {
         cursor: msgs.length,
         recentMessages,
         roleBrief: roleBriefFor(a.role ?? ''),
+        clientKind: harness.kind,
         hint: muted
-          ? `Joined as "${finalName}" — but the host (${updated.createdBy}) has muted you in this room. room_send will return error="muted" until you're unmuted. Call room_listen to read the conversation while you wait. PRESENCE CONTRACT: next call MUST be room_listen with code="${a.code}" since=${msgs.length}.`
-          : `Joined as "${finalName}". ${recentMessages.length} recent messages above for context. PRESENCE CONTRACT: your next tool call MUST be room_listen with code="${a.code}" and since=${msgs.length}. After every room_send, queue another room_listen. Stay in the loop until the room ends, the host removes you, or you announce you're leaving. Do NOT end your turn without a pending room_listen.`,
+          ? `Joined as "${finalName}" — but the host (${updated.createdBy}) has muted you in this room. room_send will return error="muted" until you're unmuted. Call room_listen to read the conversation while you wait. PRESENCE CONTRACT: next call MUST be room_listen with code="${a.code}" since=${msgs.length}.${persistenceNudge}`
+          : `Joined as "${finalName}". ${recentMessages.length} recent messages above for context. PRESENCE CONTRACT: your next tool call MUST be room_listen with code="${a.code}" and since=${msgs.length}. After every room_send, queue another room_listen. Stay in the loop until the room ends, the host removes you, or you announce you're leaving. Do NOT end your turn without a pending room_listen.${persistenceNudge}`,
       });
     }
 

--- a/apps/mcp/test/harness.test.ts
+++ b/apps/mcp/test/harness.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { detectHarness, persistenceSetupHint } from '../src/harness.js';
+
+function env(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return overrides as NodeJS.ProcessEnv;
+}
+
+describe('detectHarness', () => {
+  it('detects Claude Code via CLAUDECODE=1', () => {
+    expect(detectHarness(env({ CLAUDECODE: '1' })).kind).toBe('claude-code');
+  });
+
+  it('detects Claude Code via CLAUDE_CODE_ENTRYPOINT', () => {
+    expect(detectHarness(env({ CLAUDE_CODE_ENTRYPOINT: 'cli' })).kind).toBe('claude-code');
+  });
+
+  it('detects Cursor via CURSOR_TRACE_ID', () => {
+    expect(detectHarness(env({ CURSOR_TRACE_ID: 'abc' })).kind).toBe('cursor');
+  });
+
+  it('detects Cursor via TERM_PROGRAM', () => {
+    expect(detectHarness(env({ TERM_PROGRAM: 'Cursor' })).kind).toBe('cursor');
+  });
+
+  it('detects Codex CLI via CODEX_RUN_ID', () => {
+    expect(detectHarness(env({ CODEX_RUN_ID: 'r1' })).kind).toBe('codex');
+  });
+
+  it('detects Claude Desktop via macOS bundle identifier', () => {
+    expect(
+      detectHarness(env({ __CFBundleIdentifier: 'com.anthropic.claudefordesktop' })).kind,
+    ).toBe('claude-desktop');
+  });
+
+  it('falls back to unknown when no signals match', () => {
+    expect(detectHarness(env({})).kind).toBe('unknown');
+  });
+
+  it('Claude Code wins when both Claude and Codex env vars are present', () => {
+    // CLAUDECODE=1 reliably set inside Claude Code. CODEX_HOME is just
+    // ~/.codex and may exist on Claude Code users' machines from a prior
+    // codex install — the Claude Code branch must win.
+    expect(detectHarness(env({ CLAUDECODE: '1', CODEX_HOME: '/Users/x/.codex' })).kind).toBe(
+      'claude-code',
+    );
+  });
+
+  it('claude-code and codex are flagged as not needing setup', () => {
+    expect(detectHarness(env({ CLAUDECODE: '1' })).needsPersistenceSetup).toBe(false);
+    expect(detectHarness(env({ CODEX_RUN_ID: 'r1' })).needsPersistenceSetup).toBe(false);
+  });
+
+  it('cursor / unknown / claude-desktop / gemini-cli need setup', () => {
+    expect(detectHarness(env({ CURSOR_TRACE_ID: 'x' })).needsPersistenceSetup).toBe(true);
+    expect(detectHarness(env({})).needsPersistenceSetup).toBe(true);
+    expect(
+      detectHarness(env({ __CFBundleIdentifier: 'com.anthropic.claudefordesktop' }))
+        .needsPersistenceSetup,
+    ).toBe(true);
+    expect(detectHarness(env({ GEMINI_CLI: '1' })).needsPersistenceSetup).toBe(true);
+  });
+});
+
+describe('persistenceSetupHint', () => {
+  it('returns empty string for strong-loop harnesses', () => {
+    expect(persistenceSetupHint(detectHarness(env({ CLAUDECODE: '1' })))).toBe('');
+    expect(persistenceSetupHint(detectHarness(env({ CODEX_RUN_ID: 'r1' })))).toBe('');
+  });
+
+  it('returns a setup nudge mentioning init for weak-loop harnesses', () => {
+    const hint = persistenceSetupHint(detectHarness(env({ CURSOR_TRACE_ID: 'x' })));
+    expect(hint).toContain('Cursor');
+    expect(hint).toContain('agent-room-mcp init');
+  });
+
+  it('uses generic label for unknown harnesses', () => {
+    const hint = persistenceSetupHint(detectHarness(env({})));
+    expect(hint).toContain('this client');
+    expect(hint).toContain('agent-room-mcp init');
+  });
+});

--- a/apps/web/src/components/AgentJoinQuickstart.tsx
+++ b/apps/web/src/components/AgentJoinQuickstart.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from 'react';
+
+export type AgentClientId =
+  | 'claude-code'
+  | 'claude-desktop'
+  | 'cursor'
+  | 'codex'
+  | 'gemini'
+  | 'cline'
+  | 'print';
+
+const CLIENT_ROWS: {
+  id: AgentClientId;
+  label: string;
+  /** Numeric answer at the `npx agent-room-mcp init` prompt (see apps/mcp/src/init.ts). */
+  initMenuKey: string;
+  restartTarget: string;
+  note?: string;
+}[] = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    initMenuKey: '1',
+    restartTarget: 'Claude Code',
+    note: 'MCP + autonomous-chat hooks (default installer path).',
+  },
+  {
+    id: 'claude-desktop',
+    label: 'Claude Desktop',
+    initMenuKey: '2',
+    restartTarget: 'Claude Desktop',
+    note: 'MCP only — rely on room_listen in your prompts for live messages.',
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    initMenuKey: '3',
+    restartTarget: 'Cursor',
+    note: 'Needs Cursor 1.7+ for the stop hook that keeps room_listen alive.',
+  },
+  {
+    id: 'codex',
+    label: 'Codex CLI',
+    initMenuKey: '4',
+    restartTarget: 'Codex CLI',
+    note: 'MCP + hooks when installer runs without --no-hooks.',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini CLI',
+    initMenuKey: '5',
+    restartTarget: 'Gemini CLI',
+    note: '',
+  },
+  {
+    id: 'cline',
+    label: 'Cline (VS Code extension)',
+    initMenuKey: '6',
+    restartTarget: 'VS Code + Cline',
+    note: 'Paste the MCP snippet into Cline’s MCP Servers panel if prompted.',
+  },
+  {
+    id: 'print',
+    label: 'Other / manual paste',
+    initMenuKey: '7',
+    restartTarget: 'your client',
+    note: 'Prints every harness snippet — copy the block that matches your tool.',
+  },
+];
+
+function copyText(text: string, onDone: () => void) {
+  void navigator.clipboard.writeText(text).then(onDone).catch(() => {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.left = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      onDone();
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+type Props = {
+  /** Room code with dashes, e.g. ABC-DEF-GHJ */
+  roomCode: string;
+};
+
+export function AgentJoinQuickstart({ roomCode }: Props) {
+  const [client, setClient] = useState<AgentClientId>('cursor');
+  const [copied, setCopied] = useState<string | null>(null);
+  const row = useMemo(() => CLIENT_ROWS.find((r) => r.id === client)!, [client]);
+
+  const joinUrl = useMemo(
+    () => `${typeof window !== 'undefined' ? window.location.origin : 'https://www.agent-room.com'}/j/${roomCode}`,
+    [roomCode],
+  );
+
+  const initBlock = `npx agent-room-mcp init`;
+  const initHint =
+    client === 'print'
+      ? 'At the first prompt, type 7 and press Enter (Print configs) — do not press Enter alone, that selects Claude Code.'
+      : `At the first prompt, type ${row.initMenuKey} and press Enter (${row.label}). Do not pass --no-hooks if you want the agent to stay in the room.`;
+
+  const agentPrompt = `Join agent-room ${roomCode} as <your agent name>. After room_join, stay in a room_listen loop: on quiet timeout, call room_listen again with the same cursor; use room_send when you need to speak. Stop only if the host ends the room, removes you, or tells you to leave.`;
+
+  return (
+    <div className="mb-5 border border-border-faint rounded-lg overflow-hidden">
+      <div className="px-3 py-2 bg-surface-soft border-b border-border-faint">
+        <div className="text-[11px] font-semibold text-ink-muted">Bring an AI agent into this room</div>
+        <p className="text-[10px] text-ink-faint mt-0.5 leading-relaxed">
+          One-time setup on the machine that runs the agent. Never paste API keys, tokens, or private data into the
+          room — use env files and your host’s normal secret stores.
+        </p>
+      </div>
+      <div className="p-3 space-y-3">
+        <label className="block">
+          <span className="text-[10px] font-semibold text-ink-muted block mb-1">Your agent tool</span>
+          <select
+            value={client}
+            onChange={(e) => setClient(e.target.value as AgentClientId)}
+            className="w-full px-2.5 py-1.5 bg-surface border border-border rounded-lg outline-none text-xs focus:border-accent focus:ring-2 focus:ring-accent-tint"
+          >
+            {CLIENT_ROWS.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        {row.note && <p className="text-[10px] text-ink-soft leading-relaxed">{row.note}</p>}
+
+        <ol className="list-decimal pl-4 space-y-2 text-[10px] text-ink-muted leading-relaxed">
+          <li>
+            <span className="text-ink">Install the Agent Room MCP server</span>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              <code className="px-1.5 py-0.5 bg-surface-soft border border-border-faint rounded text-[10px] font-mono break-all">
+                {initBlock}
+              </code>
+              <button
+                type="button"
+                onClick={() => copyText(initBlock, () => { setCopied('init'); setTimeout(() => setCopied(null), 1500); })}
+                className="shrink-0 text-[10px] font-medium text-accent hover:underline"
+              >
+                {copied === 'init' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p className="mt-1 text-ink-faint">{initHint}</p>
+          </li>
+          <li>
+            <span className="text-ink">Restart {row.restartTarget}</span> so it loads MCP{client === 'cursor' ? ' and the stop hook' : client === 'claude-code' || client === 'codex' ? ' and hooks' : ''}.
+          </li>
+          <li>
+            <span className="text-ink">Share this join link with the agent</span> (or paste it in the chat where you drive the agent):
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              <code className="px-1.5 py-0.5 bg-surface-soft border border-border-faint rounded text-[10px] font-mono break-all">
+                {joinUrl}
+              </code>
+              <button
+                type="button"
+                onClick={() => copyText(joinUrl, () => { setCopied('url'); setTimeout(() => setCopied(null), 1500); })}
+                className="shrink-0 text-[10px] font-medium text-accent hover:underline"
+              >
+                {copied === 'url' ? 'Copied' : 'Copy URL'}
+              </button>
+            </div>
+          </li>
+          <li>
+            <span className="text-ink">Optional prompt to paste</span> (tune the name):
+            <div className="mt-1 flex flex-col gap-1">
+              <pre className="p-2 bg-surface-soft border border-border-faint rounded text-[9px] font-mono whitespace-pre-wrap break-words text-ink-muted max-h-28 overflow-y-auto">
+                {agentPrompt}
+              </pre>
+              <button
+                type="button"
+                onClick={() => copyText(agentPrompt, () => { setCopied('prompt'); setTimeout(() => setCopied(null), 1500); })}
+                className="self-start text-[10px] font-medium text-accent hover:underline"
+              >
+                {copied === 'prompt' ? 'Copied prompt' : 'Copy prompt'}
+              </button>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/screens/Join.tsx
+++ b/apps/web/src/screens/Join.tsx
@@ -6,6 +6,7 @@ import { isValidCode, CODE_LEN, ROLE_PRESETS } from '@agent-room/shared';
 import { ENV } from '../env.js';
 import { CodeInput } from '../components/CodeInput.js';
 import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
+import { AgentJoinQuickstart } from '../components/AgentJoinQuickstart.js';
 import { colorForName, initialsFor } from '../lib/colors.js';
 
 function stripDashes(s: string) { return s.replace(/-/g, ''); }
@@ -106,6 +107,8 @@ export function Join() {
               <div className="text-[9px] text-ink-soft">Hosted by {room.createdBy} · {room.participants.length} here</div>
             </div>
           </div>
+
+          <AgentJoinQuickstart roomCode={room.code} />
 
           <label className="block mb-3">
             <span className="text-[11px] font-semibold text-ink-muted block mb-1">Your name</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -38,7 +38,8 @@
         "@types/node": "^20.12.0",
         "tsup": "^8.5.1",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^1.5.0"
       }
     },
     "apps/mcp/node_modules/zod": {


### PR DESCRIPTION
## Summary

Two coordinated changes to make agents stay present in rooms across more harnesses:

- **MCP (clientKind + persistence hint)**: `room_join` / `room_create` now detect which agent harness is running the MCP process (Claude Code / Cursor / Codex / Claude Desktop / Gemini / Cline) from boot-time env vars and append a one-line "run \`npx agent-room-mcp init\`" nudge to the response hint when the harness is known not to auto-loop tool calls. Strong-loop harnesses (Claude Code, Codex CLI) get no extra noise. Also exposes `clientKind` in the response payload for transparency.
- **Web (/j Quickstart)**: adds a "Bring an AI agent" panel on the join page with a client picker that mirrors the `init` menu, copy buttons for the install command and join URL, and a paste-able starter prompt. Includes a "don't paste keys / PII into the room" warning.

Bumps `agent-room-mcp` to **0.18.0**.

Designed and implemented in a live agent-room session (`CFJ-6HK-FTU`) — Claude Code wrote PR-1+2, Cursor wrote PR-3, both reviewed each other.

## Test plan

- [x] `npm run build` — workspace build green (mcp + web)
- [x] `npm test` — 13 new harness tests + 6 existing colors tests
- [x] Smoke-tested `detectHarness` across simulated envs (claude-code → no nudge; cursor / claude-desktop / unknown → nudge fires)
- [ ] Vercel preview: open `/j/<some-code>` and verify the Quickstart renders + copy buttons work
- [ ] Pull a fresh `npx agent-room-mcp@0.18.0` and `room_join` from a non-Claude-Code client to confirm `clientKind` and persistence nudge appear in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)