### PR TITLE
Label persistent versus manual client support

### DIFF
--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -20,8 +20,8 @@ const FEATURES = [
   },
   {
     icon: '⚡',
-    title: 'Six MCP clients, one room',
-    desc: 'Claude Code, Claude Desktop, Cursor, Codex CLI, Gemini CLI, Cline. Drop in any combo. One config snippet per client. No vendor lock.',
+    title: 'Persistent on the core agent stack',
+    desc: 'Claude Code, Cursor, and Codex stay present through room pauses. Claude Desktop, Gemini CLI, and Cline can join through MCP with manual listen prompts.',
   },
   {
     icon: '📦',
@@ -192,9 +192,8 @@ export function Home() {
         </div>
       </header>
 
-      {/* Works-with strip — the "neutral cross-vendor bus" pitch only lands
-         if visitors can see the lineup of clients on day one. Five named
-         agents = a real lineup, not a Claude-only side project. */}
+      {/* Works-with strip — show the full MCP compatibility story, but
+         distinguish fully persistent clients from one-shot/manual clients. */}
       <section className="border-y border-border-faint bg-white">
         <div className="max-w-6xl mx-auto px-6 py-12">
           <div className="text-center mb-6">
@@ -202,23 +201,26 @@ export function Home() {
               Works with the agent stack you already use
             </span>
           </div>
-          <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-6">
+          <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-5">
             {[
-              { name: 'Claude Code',   color: 'bg-violet-100 text-violet-700',   letter: 'C'  },
-              { name: 'Claude Desktop',color: 'bg-amber-100 text-amber-800',     letter: 'Cd' },
-              { name: 'Cursor',        color: 'bg-blue-100 text-blue-700',       letter: 'Cu' },
-              { name: 'Codex CLI',     color: 'bg-emerald-100 text-emerald-700', letter: 'Cx' },
-              { name: 'Gemini CLI',    color: 'bg-rose-100 text-rose-700',       letter: 'G'  },
-              { name: 'Cline',         color: 'bg-cyan-100 text-cyan-700',       letter: 'Cl' },
+              { name: 'Claude Code',   color: 'bg-violet-100 text-violet-700',   letter: 'C',  status: 'Persistent' },
+              { name: 'Cursor',        color: 'bg-blue-100 text-blue-700',       letter: 'Cu', status: 'Persistent' },
+              { name: 'Codex CLI',     color: 'bg-emerald-100 text-emerald-700', letter: 'Cx', status: 'Persistent' },
+              { name: 'Claude Desktop',color: 'bg-slate-100 text-slate-500',     letter: 'Cd', status: 'Manual listen' },
+              { name: 'Gemini CLI',    color: 'bg-slate-100 text-slate-500',     letter: 'G',  status: 'Manual listen' },
+              { name: 'Cline',         color: 'bg-slate-100 text-slate-500',     letter: 'Cl', status: 'Limited' },
             ].map(c => (
-              <div key={c.name} className="flex items-center gap-2.5 grayscale-0">
+              <div key={c.name} className="flex items-center gap-2.5">
                 <div className={`w-9 h-9 rounded-lg ${c.color} flex items-center justify-center text-sm font-bold`}>{c.letter}</div>
-                <span className="text-sm font-semibold text-ink-muted">{c.name}</span>
+                <div>
+                  <div className="text-sm font-semibold text-ink-muted leading-tight">{c.name}</div>
+                  <div className={`text-[10px] font-semibold leading-tight ${c.status === 'Persistent' ? 'text-emerald-600' : 'text-ink-faint'}`}>{c.status}</div>
+                </div>
               </div>
             ))}
           </div>
           <p className="mt-6 text-center text-xs text-ink-faint">
-            One MCP server, one config snippet, every client. Your team brings whichever AI it already uses.
+            Persistent room presence is tested on Claude Code, Cursor, and Codex. Other MCP clients can join and send, but may need manual room_listen prompts.
           </p>
         </div>
       </section>
@@ -335,7 +337,7 @@ export function Home() {
               <button onClick={() => copyText('npx agent-room-mcp init', 'Command copied')} className="text-xs font-semibold text-accent bg-accent/15 hover:bg-accent/25 px-3 py-1 rounded-md transition">Copy</button>
             </div>
             <code className="text-xl sm:text-2xl text-emerald-400 font-mono break-all">$ npx agent-room-mcp init</code>
-            <p className="text-sm text-slate-500 mt-4">One command — pick Claude Code, Claude Desktop, Cursor, Codex CLI, or Gemini CLI. Idempotent and safe to re-run.</p>
+            <p className="text-sm text-slate-500 mt-4">One command — pick Claude Code, Claude Desktop, Cursor, Codex CLI, Gemini CLI, or Cline. Idempotent and safe to re-run.</p>
           </div>
 
           {/* Manual config — consolidated. Five of the six clients share
@@ -351,7 +353,7 @@ export function Home() {
                 <span className="text-[10px] font-semibold text-ink-faint uppercase tracking-wider">JSON</span>
               </div>
               <p className="text-sm text-ink-soft mb-4 leading-relaxed">
-                Same snippet works for <strong>Claude Code, Claude Desktop, Cursor / Windsurf, Gemini CLI, and Cline</strong>. Just drop it into the right config file (paths on the right).
+                Same snippet works for <strong>Claude Code, Claude Desktop, Cursor / Windsurf, Gemini CLI, and Cline</strong>. Persistent listening is tested on Claude Code, Cursor, and Codex; other clients may need manual room_listen prompts.
               </p>
               <div className="bg-slate-50 border border-border rounded-xl relative flex-1 flex flex-col">
                 <button onClick={() => copyText(MCP_JSON, 'Config copied')} className="absolute top-2.5 right-2.5 text-[11px] font-semibold text-accent bg-accent-tint hover:bg-accent-tint-border px-2 py-1 rounded-md transition z-10">Copy</button>


### PR DESCRIPTION
## Summary
- distinguish persistent clients from manual/limited MCP clients in the homepage support strip
- update feature and install copy so Gemini CLI/Cline/Claude Desktop are not implied to have tested persistent listening
- keep limited clients visible as MCP-compatible rather than removing them

## Verification
- npm -w apps/web run build
- npm test
- git diff --check
- Chrome headless desktop screenshot