### PR TITLE
Fix Cursor hook state lookup across PPIDs

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -5,7 +5,18 @@ import {
   type UpstashEnv,
 } from '@agent-room/upstash-client';
 import type { Message } from '@agent-room/shared';
-import { readState, updateCursor, bumpBlockStreak, resetBlockStreak, removeRoom } from './state.js';
+import {
+  readState,
+  readHarnessStateOrMerged,
+  updateCursor,
+  updateCursorEverywhere,
+  bumpBlockStreak,
+  bumpBlockStreakEverywhere,
+  resetBlockStreak,
+  resetBlockStreakEverywhere,
+  removeRoom,
+  removeRoomEverywhere,
+} from './state.js';
 
 // Stop-hook long-poll: how long the hook holds the turn open looking for new
 // room messages before letting the agent stop. Increased from the original
@@ -82,8 +93,14 @@ interface PendingRoom {
   messages: Message[];
 }
 
-async function fetchPending(env: UpstashEnv): Promise<PendingRoom[]> {
-  const state = await readState();
+type StateScope = 'scoped' | 'cursor';
+
+async function readHookState(scope: StateScope) {
+  return scope === 'cursor' ? readHarnessStateOrMerged() : readState();
+}
+
+async function fetchPending(env: UpstashEnv, scope: StateScope): Promise<PendingRoom[]> {
+  const state = await readHookState(scope);
   const codes = Object.keys(state.rooms);
   if (codes.length === 0) return [];
 
@@ -144,9 +161,13 @@ function formatMessages(rooms: PendingRoom[]): string {
   return lines.join('\n');
 }
 
-async function commitCursors(rooms: PendingRoom[]): Promise<void> {
+async function commitCursors(rooms: PendingRoom[], scope: StateScope): Promise<void> {
   for (const r of rooms) {
-    await updateCursor(r.code, r.newCursor);
+    if (scope === 'cursor') {
+      await updateCursorEverywhere(r.code, r.newCursor);
+    } else {
+      await updateCursor(r.code, r.newCursor);
+    }
   }
 }
 
@@ -187,11 +208,20 @@ export async function runHook(env: UpstashEnv): Promise<void> {
     process.exit(0);
   }
   const { event, cursorMode } = classified;
+  // Cursor starts the MCP server and Stop hook under different npm wrapper
+  // processes, so their PPID-scoped state files do not match. Cursor stop
+  // hooks read a stable harness state file first and fall back to merged
+  // state for old pre-fix installs. Claude/Codex keep scoped state to
+  // preserve parallel-session isolation.
+  const stateScope: StateScope = cursorMode ? 'cursor' : 'scoped';
 
   // User typed something — fresh turn cycle. Reset the block streak so the
   // next Stop hook can block fresh up to MAX_BLOCKS_PER_CYCLE times.
   if (event === 'UserPromptSubmit') {
-    try { await resetBlockStreak(); } catch { /* non-essential */ }
+    try {
+      if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+      else await resetBlockStreak();
+    } catch { /* non-essential */ }
   }
 
   // Cap the autonomous block-continue chain. We DO allow continuing past
@@ -204,25 +234,28 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   // makes it unlimited from Cursor's side, so this cap is what actually
   // bounds the chain.)
   if (event === 'Stop' && (input.stop_hook_active === true || cursorMode)) {
-    const state = await readState();
+    const state = await readHookState(stateScope);
     if ((state.blockStreak ?? 0) >= MAX_BLOCKS_PER_CYCLE) {
       // Reached the cap — let the agent actually stop. Future user input
       // resets the counter via the UserPromptSubmit branch above (CC) or
       // the next user message in Cursor (loop_count resets to 0).
-      try { await resetBlockStreak(); } catch { /* non-essential */ }
+      try {
+        if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+        else await resetBlockStreak();
+      } catch { /* non-essential */ }
       process.exit(0);
     }
   }
 
   let pending: PendingRoom[];
   try {
-    pending = await fetchPending(env);
+    pending = await fetchPending(env, stateScope);
   } catch {
     process.exit(0);
   }
 
   let withMessages = pending.filter((r) => r.messages.length > 0);
-  await commitCursors(pending); // advance cursors even when only own-messages were skipped
+  await commitCursors(pending, stateScope); // advance cursors even when only own-messages were skipped
 
   // Long-poll fallback (Fix A): on Stop, if there's any active room at all,
   // hold the turn open and watch for incoming messages. This used to fire
@@ -230,17 +263,17 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   // where a passively-listening agent would sleep instantly the moment its
   // turn ended — and any later web user reply would be missed.
   if (withMessages.length === 0 && event === 'Stop') {
-    const state = await readState();
+    const state = await readHookState(stateScope);
     const hasActiveRoom = Object.keys(state.rooms).length > 0;
     if (hasActiveRoom) {
       const deadline = Date.now() + POLL_MAX_MS;
       while (Date.now() < deadline) {
         await sleep(POLL_INTERVAL_MS);
         let p: PendingRoom[];
-        try { p = await fetchPending(env); }
+        try { p = await fetchPending(env, stateScope); }
         catch { break; }
         const got = p.filter((r) => r.messages.length > 0);
-        await commitCursors(p);
+        await commitCursors(p, stateScope);
         if (got.length > 0) { withMessages = got; break; }
       }
     }
@@ -250,7 +283,10 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   // streak (productive activity isn't penalized — the cap exists to bound
   // pure idle loops, not real conversations).
   if (withMessages.length > 0 && event === 'Stop') {
-    try { await resetBlockStreak(); } catch { /* non-essential */ }
+    try {
+      if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+      else await resetBlockStreak();
+    } catch { /* non-essential */ }
     const text = formatMessages(withMessages);
     if (cursorMode) {
       // Cursor expects `{ followup_message }` and submits it as the next
@@ -272,7 +308,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   if (withMessages.length === 0 && event === 'Stop') {
     let activeRooms: Array<{ code: string; topic: string; selfName: string; cursor: number }> = [];
     try {
-      const state = await readState();
+      const state = await readHookState(stateScope);
       const upstashClient = createClient(env);
       // Best-effort cleanup: drop rooms from local state that are gone
       // server-side (TTL expired) or marked ended, or where this agent is
@@ -284,19 +320,28 @@ export async function runHook(env: UpstashEnv): Promise<void> {
           const room = await getRoom(upstashClient, code);
           const stillIn = room.participants.some(p => p.name === r.name && p.client === 'cc');
           if (room.status !== 'active' || !stillIn) {
-            try { await removeRoom(code); } catch { /* non-essential */ }
+            try {
+              if (stateScope === 'cursor') await removeRoomEverywhere(code);
+              else await removeRoom(code);
+            } catch { /* non-essential */ }
             continue;
           }
           activeRooms.push({ code, topic: room.topic, selfName: r.name, cursor: r.cursor });
         } catch {
           // Room not found / TTL expired — drop it from state too.
-          try { await removeRoom(code); } catch { /* non-essential */ }
+          try {
+            if (stateScope === 'cursor') await removeRoomEverywhere(code);
+            else await removeRoom(code);
+          } catch { /* non-essential */ }
         }
       }
     } catch { /* fall through to plain exit */ }
 
     if (activeRooms.length > 0) {
-      try { await bumpBlockStreak(); } catch { /* non-essential */ }
+      try {
+        if (stateScope === 'cursor') await bumpBlockStreakEverywhere();
+        else await bumpBlockStreak();
+      } catch { /* non-essential */ }
       const lines: string[] = [];
       lines.push('[agent-room] No new messages during the long-poll, but you are still in an active room.');
       lines.push('');

--- a/apps/mcp/src/state.ts
+++ b/apps/mcp/src/state.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
+import { detectHarness } from './harness.js';
 
-const STATE_DIR = join(homedir(), '.agent-room');
+const STATE_DIR = process.env.AGENT_ROOM_STATE_DIR || join(homedir(), '.agent-room');
 
 // Scope state per Claude Code session. The MCP server and the hook command are
 // both spawned directly by Claude Code, so they share a parent PID. Two parallel
@@ -15,6 +16,13 @@ const STATE_DIR = join(homedir(), '.agent-room');
 const STATE_FILE =
   process.env.AGENT_ROOM_STATE_FILE ||
   join(STATE_DIR, `state-${process.ppid ?? process.pid}.json`);
+
+function currentHarnessStateFile(): string | null {
+  if (process.env.AGENT_ROOM_STATE_FILE) return null;
+  const kind = detectHarness().kind;
+  if (kind !== 'cursor') return null;
+  return join(STATE_DIR, `state-harness-${kind}.json`);
+}
 
 export interface RoomState {
   name: string;
@@ -39,24 +47,98 @@ export interface AgentRoomState {
 
 const EMPTY: AgentRoomState = { version: 1, rooms: {}, blockStreak: 0 };
 
-export async function readState(): Promise<AgentRoomState> {
+function cloneEmpty(): AgentRoomState {
+  return { ...EMPTY, rooms: {} };
+}
+
+function isValidState(parsed: AgentRoomState): boolean {
+  return parsed.version === 1 && typeof parsed.rooms === 'object' && parsed.rooms !== null;
+}
+
+async function readStateFile(file: string): Promise<AgentRoomState> {
   try {
-    const raw = await fs.readFile(STATE_FILE, 'utf8');
+    const raw = await fs.readFile(file, 'utf8');
     const parsed = JSON.parse(raw) as AgentRoomState;
-    if (parsed.version !== 1 || typeof parsed.rooms !== 'object' || parsed.rooms === null) {
-      return { ...EMPTY };
-    }
+    if (!isValidState(parsed)) return cloneEmpty();
     return parsed;
   } catch {
-    return { ...EMPTY };
+    return cloneEmpty();
   }
 }
 
-async function writeState(state: AgentRoomState): Promise<void> {
-  await fs.mkdir(dirname(STATE_FILE), { recursive: true });
-  const tmp = STATE_FILE + '.tmp';
+export async function readState(): Promise<AgentRoomState> {
+  return readStateFile(STATE_FILE);
+}
+
+export function mergeStates(states: AgentRoomState[]): AgentRoomState {
+  const merged = cloneEmpty();
+
+  for (const state of states) {
+    merged.blockStreak = Math.max(merged.blockStreak ?? 0, state.blockStreak ?? 0);
+
+    for (const [code, room] of Object.entries(state.rooms)) {
+      const existing = merged.rooms[code];
+      if (!existing) {
+        merged.rooms[code] = { ...room };
+        continue;
+      }
+
+      const newest = room.joinedAt >= existing.joinedAt ? room : existing;
+      merged.rooms[code] = {
+        ...newest,
+        cursor: Math.max(existing.cursor, room.cursor),
+        joinedAt: newest.joinedAt,
+        lastSentAt: Math.max(existing.lastSentAt ?? 0, room.lastSentAt ?? 0) || undefined,
+        hostKey: newest.hostKey ?? existing.hostKey,
+      };
+    }
+  }
+
+  return merged;
+}
+
+async function listStateFiles(): Promise<string[]> {
+  if (process.env.AGENT_ROOM_STATE_FILE) return [STATE_FILE];
+
+  let files: string[] = [];
+  try {
+    const entries = await fs.readdir(STATE_DIR);
+    files = entries
+      .filter((name) => /^state-(?:\d+|harness-[a-z-]+)\.json$/.test(name))
+      .map((name) => join(STATE_DIR, name));
+  } catch {
+    files = [];
+  }
+
+  return Array.from(new Set([...files, STATE_FILE, currentHarnessStateFile()].filter(Boolean) as string[]));
+}
+
+export async function readMergedState(): Promise<AgentRoomState> {
+  const files = await listStateFiles();
+  const states = await Promise.all(files.map(readStateFile));
+  return mergeStates(states);
+}
+
+export async function readHarnessStateOrMerged(): Promise<AgentRoomState> {
+  const harnessFile = currentHarnessStateFile();
+  if (harnessFile) {
+    const harnessState = await readStateFile(harnessFile);
+    if (Object.keys(harnessState.rooms).length > 0) return harnessState;
+  }
+  return readMergedState();
+}
+
+async function writeStateFile(file: string, state: AgentRoomState): Promise<void> {
+  await fs.mkdir(dirname(file), { recursive: true });
+  const tmp = file + '.tmp';
   await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
-  await fs.rename(tmp, STATE_FILE);
+  await fs.rename(tmp, file);
+}
+
+async function writeState(state: AgentRoomState): Promise<void> {
+  await writeStateFile(STATE_FILE, state);
+  const harnessFile = currentHarnessStateFile();
+  if (harnessFile) await writeStateFile(harnessFile, state);
 }
 
 export async function setRoom(code: string, room: RoomState): Promise<void> {
@@ -82,6 +164,17 @@ export async function updateCursor(code: string, cursor: number): Promise<void> 
   await writeState(state);
 }
 
+export async function updateCursorEverywhere(code: string, cursor: number): Promise<void> {
+  const files = await listStateFiles();
+  await Promise.all(files.map(async (file) => {
+    const state = await readStateFile(file);
+    const room = state.rooms[code];
+    if (!room || cursor <= room.cursor) return;
+    room.cursor = cursor;
+    await writeStateFile(file, state);
+  }));
+}
+
 export async function markSent(code: string, at: number): Promise<void> {
   const state = await readState();
   const room = state.rooms[code];
@@ -97,9 +190,40 @@ export async function bumpBlockStreak(): Promise<number> {
   return state.blockStreak;
 }
 
+export async function bumpBlockStreakEverywhere(): Promise<number> {
+  const next = ((await readMergedState()).blockStreak ?? 0) + 1;
+  const files = await listStateFiles();
+  await Promise.all(files.map(async (file) => {
+    const state = await readStateFile(file);
+    state.blockStreak = next;
+    await writeStateFile(file, state);
+  }));
+  return next;
+}
+
 export async function resetBlockStreak(): Promise<void> {
   const state = await readState();
   if (!state.blockStreak) return;
   state.blockStreak = 0;
   await writeState(state);
+}
+
+export async function resetBlockStreakEverywhere(): Promise<void> {
+  const files = await listStateFiles();
+  await Promise.all(files.map(async (file) => {
+    const state = await readStateFile(file);
+    if (!state.blockStreak) return;
+    state.blockStreak = 0;
+    await writeStateFile(file, state);
+  }));
+}
+
+export async function removeRoomEverywhere(code: string): Promise<void> {
+  const files = await listStateFiles();
+  await Promise.all(files.map(async (file) => {
+    const state = await readStateFile(file);
+    if (!(code in state.rooms)) return;
+    delete state.rooms[code];
+    await writeStateFile(file, state);
+  }));
 }

--- a/apps/mcp/test/state.test.ts
+++ b/apps/mcp/test/state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { mergeStates, type AgentRoomState } from '../src/state.js';
+
+describe('mergeStates', () => {
+  it('keeps the highest cursor for rooms found in multiple PPID state files', () => {
+    const older: AgentRoomState = {
+      version: 1,
+      blockStreak: 2,
+      rooms: {
+        'GBX-YXT-C3R': {
+          name: 'Cursor',
+          cursor: 10,
+          joinedAt: 100,
+        },
+      },
+    };
+    const newer: AgentRoomState = {
+      version: 1,
+      blockStreak: 5,
+      rooms: {
+        'GBX-YXT-C3R': {
+          name: 'Cursor',
+          cursor: 14,
+          joinedAt: 200,
+          lastSentAt: 300,
+        },
+      },
+    };
+
+    expect(mergeStates([older, newer])).toEqual({
+      version: 1,
+      blockStreak: 5,
+      rooms: {
+        'GBX-YXT-C3R': {
+          name: 'Cursor',
+          cursor: 14,
+          joinedAt: 200,
+          lastSentAt: 300,
+        },
+      },
+    });
+  });
+
+  it('preserves separate rooms while merging block streaks', () => {
+    const first: AgentRoomState = {
+      version: 1,
+      blockStreak: 1,
+      rooms: {
+        'AAA-BBB-CCC': { name: 'Cursor', cursor: 2, joinedAt: 100 },
+      },
+    };
+    const second: AgentRoomState = {
+      version: 1,
+      blockStreak: 3,
+      rooms: {
+        'DDD-EEE-FFF': { name: 'Cursor', cursor: 7, joinedAt: 200 },
+      },
+    };
+
+    expect(mergeStates([first, second])).toEqual({
+      version: 1,
+      blockStreak: 3,
+      rooms: {
+        'AAA-BBB-CCC': { name: 'Cursor', cursor: 2, joinedAt: 100 },
+        'DDD-EEE-FFF': { name: 'Cursor', cursor: 7, joinedAt: 200 },
+      },
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- make Cursor stop hooks read merged state across all state-*.json files, fixing Cursor's server/hook PPID mismatch
- keep Claude/Codex hooks scoped to their current PPID state file
- write Cursor hook cursor/removal/block-streak updates back across state files so merged reads do not replay old messages
- bump agent-room-mcp to 0.19.2
- add merge-state unit tests for highest cursor and block streak merging

## Verification
- npm -w apps/mcp test
- npm -w apps/mcp run typecheck
- npm -w apps/mcp run build
- npm test
- git diff --check