### PR TITLE
fix(mcp): detect Cursor stop hook payloads with hook_event_name (0.18.1)

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -55,7 +55,23 @@ interface HookInput {
 }
 
 function isCursorStopInput(input: HookInput): boolean {
-  return input.hook_event_name === undefined && typeof input.status === 'string';
+  return (
+    typeof input.status === 'string' &&
+    (input.hook_event_name === undefined || input.hook_event_name.toLowerCase() === 'stop')
+  );
+}
+
+export function classifyHookInput(input: HookInput): { event: string; cursorMode: boolean } | null {
+  const cursorMode = isCursorStopInput(input);
+  if (cursorMode) return { event: 'Stop', cursorMode };
+
+  if (input.hook_event_name) {
+    const normalized =
+      input.hook_event_name.toLowerCase() === 'stop' ? 'Stop' : input.hook_event_name;
+    return { event: normalized, cursorMode };
+  }
+
+  return null;
 }
 
 interface PendingRoom {
@@ -156,22 +172,21 @@ async function readStdin(): Promise<HookInput> {
 
 export async function runHook(env: UpstashEnv): Promise<void> {
   const input = await readStdin();
-  const cursorMode = isCursorStopInput(input);
   // Normalize the event name across clients. Cursor only fires the stop
-  // hook (no UserPromptSubmit / SessionStart equivalent today), so we
-  // collapse its `status` into our internal "Stop" event for the rest of
-  // the pipeline. Claude Code / Codex still send their own event name.
+  // hook (no UserPromptSubmit / SessionStart equivalent today). Older
+  // Cursor hook docs/examples showed `{ status, loop_count }` without a
+  // `hook_event_name`, while current Cursor payloads may include
+  // `{ hook_event_name: "stop", status, loop_count }`. Collapse both into
+  // our internal "Stop" event so Cursor still gets `followup_message`.
+  // Claude Code / Codex still send their own event names.
   // An empty stdin payload (e.g. manual test invocation) falls through to
   // a no-op — we used to default to 'Stop' which could trigger phantom
   // long-polls; now we only act when we actually got an event.
-  let event: string;
-  if (cursorMode) {
-    event = 'Stop';
-  } else if (input.hook_event_name) {
-    event = input.hook_event_name;
-  } else {
+  const classified = classifyHookInput(input);
+  if (!classified) {
     process.exit(0);
   }
+  const { event, cursorMode } = classified;
 
   // User typed something — fresh turn cycle. Reset the block streak so the
   // next Stop hook can block fresh up to MAX_BLOCKS_PER_CYCLE times.

--- a/apps/mcp/test/hook.test.ts
+++ b/apps/mcp/test/hook.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { classifyHookInput } from '../src/hook.js';
+
+describe('classifyHookInput', () => {
+  it('detects Cursor stop payloads without hook_event_name', () => {
+    expect(classifyHookInput({ status: 'completed', loop_count: 0 })).toEqual({
+      event: 'Stop',
+      cursorMode: true,
+    });
+  });
+
+  it('detects current Cursor stop payloads that include hook_event_name', () => {
+    expect(classifyHookInput({
+      hook_event_name: 'stop',
+      status: 'completed',
+      loop_count: 0,
+    })).toEqual({
+      event: 'Stop',
+      cursorMode: true,
+    });
+  });
+
+  it('normalizes lowercase stop for non-Cursor hook payloads', () => {
+    expect(classifyHookInput({ hook_event_name: 'stop' })).toEqual({
+      event: 'Stop',
+      cursorMode: false,
+    });
+  });
+
+  it('ignores empty hook payloads', () => {
+    expect(classifyHookInput({})).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Bug

Cursor agents joined the room once and then silently dropped out — never reappeared in the participants list, never replied. Reported live in agent-room `GBX-YXT-C3R`.

## Root cause

Cursor 1.7+ stop hook payloads now include **both** `hook_event_name: "stop"` AND `status: "completed"`. Older Cursor only sent `{ status, loop_count }` without `hook_event_name`. Our detection in `apps/mcp/src/hook.ts` required `hook_event_name === undefined`:

```ts
function isCursorStopInput(input: HookInput): boolean {
  return input.hook_event_name === undefined && typeof input.status === 'string';
}
```

Walking through the new payload:
1. `isCursorStopInput` → `false` (because `hook_event_name` is defined).
2. `event` ← raw lowercase `"stop"`.
3. All four `event === "Stop"` branches in `runHook` fail (capitalization mismatch).
4. Falls through to `if (withMessages.length === 0) process.exit(0)` — silent exit, no `followup_message`.
5. Cursor turn ends with no instruction to call `room_listen` again.
6. `lastSeenAt` + `listenUntil` go stale on the server side.
7. Participant drops from the rendered list.

## Fix

- `isCursorStopInput` now matches when `status` is a string AND `hook_event_name` is either undefined OR lowercased `"stop"`.
- Extract `classifyHookInput()` that:
  - returns `{ event: 'Stop', cursorMode: true }` for any Cursor shape;
  - normalizes lowercase `"stop"` → `"Stop"` for non-Cursor payloads (defense in depth);
  - returns `null` for empty payloads (preserves the existing no-op-on-empty behavior used by manual test invocations).
- 4 new vitest cases for `classifyHookInput`.
- Bumps `agent-room-mcp` → `0.18.1`.

## Why Claude Code / Codex CLI weren't affected

They send `hook_event_name: "Stop"` (capitalized). The old code's non-Cursor branch matched `"Stop"` directly. Only the new Cursor lowercase + dual-field combo hit the dead zone.

## Verification

- `npm -w apps/mcp test` → 17/17 passing (13 harness + 4 new hook).
- `npm -w apps/mcp run typecheck` ✓
- `npm -w apps/mcp run build` ✓
- `npm test` (full repo) ✓

## Test plan

- [ ] Merge → Vercel preview spins up (no app changes, but MCP package rebuilds).
- [ ] After merge, publish `agent-room-mcp@0.18.1` to npm so users actually pick up the fix (the deployed web app doesn't rely on this; it's the MCP package consumed by Cursor / Claude Code / Codex CLI / etc.).
- [ ] Reproduce: in Cursor 1.7+, run `npx agent-room-mcp init`, restart Cursor, send "join the room <code>" — confirm Cursor stays in the participants list across multiple turns.

## Authorship

Patch by **Codex** (coding agent in room `GBX-YXT-C3R`).
Reviewed and verified by **Claude** in the same room.
Bug report + final approval: **Robin**.