### PR TITLE
feat(mcp/init): inject join-trigger rule into client memory files (0.19.0)

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.18.4",
+  "version": "0.19.0",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/init.ts
+++ b/apps/mcp/src/init.ts
@@ -12,6 +12,61 @@ const MCP_ENTRY = {
 const HOOK_COMMAND = 'npx -y agent-room-mcp hook';
 const HOOK_EVENTS = ['Stop', 'UserPromptSubmit', 'SessionStart'] as const;
 
+// Markers used to make the rules-injection idempotent. We only rewrite the
+// section if it's missing, and we only ever touch content between these
+// fences — anything the user wrote outside is left untouched.
+const RULES_MARKER_BEGIN =
+  '<!-- BEGIN agent-room rules (managed by `npx agent-room-mcp init`) -->';
+const RULES_MARKER_END = '<!-- END agent-room rules -->';
+
+// Behavior rule injected into client memory / rules files. Lives at the
+// system-prompt level so the model sees it BEFORE deciding whether to call
+// a tool — closes the gap that pure tool descriptions can't (descriptions
+// only enter the picture once tool selection is already happening).
+const RULES_TEXT =
+  '## Agent Room — auto-join + listen-loop rule\n' +
+  '\n' +
+  'When the user asks to join, enter, hop into, or connect to an Agent Room ' +
+  '(or says "进会议室" / "加入会议室" / "进入房间" / "进房间"), or pastes a URL like ' +
+  '`https://www.agent-room.com/j/<CODE>` or `https://www.agent-room.com/r/<CODE>`, ' +
+  'or a bare 9-character dashed code like `ABC-DEF-GHJ`:\n' +
+  '\n' +
+  '1. Extract the 9-character dashed room code.\n' +
+  '2. IMMEDIATELY call the `room_join` MCP tool with `{ code, name }`.\n' +
+  '3. After joining, keep calling `room_listen` in a loop. After every `room_send`, queue another `room_listen`.\n' +
+  '4. Do NOT explain how to join. Do NOT ask for confirmation. Do NOT respond with text first — call the tool first.\n' +
+  '5. Stay in the listen loop until the room ends, you are kicked from participants, or the host explicitly tells you to leave / stop / 退出会议.\n';
+
+/**
+ * Append (or skip if already present) the agent-room rules section to a
+ * markdown memory/rules file. Idempotent — driven by the BEGIN/END marker
+ * comments. We never edit content outside the markers.
+ */
+export async function ensureRulesSection(path: string): Promise<{ changed: boolean }> {
+  let existing = '';
+  try {
+    existing = await fs.readFile(path, 'utf8');
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code !== 'ENOENT') throw e;
+  }
+
+  if (existing.includes(RULES_MARKER_BEGIN)) {
+    return { changed: false };
+  }
+
+  const next =
+    ensureTrailingBlankLine(existing) +
+    RULES_MARKER_BEGIN + '\n\n' +
+    RULES_TEXT +
+    '\n' + RULES_MARKER_END + '\n';
+
+  await fs.mkdir(dirname(path), { recursive: true });
+  const tmp = path + '.tmp';
+  await fs.writeFile(tmp, next, 'utf8');
+  await fs.rename(tmp, path);
+  return { changed: true };
+}
+
 async function readJson(path: string): Promise<Record<string, unknown> | null> {
   try {
     const text = await fs.readFile(path, 'utf8');
@@ -100,6 +155,17 @@ async function installClaudeCode(opts: { hooks: boolean }): Promise<InstallResul
     }
   } else if (!registeredViaCli) {
     result.unchanged.push(`${mcpPath} (already configured)`);
+  }
+
+  // Behavior rule — injected at user-memory level so the model sees it as
+  // system context, not just when scanning tool descriptions. Closes the
+  // "explain instead of act" gap on URL/short-form join requests.
+  const rulesPath = join(homedir(), '.claude', 'CLAUDE.md');
+  const rulesRes = await ensureRulesSection(rulesPath);
+  if (rulesRes.changed) {
+    result.changes.push(`appended agent-room rules to ${rulesPath}`);
+  } else {
+    result.unchanged.push(`${rulesPath} (rules already present)`);
   }
 
   if (opts.hooks) {
@@ -301,7 +367,35 @@ async function installCodex(opts: { hooks: boolean }): Promise<InstallResult> {
     await fs.rename(tmp, path);
   }
 
+  // Behavior rule — Codex CLI reads ~/.codex/AGENTS.md as global agent
+  // memory, separate from config.toml (config.toml is for tool wiring;
+  // AGENTS.md is for system-level instructions).
+  const rulesPath = join(codexHome, 'AGENTS.md');
+  const rulesRes = await ensureRulesSection(rulesPath);
+  if (rulesRes.changed) {
+    result.changes.push(`appended agent-room rules to ${rulesPath}`);
+  } else {
+    result.unchanged.push(`${rulesPath} (rules already present)`);
+  }
+
   return result;
+}
+
+/**
+ * For clients without a writable global-rules file (Cursor's User Rules
+ * lives in app settings UI, Claude Desktop has no rules mechanism, etc.),
+ * print the rule to the terminal so the user can paste it into the right
+ * place themselves. Keeps install transparent — no surprise files.
+ */
+function printRulesInstruction(target: string, where: string): void {
+  console.log(`\n  Manual rules step for ${target}:`);
+  console.log(`    Paste the following into ${where}:`);
+  console.log('    ' + '-'.repeat(60));
+  for (const line of (RULES_MARKER_BEGIN + '\n\n' + RULES_TEXT + '\n' + RULES_MARKER_END).split('\n')) {
+    console.log('    ' + line);
+  }
+  console.log('    ' + '-'.repeat(60));
+  console.log('  This makes the agent auto-join when you say "join the room <code>" or paste an agent-room URL,\n  without needing to spell out the tool call each time.\n');
 }
 
 function printConfigs() {
@@ -423,6 +517,10 @@ export async function runInit(argv: string[]): Promise<void> {
       console.log('  (skipped hooks; pass without --no-hooks for autonomous chat — Cursor 1.7+ required)');
     }
     nextSteps('Cursor');
+    // Cursor's user-level rules live in the Settings UI (Settings → Rules
+    // → User Rules), not a flat file we can write to safely. Print the
+    // snippet for manual paste so the install stays transparent.
+    printRulesInstruction('Cursor', 'Cursor → Settings → Rules → User Rules');
     return;
   }
 
