### PR TITLE
feat(mcp): distinguish participants and keep Cursor present

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -153,6 +153,57 @@ export function registerTools(server: Server, env: UpstashEnv) {
   const harness = detectHarness();
   const persistenceNudge = persistenceSetupHint(harness);
 
+  function startRoomWatcher(code: string, selfName: string, startCursor: number): void {
+    if (watchers.has(code)) {
+      watchers.get(code)!.stop();
+    }
+
+    let cursor = startCursor;
+    let running = true;
+
+    const poll = async () => {
+      while (running) {
+        try {
+          if (selfName) {
+            await setListenUntil(client, code, selfName, Date.now() + 5000);
+          }
+          const msgs = await listMessages(client, code, cursor);
+          if (msgs.length > 0) {
+            cursor += msgs.length;
+            const others = msgs.filter((m: Message) => !(m.client === 'cc' && m.name === selfName));
+            if (others.length > 0) {
+              const summary = others.map((m: Message) => `${m.name}: ${m.text}`).join('\n');
+              try {
+                await server.sendLoggingMessage({
+                  level: 'info',
+                  logger: `room:${code}`,
+                  data: JSON.stringify({
+                    type: 'new_messages',
+                    code,
+                    cursor,
+                    messages: others.map((m: Message) => ({
+                      name: m.name,
+                      text: m.text,
+                      time: m.time,
+                      client: m.client,
+                    })),
+                    summary,
+                  }),
+                });
+              } catch { /* client may not support logging */ }
+            }
+          }
+        } catch { /* network/presence errors are transient; retry */ }
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    };
+
+    poll(); // fire and forget
+    watchers.set(code, { stop: () => { running = false; } });
+  }
+
+  const shouldAutoWatch = harness.kind === 'cursor';
+
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
       {
@@ -361,6 +412,9 @@ export function registerTools(server: Server, env: UpstashEnv) {
       if (listenAfterJoin) {
         const first = await runRoomListenPoll(client, code, msgs.length, listenMs, a.name);
         await updateCursor(code, first.cursor);
+        if (!first.terminated && shouldAutoWatch) {
+          startRoomWatcher(code, a.name, first.cursor);
+        }
         return ok({
           code,
           topic: created.topic,
@@ -370,18 +424,23 @@ export function registerTools(server: Server, env: UpstashEnv) {
           joinUrl: `https://www.agent-room.com/j/${code}`,
           roleBrief: roleBriefFor(a.role ?? ''),
           initialListenMs: listenMs,
+          autoWatchStarted: !first.terminated && shouldAutoWatch,
           clientKind: harness.kind,
           hint:
             `Room created; first listen window ran in this same call (${listenMs}ms). ${first.hint}${persistenceNudge}`,
         });
       }
 
+      if (shouldAutoWatch) {
+        startRoomWatcher(code, a.name, msgs.length);
+      }
       return ok({
         code,
         topic: created.topic,
         cursor: msgs.length,
         joinUrl: `https://www.agent-room.com/j/${code}`,
         roleBrief: roleBriefFor(a.role ?? ''),
+        autoWatchStarted: shouldAutoWatch,
         clientKind: harness.kind,
         hint: `Room created. ${nextListenContract(code, msgs.length)}${persistenceNudge}`,
       });
@@ -402,11 +461,14 @@ export function registerTools(server: Server, env: UpstashEnv) {
       // Otherwise, joining as the host's display name will be rejected by
       // verifyHostKey — clean error, no silent impersonation.
       const targetRoom = await getRoom(client, a.code);
+      let storedStateRoom: Awaited<ReturnType<typeof readState>>['rooms'][string] | undefined;
+      try {
+        const state = await readState();
+        storedStateRoom = state.rooms[a.code];
+      } catch { /* local state is optional; treat as fresh join */ }
       if (a.name === targetRoom.createdBy) {
         try {
-          const state = await readState();
-          const stored = state.rooms[a.code];
-          await verifyHostKey(client, a.code, stored?.hostKey);
+          await verifyHostKey(client, a.code, storedStateRoom?.hostKey);
         } catch (e) {
           if (e instanceof HostNameTakenError) {
             return ok({
@@ -417,11 +479,38 @@ export function registerTools(server: Server, env: UpstashEnv) {
           throw e;
         }
       }
+      const priorIdentity = storedStateRoom
+        ? { name: storedStateRoom.name, client: 'cc' as const }
+        : undefined;
+      const reconnecting = Boolean(
+        priorIdentity &&
+        targetRoom.participants.some((p: Participant) =>
+          p.name === priorIdentity.name && p.client === priorIdentity.client
+        )
+      );
       const updated = await joinRoom(client, a.code, participant, {
-        priorIdentity: { name: a.name, client: 'cc' },
+        ...(priorIdentity ? { priorIdentity } : {}),
       });
       // Use the post-suffix name so future writes match the row we just made.
       const finalName = updated.participant.name;
+      const myEntry = updated.participants.find((p: Participant) => p.name === finalName && p.client === 'cc');
+      const muted = myEntry?.canSpeak === false;
+      if (!reconnecting && !muted) {
+        const greeting: Message = {
+          id: Date.now(),
+          type: 'msg',
+          name: finalName,
+          initials: updated.participant.initials,
+          color: updated.participant.color,
+          role: updated.participant.role,
+          text: `Hi all — ${finalName} here. I'm in the room and listening.`,
+          client: 'cc',
+          time: Date.now(),
+        };
+        try {
+          await appendMessage(client, a.code, greeting);
+        } catch { /* greeting is nice-to-have; join/listen must still proceed */ }
+      }
       const msgs = await listMessages(client, a.code, 0);
       await setRoom(a.code, { name: finalName, cursor: msgs.length, joinedAt: Date.now() });
       const recentMessages = msgs.slice(-20).map((m: Message) => ({
@@ -431,8 +520,6 @@ export function registerTools(server: Server, env: UpstashEnv) {
         text: m.text,
         time: m.time,
       }));
-      const myEntry = updated.participants.find((p: Participant) => p.name === finalName && p.client === 'cc');
-      const muted = myEntry?.canSpeak === false;
 
       const listenAfterJoin = a.listenAfterJoin !== false;
       const listenMs = resolvedListenTimeoutMs(a.listenTimeoutMs);
@@ -440,6 +527,9 @@ export function registerTools(server: Server, env: UpstashEnv) {
       if (listenAfterJoin) {
         const first = await runRoomListenPoll(client, a.code, msgs.length, listenMs, finalName);
         await updateCursor(a.code, first.cursor);
+        if (!first.terminated && shouldAutoWatch) {
+          startRoomWatcher(a.code, finalName, first.cursor);
+        }
         const joinLine = muted
           ? `Joined as "${finalName}" — but the host (${updated.createdBy}) has muted you in this room. room_send will return error="muted" until you are unmuted. Call room_listen to read the conversation while you wait.`
           : `Joined as "${finalName}". ${recentMessages.length} recent messages above for context.`;
@@ -462,11 +552,15 @@ export function registerTools(server: Server, env: UpstashEnv) {
           recentMessages,
           roleBrief: roleBriefFor(a.role ?? ''),
           initialListenMs: listenMs,
+          autoWatchStarted: !first.terminated && shouldAutoWatch,
           clientKind: harness.kind,
           hint: `${joinLine} First listen window ran in this same call (${listenMs}ms). ${first.hint}${persistenceNudge}`,
         });
       }
 
+      if (shouldAutoWatch) {
+        startRoomWatcher(a.code, finalName, msgs.length);
+      }
       return ok({
         code: a.code,
         topic: updated.topic,
@@ -483,6 +577,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
         cursor: msgs.length,
         recentMessages,
         roleBrief: roleBriefFor(a.role ?? ''),
+        autoWatchStarted: shouldAutoWatch,
         clientKind: harness.kind,
         hint: muted
           ? `Joined as "${finalName}" — but the host (${updated.createdBy}) has muted you in this room. room_send will return error="muted" until you're unmuted. Call room_listen to read the conversation while you wait. ${nextListenContract(a.code, msgs.length)}${persistenceNudge}`
@@ -596,53 +691,8 @@ export function registerTools(server: Server, env: UpstashEnv) {
     if (name === 'room_watch') {
       const code = a.code;
       const selfName = a.name || '';
-
-      // Stop existing watcher for this room
-      if (watchers.has(code)) {
-        watchers.get(code)!.stop();
-      }
-
-      let cursor = a.since ?? 0;
-      let running = true;
-
-      const poll = async () => {
-        while (running) {
-          try {
-            const msgs = await listMessages(client, code, cursor);
-            if (msgs.length > 0) {
-              cursor += msgs.length;
-              // Filter out own messages
-              const others = msgs.filter((m: Message) => !(m.client === 'cc' && m.name === selfName));
-              if (others.length > 0) {
-                const summary = others.map((m: Message) => `${m.name}: ${m.text}`).join('\n');
-                try {
-                  await server.sendLoggingMessage({
-                    level: 'info',
-                    logger: `room:${code}`,
-                    data: JSON.stringify({
-                      type: 'new_messages',
-                      code,
-                      cursor,
-                      messages: others.map((m: Message) => ({
-                        name: m.name,
-                        text: m.text,
-                        time: m.time,
-                        client: m.client,
-                      })),
-                      summary,
-                    }),
-                  });
-                } catch { /* client may not support logging */ }
-              }
-            }
-          } catch { /* network error, retry */ }
-          await new Promise((r) => setTimeout(r, 2000));
-        }
-      };
-
-      poll(); // fire and forget
-
-      watchers.set(code, { stop: () => { running = false; } });
+      const cursor = a.since ?? 0;
+      startRoomWatcher(code, selfName, cursor);
 
       return ok({
         watching: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/upstash-client/src/rooms.ts
+++ b/packages/upstash-client/src/rooms.ts
@@ -1,5 +1,5 @@
 import type { Room, Participant } from '@agent-room/shared';
-import { ROOM_TTL_SECONDS } from '@agent-room/shared';
+import { AVATAR_PALETTE, ROOM_TTL_SECONDS } from '@agent-room/shared';
 import type { UpstashClient } from './client.js';
 import { RoomNotFoundError, ConcurrencyError } from './errors.js';
 
@@ -108,13 +108,12 @@ export class HostNameTakenError extends Error {
 //    HostNameTakenError. This is what stops "anyone with the code can
 //    impersonate the host".
 //
-// 2. Non-host name collision: if some OTHER (name, client) tuple already
-//    exists in the room and the caller hasn't shown they own the original
-//    seat (no shared client identity yet — see Tier B), we auto-suffix
-//    "(2)" / "(3)" so two real humans named "Robin" don't displace each
-//    other and so no one can squat over an existing participant.
+// 2. Non-host name collision: if any other participant already uses the same
+//    visible room name and the caller hasn't shown they own the original seat
+//    (no shared client identity yet — see Tier B), we auto-suffix "(2)" /
+//    "(3)" so two real humans or agents named "Robin" stay distinguishable.
 //
-// `requesterClaim` is the caller's previous (name, client) tuple if any —
+// `priorIdentity` is the caller's previous (name, client) tuple if any —
 // the web client passes its sessionStorage entry so a refresh on /r/CODE
 // still updates the same row instead of getting a "(2)" suffix.
 export interface JoinRoomOptions {
@@ -132,6 +131,45 @@ export interface JoinRoomOptions {
 // work; new callers can read `result.participant.name` to learn what name
 // was actually assigned.
 export type JoinRoomResult = Room & { participant: Participant };
+
+function isPriorIdentity(
+  p: Participant,
+  priorIdentity: JoinRoomOptions['priorIdentity'],
+): boolean {
+  return Boolean(priorIdentity && p.name === priorIdentity.name && p.client === priorIdentity.client);
+}
+
+function uniqueNameForRoom(
+  desiredName: string,
+  current: Room,
+  priorIdentity: JoinRoomOptions['priorIdentity'],
+): string {
+  const taken = new Set(
+    current.participants
+      .filter(p => !isPriorIdentity(p, priorIdentity))
+      .map(p => p.name),
+  );
+  if (!taken.has(desiredName) || desiredName === current.createdBy) return desiredName;
+
+  let n = 2;
+  let candidate = `${desiredName} (${n})`;
+  while (taken.has(candidate)) candidate = `${desiredName} (${++n})`;
+  return candidate;
+}
+
+function uniqueColorForRoom(
+  desiredColor: string,
+  current: Room,
+  priorIdentity: JoinRoomOptions['priorIdentity'],
+): string {
+  const used = new Set(
+    current.participants
+      .filter(p => !isPriorIdentity(p, priorIdentity))
+      .map(p => p.color),
+  );
+  if (!used.has(desiredColor)) return desiredColor;
+  return AVATAR_PALETTE.find(color => !used.has(color)) ?? desiredColor;
+}
 
 export async function joinRoom(
   client: UpstashClient,
@@ -152,26 +190,17 @@ export async function joinRoom(
       // if the key is wrong. Reaching this branch means the caller has
       // already proven they own the host slot.
     } else {
-      // Non-host name collision: walk siblings and append "(N)" until unique
-      // for this client kind. priorIdentity bypasses the suffix when the
-      // caller is updating their own previous row.
-      const isMyOwnRow = options.priorIdentity
-        && options.priorIdentity.name === participant.name
-        && options.priorIdentity.client === participant.client;
-      if (!isMyOwnRow) {
-        const taken = new Set(
-          current.participants
-            .filter(p => p.client === participant.client)
-            .map(p => p.name),
-        );
-        if (taken.has(next.name) && next.name !== current.createdBy) {
-          let n = 2;
-          let candidate = `${participant.name} (${n})`;
-          while (taken.has(candidate)) candidate = `${participant.name} (${++n})`;
-          next = { ...next, name: candidate };
-        }
-      }
+      // Non-host name collision: names are room-visible labels, so keep
+      // them unique across client kinds too (web Robin vs agent Robin).
+      // priorIdentity bypasses the suffix when the caller is updating their
+      // own previous row.
+      next = { ...next, name: uniqueNameForRoom(participant.name, current, options.priorIdentity) };
     }
+
+    next = {
+      ...next,
+      color: uniqueColorForRoom(next.color, current, options.priorIdentity),
+    };
 
     // Default canSpeak: TRUE for everyone (host, agents, walk-ins). The
     // earlier "host approves new joiners" gate added too much friction —

--- a/packages/upstash-client/test/rooms.test.ts
+++ b/packages/upstash-client/test/rooms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Room } from '@agent-room/shared';
+import { AVATAR_PALETTE, type Room } from '@agent-room/shared';
 import { createClient, createRoom, getRoom, RoomNotFoundError, casRoom, ConcurrencyError, joinRoom } from '../src/index.js';
 
 const ENV = { url: 'https://example.upstash.io', token: 't' };
@@ -142,7 +142,7 @@ describe('joinRoom', () => {
     expect(updated.version).toBe(2);
   });
 
-  it('auto-suffixes a colliding name on the same client kind', async () => {
+  it('auto-suffixes a colliding name across client kinds', async () => {
     const before: Room = {
       code: 'A', topic: 't', createdAt: 0, createdBy: 'host', status: 'active', version: 1,
       participants: [
@@ -156,12 +156,57 @@ describe('joinRoom', () => {
 
     const client = createClient(ENV);
     const updated = await joinRoom(client, 'A', {
-      name: 'Robin', role: '', color: '#000', initials: 'RO', client: 'web',
+      name: 'Robin', role: '', color: '#111', initials: 'RO', client: 'cc',
       joinedAt: 100, lastSeenAt: 100,
     });
 
     expect(updated.participant.name).toBe('Robin (2)');
     expect(updated.participants).toHaveLength(2);
+  });
+
+  it('keeps a reconnecting prior identity from getting suffixed', async () => {
+    const before: Room = {
+      code: 'A', topic: 't', createdAt: 0, createdBy: 'host', status: 'active', version: 1,
+      participants: [
+        { name: 'Codex', role: '', color: '#000', initials: 'CO', client: 'cc', joinedAt: 0, lastSeenAt: 0, canSpeak: true },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResp({ result: JSON.stringify(before) }))
+      .mockResolvedValueOnce(mockResp({ result: 'OK' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
+    const updated = await joinRoom(client, 'A', {
+      name: 'Codex', role: '', color: '#000', initials: 'CO', client: 'cc',
+      joinedAt: 100, lastSeenAt: 100,
+    }, {
+      priorIdentity: { name: 'Codex', client: 'cc' },
+    });
+
+    expect(updated.participant.name).toBe('Codex');
+    expect(updated.participants).toHaveLength(1);
+  });
+
+  it('chooses an unused avatar color when the requested color is already taken', async () => {
+    const before: Room = {
+      code: 'A', topic: 't', createdAt: 0, createdBy: 'host', status: 'active', version: 1,
+      participants: [
+        { name: 'Claude', role: '', color: AVATAR_PALETTE[0]!, initials: 'CL', client: 'cc', joinedAt: 0, lastSeenAt: 0, canSpeak: true },
+      ],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResp({ result: JSON.stringify(before) }))
+      .mockResolvedValueOnce(mockResp({ result: 'OK' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
+    const updated = await joinRoom(client, 'A', {
+      name: 'Codex', role: '', color: AVATAR_PALETTE[0]!, initials: 'CO', client: 'cc',
+      joinedAt: 100, lastSeenAt: 100,
+    });
+
+    expect(updated.participant.color).toBe(AVATAR_PALETTE[1]);
   });
 
   it('lands cc (agent) joiners with canSpeak=true (mute model)', async () => {


### PR DESCRIPTION
## Summary
- keep visible participant names unique across web/agent clients
- assign an unused avatar color on join when the requested color is already taken
- make MCP agents greet the room on fresh join without repeating on reconnect
- use local MCP state only for true reconnect priorIdentity, preventing fresh same-name agents from overwriting an existing seat
- auto-start a Cursor background watcher on create/join; watcher refreshes listenUntil/lastSeenAt and emits logging notifications to reduce presence gaps
- bump agent-room-mcp to 0.18.4

## Verification
- npm -w packages/upstash-client test
- npm -w apps/mcp test
- npm -w apps/mcp run typecheck
- npm -w apps/mcp run build
- npm test