### PR TITLE
fix(mcp): preserve participant styling on send

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -587,12 +587,14 @@ export function registerTools(server: Server, env: UpstashEnv) {
 
     if (name === 'room_send') {
       let role: string = a.role ?? '';
-      if (!role) {
-        try {
-          const room = await getRoom(client, a.code);
-          role = room.participants.find((p: Participant) => p.name === a.name)?.role ?? '';
-        } catch { /* fall through */ }
-      }
+      let speaker: Participant | undefined;
+      try {
+        const room = await getRoom(client, a.code);
+        speaker = room.participants.find((p: Participant) => p.name === a.name && p.client === 'cc');
+        if (!role) {
+          role = speaker?.role ?? '';
+        }
+      } catch { /* fall through */ }
       // Cursor's Composer agent (and probably other client subsystems we
       // haven't seen yet) sometimes JSON.stringify's its own message body
       // before passing it as the `text` arg, so a real newline arrives as
@@ -607,8 +609,8 @@ export function registerTools(server: Server, env: UpstashEnv) {
         id: Date.now(),
         type: 'msg',
         name: a.name,
-        initials: initialsFor(a.name),
-        color: colorForName(a.name),
+        initials: speaker?.initials ?? initialsFor(a.name),
+        color: speaker?.color ?? colorForName(a.name),
         role,
         text,
         client: 'cc',

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.18.4",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- make room_send reuse the speaker participant row for color, initials, and default role
- fixes Cursor (2) messages changing color/initials after the join greeting
- bump agent-room-mcp to 0.19.1

## Verification
- npm -w apps/mcp test
- npm -w apps/mcp run typecheck
- npm -w apps/mcp run build
- npm test