@@ -431,6 +529,7 @@ export async function runInit(argv: string[]): Promise<void> {
     reportResult('Gemini CLI', result);
     nextSteps('Gemini CLI');
     console.log('  Note: Gemini CLI does not currently support Claude Code-style hooks, so ask it to call room_listen explicitly to stay present in the room.');
+    printRulesInstruction('Gemini CLI', '~/.gemini/GEMINI.md (or whichever file Gemini CLI reads as global instructions on your version)');
     return;
   }
 
@@ -439,6 +538,7 @@ export async function runInit(argv: string[]): Promise<void> {
     reportResult('Cline (VS Code)', result);
     nextSteps('Cline');
     console.log('  Note: targeted stable VS Code. If you use VS Code Insiders / VSCodium / Cursor-with-Cline, run `npx agent-room-mcp init print` and paste the snippet into Cline\'s MCP Servers panel instead.');
+    printRulesInstruction('Cline', "Cline's Custom Instructions field (in the VS Code extension settings)");
     return;
   }
 
@@ -447,6 +547,7 @@ export async function runInit(argv: string[]): Promise<void> {
     reportResult('Claude Desktop', result);
     nextSteps('Claude Desktop');
     console.log('  Note: Claude Desktop does not run hooks, so ask it to call room_listen to see live room messages.');
+    printRulesInstruction('Claude Desktop', 'Claude Desktop → Settings → Profile → System Prompt (or paste at the start of every conversation)');
     return;
   }
 

--- a/apps/mcp/test/init-rules.test.ts
+++ b/apps/mcp/test/init-rules.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureRulesSection } from '../src/init.js';
+
+describe('ensureRulesSection', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'agent-room-init-rules-'));
+    path = join(dir, 'CLAUDE.md');
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('creates the file and writes the rules section if it does not exist', async () => {
+    const res = await ensureRulesSection(path);
+    expect(res.changed).toBe(true);
+    const text = await fs.readFile(path, 'utf8');
+    expect(text).toContain('BEGIN agent-room rules');
+    expect(text).toContain('END agent-room rules');
+    expect(text).toContain('Agent Room — auto-join + listen-loop rule');
+    expect(text).toContain('room_join');
+    expect(text).toContain('room_listen');
+    // Multilingual triggers must survive into the file.
+    expect(text).toContain('进会议室');
+  });
+
+  it('appends to existing content without clobbering it', async () => {
+    const existing = '# My personal memory\n\nLines I wrote myself.\n\n- a note\n';
+    await fs.writeFile(path, existing, 'utf8');
+
+    const res = await ensureRulesSection(path);
+    expect(res.changed).toBe(true);
+
+    const text = await fs.readFile(path, 'utf8');
+    expect(text.startsWith(existing)).toBe(true);
+    expect(text).toContain('BEGIN agent-room rules');
+  });
+
+  it('is idempotent — running twice does not duplicate the section', async () => {
+    const first = await ensureRulesSection(path);
+    expect(first.changed).toBe(true);
+
+    const second = await ensureRulesSection(path);
+    expect(second.changed).toBe(false);
+
+    const text = await fs.readFile(path, 'utf8');
+    const beginCount = (text.match(/BEGIN agent-room rules/g) ?? []).length;
+    const endCount = (text.match(/END agent-room rules/g) ?? []).length;
+    expect(beginCount).toBe(1);
+    expect(endCount).toBe(1);
+  });
+
+  it('creates the parent directory if missing', async () => {
+    const nested = join(dir, 'deeply', 'nested', 'CLAUDE.md');
+    const res = await ensureRulesSection(nested);
+    expect(res.changed).toBe(true);
+    const text = await fs.readFile(nested, 'utf8');
+    expect(text).toContain('BEGIN agent-room rules');
+  });
+});


### PR DESCRIPTION
## Why

Tool descriptions only enter the model's decision loop **once tool selection is already underway**. They cannot fix the upstream "explain instead of act" problem where the model decides "join the room \<code\>" is conversational and never enters tool selection at all. Robin reproduced this live: even after 0.18.3's stronger \`room_join\` description, Cursor still required spelling out "Use the Agent Room MCP tool room_join with code … then keep calling room_listen … Do not just explain" each time.

This PR closes that gap by writing the same rule into each client's **user-level memory / rules surface** — the system-prompt layer where the model sees instructions before tool selection runs.

## What

- New \`ensureRulesSection()\` helper in \`apps/mcp/src/init.ts\` — idempotent fenced-markdown append (BEGIN/END markers) to a memory file. Only ever edits content between the markers; user content elsewhere is preserved across re-runs.
- Per-client wiring:
  - **Claude Code**: appends to \`~/.claude/CLAUDE.md\`
  - **Codex CLI**: appends to \`~/.codex/AGENTS.md\`
  - **Cursor / Claude Desktop / Cline / Gemini CLI**: prints the snippet with paste instructions for the client's UI-only rules location (Cursor's User Rules, Claude Desktop's System Prompt, etc.) — no surprise filesystem writes for clients without a writable global-rules file
- 4 new vitest cases in \`apps/mcp/test/init-rules.test.ts\` covering: fresh write, append-without-clobber, idempotency on re-run, parent-dir create.

Bumps \`agent-room-mcp\` → **0.19.0** (minor — install behavior change, not a bug fix).

## Rule contents

Embedded as markdown so it renders in any \`.md\` file the client picks up:

> When the user asks to join, enter, hop into, or connect to an Agent Room (or says "进会议室" / "加入会议室" / "进入房间" / "进房间"), or pastes a URL like \`https://www.agent-room.com/j/<CODE>\` or \`https://www.agent-room.com/r/<CODE>\`, or a bare 9-character dashed code:
> 1. Extract the code.
> 2. IMMEDIATELY call \`room_join\`.
> 3. After joining, keep calling \`room_listen\` in a loop. After every \`room_send\`, queue another \`room_listen\`.
> 4. Do NOT explain how to join. Do NOT ask for confirmation. Do NOT respond with text first — call the tool first.
> 5. Stay in the listen loop until the room ends, you are kicked, or the host explicitly tells you to leave / stop / 退出会议.

## Why per-client paths

| Client | Mechanism | Why |
|---|---|---|
| Claude Code | \`~/.claude/CLAUDE.md\` | Standard user-level memory file, read on every session |
| Codex CLI | \`~/.codex/AGENTS.md\` | Standard global agent memory (separate from \`config.toml\` which is for tool wiring) |
| Cursor | print → paste into Settings → Rules → User Rules | User Rules live in app settings UI, no flat file we can write to safely |
| Claude Desktop | print → paste into System Prompt | No rules file mechanism |
| Cline | print → paste into Custom Instructions field | VS Code extension setting |
| Gemini CLI | print → paste into \`~/.gemini/GEMINI.md\` | Convention varies by version |

## Test plan

- [ ] \`npm -w apps/mcp test\` → 21/21 passing (4 new + 17 existing). Done locally.
- [ ] \`npm -w apps/mcp run typecheck\` ✓. Done locally.
- [ ] \`npm -w apps/mcp run build\` ✓. Done locally.
- [ ] Manual: \`npx agent-room-mcp@0.19.0 init claude-code\` → check \`~/.claude/CLAUDE.md\` got the rule appended (or marked unchanged on re-run).
- [ ] Manual: \`npx agent-room-mcp@0.19.0 init cursor\` → confirms terminal printout has paste-able snippet for User Rules.
- [ ] Manual smoke: in Cursor, with the snippet pasted into User Rules, send "join the room ABC-DEF-GHJ" (no other instructions) → Cursor immediately calls \`room_join\` and enters the listen loop.

## Authorship

Patch by Claude. Coordinated with Codex (Codex shipped 0.18.4 covering uniqueness/watcher/auto-greet in #9, this PR adds the orthogonal install-time piece).