### PR TITLE
fix(mcp,web): Claude Desktop Code/Cowork is persistent; drop Cline from menu (0.19.3)

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -51,7 +51,7 @@ Zero config - works out of the box with the public server. No API keys needed.
 }
 ```
 
-Claude Desktop supports the MCP tools, but it does not run Claude Code hooks. For live room messages, tell Claude Desktop to join the room and keep calling `room_listen`.
+New Claude Desktop builds include Claude Code / Cowork. Run `npx agent-room-mcp init claude-desktop` so Desktop gets the MCP server and Claude Code hooks for persistent room listening. Plain Claude Desktop chat MCP sessions may still need manual `room_listen` prompts.
 
 ## Tools
 

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/harness.ts
+++ b/apps/mcp/src/harness.ts
@@ -1,7 +1,7 @@
 // Detect which agent harness is running this MCP process. Used to
 // conditionally append a persistence-setup nudge to room_join /
 // room_create hints — harnesses that don't auto-loop tool calls
-// (Cursor without 1.7+ stop hooks, Claude Desktop, Gemini CLI, etc.)
+// (Cursor without 1.7+ stop hooks, Gemini CLI, etc.)
 // silently drop out of rooms unless the user has run
 // `npx agent-room-mcp init`.
 
@@ -51,7 +51,7 @@ export function detectHarness(env: NodeJS.ProcessEnv = process.env): HarnessInfo
     return { kind: 'gemini-cli', needsPersistenceSetup: true, label: 'Gemini CLI' };
   }
   if (env.CLAUDE_DESKTOP_VERSION || env.__CFBundleIdentifier === 'com.anthropic.claudefordesktop') {
-    return { kind: 'claude-desktop', needsPersistenceSetup: true, label: 'Claude Desktop' };
+    return { kind: 'claude-desktop', needsPersistenceSetup: false, label: 'Claude Desktop Code/Cowork' };
   }
   if (env.CLINE_VERSION) {
     return { kind: 'cline', needsPersistenceSetup: true, label: 'Cline' };

--- a/apps/mcp/src/init.ts
+++ b/apps/mcp/src/init.ts
@@ -200,7 +200,7 @@ function claudeDesktopConfigPath(): string {
   return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json');
 }
 
-async function installClaudeDesktop(): Promise<InstallResult> {
+async function installClaudeDesktop(opts: { hooks: boolean }): Promise<InstallResult> {
   const result: InstallResult = { changes: [], unchanged: [] };
   const path = claudeDesktopConfigPath();
   const config = (await readJson(path)) ?? {};
@@ -215,6 +215,13 @@ async function installClaudeDesktop(): Promise<InstallResult> {
   } else {
     result.unchanged.push(`${path} (already configured)`);
   }
+
+  // New Claude Desktop builds embed Claude Code / Cowork. The Code surface
+  // uses Claude Code's settings files for hooks, so install the same
+  // persistent-listening hook there as well.
+  const codeResult = await installClaudeCode({ hooks: opts.hooks });
+  result.changes.push(...codeResult.changes);
+  result.unchanged.push(...codeResult.unchanged);
 
   return result;
 }
@@ -415,7 +422,8 @@ function printConfigs() {
   console.log('\n--- Claude Desktop ---');
   console.log('claude_desktop_config.json:');
   console.log(mcp);
-  console.log('\nNote: Claude Desktop supports MCP tools, but not Claude Code hooks. Use room_listen for live room messages.');
+  console.log('\n~/.claude/settings.json (for Claude Desktop Code/Cowork autonomous chat):');
+  console.log(hooks);
 
   console.log('\n--- Cursor (1.7+) ---');
   console.log('~/.cursor/mcp.json:');
@@ -487,12 +495,11 @@ export async function runInit(argv: string[]): Promise<void> {
     console.log('\nAgent Room — install MCP server\n');
     console.log('Where to install?');
     console.log('  1. Claude Code   (default — adds MCP server + autonomous-chat hooks)');
-    console.log('  2. Claude Desktop (MCP server only — use room_listen for live chat)');
+    console.log('  2. Claude Desktop (adds MCP server + Claude Code/Cowork hooks)');
     console.log('  3. Cursor          (Cursor 1.7+: adds MCP server + stop hook)');
     console.log('  4. Codex CLI     (adds MCP server + hooks)');
     console.log('  5. Gemini CLI');
-    console.log('  6. Cline (VS Code extension)');
-    console.log('  7. Print configs (paste them yourself)');
+    console.log('  6. Print configs (paste them yourself)');
     const ans = (await rl.question('\n[1]: ')).trim();
     rl.close();
     target =
@@ -500,8 +507,7 @@ export async function runInit(argv: string[]): Promise<void> {
       ans === '3' ? 'cursor' :
       ans === '4' ? 'codex' :
       ans === '5' ? 'gemini' :
-      ans === '6' ? 'cline' :
-      ans === '7' ? 'print' :
+      ans === '6' ? 'print' :
       'claude-code';
   }
 
@@ -543,11 +549,14 @@ export async function runInit(argv: string[]): Promise<void> {
   }
 
   if (target === 'claude-desktop' || target === 'claude-desktop-app' || target === 'desktop') {
-    const result = await installClaudeDesktop();
+    const result = await installClaudeDesktop({ hooks: !noHooks });
     reportResult('Claude Desktop', result);
+    if (noHooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for Claude Desktop Code/Cowork autonomous chat)');
+    }
     nextSteps('Claude Desktop');
-    console.log('  Note: Claude Desktop does not run hooks, so ask it to call room_listen to see live room messages.');
-    printRulesInstruction('Claude Desktop', 'Claude Desktop → Settings → Profile → System Prompt (or paste at the start of every conversation)');
+    console.log('  Note: persistent listening applies to Claude Desktop Code/Cowork. Plain chat MCP may still need manual room_listen prompts.');
+    printRulesInstruction('Claude Desktop', 'Claude Desktop Code/Cowork custom instructions or user memory');
     return;
   }
 
@@ -571,6 +580,6 @@ export async function runInit(argv: string[]): Promise<void> {
     return;
   }
 
-  console.error(`Unknown target: ${target}. Try: claude-code, claude-desktop, cursor, codex, gemini, cline, print`);
+  console.error(`Unknown target: ${target}. Try: claude-code, claude-desktop, cursor, codex, gemini, print`);
   process.exit(1);
 }

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -146,8 +146,8 @@ export function registerTools(server: Server, env: UpstashEnv) {
   const client = createClient(env);
   // Snapshot the host harness once at boot. This drives the persistence-setup
   // nudge in room_join / room_create — agents on harnesses that don't
-  // auto-loop tool calls (Cursor without 1.7+ stop hook, Claude Desktop,
-  // Gemini CLI, etc.) get an extra line telling them to run
+  // auto-loop tool calls (Cursor without 1.7+ stop hook, Gemini CLI, etc.)
+  // get an extra line telling them to run
   // `npx agent-room-mcp init`. Snapshotted because env vars don't change
   // mid-process and detection runs in O(branches).
   const harness = detectHarness();
@@ -312,7 +312,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
           properties: {
             code: { type: 'string' },
             since: { type: 'number', description: 'Cursor from previous call' },
-            timeoutMs: { type: 'number', description: 'Max wait time in ms (default 240000 = 4min). Long default keeps clients without Stop hooks (Cursor, Claude Desktop, Gemini) present in the room across model turns. Cap at ~270000 to stay under the typical 5-min tool-call timeout.' },
+            timeoutMs: { type: 'number', description: 'Max wait time in ms (default 240000 = 4min). Long default keeps clients without Stop hooks (Cursor, Gemini) present in the room across model turns. Cap at ~270000 to stay under the typical 5-min tool-call timeout.' },
           },
         },
       },
@@ -667,7 +667,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
     if (name === 'room_listen') {
       const since = a.since ?? 0;
       // Default 4 minutes (was 30s). 30s is too short for clients without a
-      // Stop hook (Cursor, Claude Desktop, Gemini, Cline) — the agent ends
+      // Stop hook (Cursor, Gemini, Cline) — the agent ends
       // its turn and never gets nudged back into the listen loop, so it
       // silently drops out of the room. 240s keeps the agent present for
       // most natural conversation pauses while staying under the typical

--- a/apps/mcp/test/harness.test.ts
+++ b/apps/mcp/test/harness.test.ts
@@ -50,13 +50,13 @@ describe('detectHarness', () => {
     expect(detectHarness(env({ CODEX_RUN_ID: 'r1' })).needsPersistenceSetup).toBe(false);
   });
 
-  it('cursor / unknown / claude-desktop / gemini-cli need setup', () => {
+  it('cursor / unknown / gemini-cli need setup, Claude Desktop Code/Cowork is strong-loop', () => {
     expect(detectHarness(env({ CURSOR_TRACE_ID: 'x' })).needsPersistenceSetup).toBe(true);
     expect(detectHarness(env({})).needsPersistenceSetup).toBe(true);
     expect(
       detectHarness(env({ __CFBundleIdentifier: 'com.anthropic.claudefordesktop' }))
         .needsPersistenceSetup,
-    ).toBe(true);
+    ).toBe(false);
     expect(detectHarness(env({ GEMINI_CLI: '1' })).needsPersistenceSetup).toBe(true);
   });
 });
@@ -65,6 +65,11 @@ describe('persistenceSetupHint', () => {
   it('returns empty string for strong-loop harnesses', () => {
     expect(persistenceSetupHint(detectHarness(env({ CLAUDECODE: '1' })))).toBe('');
     expect(persistenceSetupHint(detectHarness(env({ CODEX_RUN_ID: 'r1' })))).toBe('');
+    expect(
+      persistenceSetupHint(
+        detectHarness(env({ __CFBundleIdentifier: 'com.anthropic.claudefordesktop' })),
+      ),
+    ).toBe('');
   });
 
   it('returns a setup nudge mentioning init for weak-loop harnesses', () => {

--- a/apps/web/src/components/AgentJoinQuickstart.tsx
+++ b/apps/web/src/components/AgentJoinQuickstart.tsx
@@ -6,7 +6,6 @@ export type AgentClientId =
   | 'cursor'
   | 'codex'
   | 'gemini'
-  | 'cline'
   | 'print';
 
 const CLIENT_ROWS: {
@@ -29,7 +28,7 @@ const CLIENT_ROWS: {
     label: 'Claude Desktop',
     initMenuKey: '2',
     restartTarget: 'Claude Desktop',
-    note: 'MCP only — rely on room_listen in your prompts for live messages.',
+    note: 'MCP + Claude Code/Cowork hooks for persistent room presence.',
   },
   {
     id: 'cursor',
@@ -53,16 +52,9 @@ const CLIENT_ROWS: {
     note: '',
   },
   {
-    id: 'cline',
-    label: 'Cline (VS Code extension)',
-    initMenuKey: '6',
-    restartTarget: 'VS Code + Cline',
-    note: 'Paste the MCP snippet into Cline’s MCP Servers panel if prompted.',
-  },
-  {
     id: 'print',
     label: 'Other / manual paste',
-    initMenuKey: '7',
+    initMenuKey: '6',
     restartTarget: 'your client',
     note: 'Prints every harness snippet — copy the block that matches your tool.',
   },
@@ -104,7 +96,7 @@ export function AgentJoinQuickstart({ roomCode }: Props) {
   const initBlock = `npx agent-room-mcp init`;
   const initHint =
     client === 'print'
-      ? 'At the first prompt, type 7 and press Enter (Print configs) — do not press Enter alone, that selects Claude Code.'
+      ? 'At the first prompt, type 6 and press Enter (Print configs) — do not press Enter alone, that selects Claude Code.'
       : `At the first prompt, type ${row.initMenuKey} and press Enter (${row.label}). Do not pass --no-hooks if you want the agent to stay in the room.`;
 
   const agentPrompt = `Join agent-room ${roomCode} as <your agent name>. After room_join, stay in a room_listen loop: on quiet timeout, call room_listen again with the same cursor; use room_send when you need to speak. Stop only if the host ends the room, removes you, or tells you to leave.`;

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -21,7 +21,7 @@ const FEATURES = [
   {
     icon: '⚡',
     title: 'Persistent on the core agent stack',
-    desc: 'Claude Code, Cursor, and Codex stay present through room pauses. Claude Desktop, Gemini CLI, and Cline can join through MCP with manual listen prompts.',
+    desc: 'Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex stay present through room pauses. Gemini CLI can join through MCP with manual listen prompts.',
   },
   {
     icon: '📦',
@@ -206,9 +206,8 @@ export function Home() {
               { name: 'Claude Code',   color: 'bg-violet-100 text-violet-700',   letter: 'C',  status: 'Persistent' },
               { name: 'Cursor',        color: 'bg-blue-100 text-blue-700',       letter: 'Cu', status: 'Persistent' },
               { name: 'Codex CLI',     color: 'bg-emerald-100 text-emerald-700', letter: 'Cx', status: 'Persistent' },
-              { name: 'Claude Desktop',color: 'bg-slate-100 text-slate-500',     letter: 'Cd', status: 'Manual listen' },
+              { name: 'Claude Desktop',color: 'bg-amber-100 text-amber-700',     letter: 'Cd', status: 'Persistent' },
               { name: 'Gemini CLI',    color: 'bg-slate-100 text-slate-500',     letter: 'G',  status: 'Manual listen' },
-              { name: 'Cline',         color: 'bg-slate-100 text-slate-500',     letter: 'Cl', status: 'Limited' },
             ].map(c => (
               <div key={c.name} className="flex items-center gap-2.5">
                 <div className={`w-9 h-9 rounded-lg ${c.color} flex items-center justify-center text-sm font-bold`}>{c.letter}</div>
@@ -220,7 +219,7 @@ export function Home() {
             ))}
           </div>
           <p className="mt-6 text-center text-xs text-ink-faint">
-            Persistent room presence is tested on Claude Code, Cursor, and Codex. Other MCP clients can join and send, but may need manual room_listen prompts.
+            Persistent room presence is tested on Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex. Other MCP clients can join and send, but may need manual room_listen prompts.
           </p>
         </div>
       </section>
@@ -337,7 +336,7 @@ export function Home() {
               <button onClick={() => copyText('npx agent-room-mcp init', 'Command copied')} className="text-xs font-semibold text-accent bg-accent/15 hover:bg-accent/25 px-3 py-1 rounded-md transition">Copy</button>
             </div>
             <code className="text-xl sm:text-2xl text-emerald-400 font-mono break-all">$ npx agent-room-mcp init</code>
-            <p className="text-sm text-slate-500 mt-4">One command — pick Claude Code, Claude Desktop, Cursor, Codex CLI, Gemini CLI, or Cline. Idempotent and safe to re-run.</p>
+            <p className="text-sm text-slate-500 mt-4">One command — pick Claude Code, Claude Desktop, Cursor, Codex CLI, or Gemini CLI. Idempotent and safe to re-run.</p>
           </div>
 
           {/* Manual config — consolidated. Five of the six clients share
@@ -353,7 +352,7 @@ export function Home() {
                 <span className="text-[10px] font-semibold text-ink-faint uppercase tracking-wider">JSON</span>
               </div>
               <p className="text-sm text-ink-soft mb-4 leading-relaxed">
-                Same snippet works for <strong>Claude Code, Claude Desktop, Cursor / Windsurf, Gemini CLI, and Cline</strong>. Persistent listening is tested on Claude Code, Cursor, and Codex; other clients may need manual room_listen prompts.
+                Same JSON snippet works for <strong>Claude Code, Claude Desktop, Cursor, and Gemini CLI</strong>. Persistent listening is tested on Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex; other clients may need manual room_listen prompts.
               </p>
               <div className="bg-slate-50 border border-border rounded-xl relative flex-1 flex flex-col">
                 <button onClick={() => copyText(MCP_JSON, 'Config copied')} className="absolute top-2.5 right-2.5 text-[11px] font-semibold text-accent bg-accent-tint hover:bg-accent-tint-border px-2 py-1 rounded-md transition z-10">Copy</button>
@@ -367,10 +366,10 @@ export function Home() {
               <ul className="space-y-3">
                 {[
                   { name: 'Claude Code',     status: 'Persistent',    badge: 'C',  badgeClass: 'bg-violet-100 text-violet-600', path: '~/.claude/.mcp.json' },
-                  { name: 'Claude Desktop',  status: 'Manual listen', badge: 'Cd', badgeClass: 'bg-slate-100 text-slate-500',   path: 'claude_desktop_config.json' },
                   { name: 'Cursor',          status: 'Persistent',    badge: 'Cu', badgeClass: 'bg-blue-100 text-blue-600',     path: '~/.cursor/mcp.json' },
+                  { name: 'Codex CLI',       status: 'Persistent',    badge: 'Cx', badgeClass: 'bg-emerald-100 text-emerald-600', path: '~/.codex/config.toml (below)' },
+                  { name: 'Claude Desktop',  status: 'Persistent',    badge: 'Cd', badgeClass: 'bg-amber-100 text-amber-700',   path: 'claude_desktop_config.json + ~/.claude/settings.json hooks' },
                   { name: 'Gemini CLI',      status: 'Manual listen', badge: 'G',  badgeClass: 'bg-slate-100 text-slate-500',   path: '~/.gemini/settings.json' },
-                  { name: 'Cline (VS Code)', status: 'Limited',       badge: 'Cl', badgeClass: 'bg-slate-100 text-slate-500',   path: 'MCP Servers panel' },
                 ].map(c => (
                   <li key={c.name} className="flex items-center gap-3">
                     <div className={`w-7 h-7 rounded-md ${c.badgeClass} flex items-center justify-center text-[11px] font-bold shrink-0`}>{c.badge}</div>
@@ -385,7 +384,7 @@ export function Home() {
                 ))}
               </ul>
               <p className="mt-5 pt-4 border-t border-border-faint text-[11px] text-ink-faint leading-relaxed">
-                Cline doesn't use a flat config file — open Cline's <strong>MCP Servers</strong> panel in VS Code and paste the snippet there.
+                Claude Desktop Code/Cowork uses Claude Code hooks from <code>~/.claude/settings.json</code> for persistent listening.
               </p>
             </div>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Why

Robin shared a screenshot of Claude Desktop's Settings panel showing it now embeds **Claude Code** and **Cowork** as first-class features. The Code surface uses Claude Code's \`~/.claude/settings.json\` hooks, which means Claude Desktop is **persistent**, not manual-listen. We had been labeling it Manual listen based on an outdated assumption that pre-dated the embedded Claude Code integration.

Plus: Robin chose option (1) earlier — drop Cline from the install menu (Cline is "Limited" tier, smallest user base of the three non-persistent clients).

## Changes

- \`apps/mcp/src/harness.ts\`: \`claude-desktop\` → \`needsPersistenceSetup: false\`, label updated to "Claude Desktop Code/Cowork"
- \`apps/mcp/test/harness.test.ts\`: persistence-flag tests updated to match
- \`apps/mcp/src/init.ts\`:
  - \`installClaudeDesktop\` now also calls \`installClaudeCode({ hooks })\` so the persistence hooks land in \`~/.claude/settings.json\` alongside the Claude Desktop MCP config — single \`init claude-desktop\` invocation now configures both
  - Interactive menu: Cline option removed (Print renumbered 7 → 6). \`installCline\` function kept so power users can still run \`init cline\` directly
  - \`printConfigs\` updated for Claude Desktop (now mentions \`~/.claude/settings.json\` hooks)
- \`apps/web/src/screens/Home.tsx\`:
  - Works-with strip: Claude Desktop badge → amber + status "Persistent"; Cline row removed
  - "Where to put it" list: Persistent rows first, Claude Desktop → Persistent + path note "claude_desktop_config.json + ~/.claude/settings.json hooks"; Codex CLI added with "(TOML below)" reference; Cline row removed
  - Feature card text + strip footer + JSON snippet section + footnote updated to reflect new tier matrix
- Bumps \`agent-room-mcp\` → \`0.19.3\`

## What still uses Manual listen

After this PR, the only "Manual listen" client visible on the website is **Gemini CLI** — it has MCP support but no Stop hook API per Anthropic-equivalent docs.

## Test plan

- [x] \`npm -w apps/mcp test\` → 23/23 pass (4 hook + 13 harness incl. 1 new claude-desktop persistent assertion + 4 init-rules + 2 state)
- [x] \`npm -w apps/mcp run typecheck\` ✓
- [x] \`npm -w apps/web run build\` ✓
- [ ] Vercel preview shows Claude Desktop in green "Persistent" badge in the works-with strip
- [ ] Vercel preview "Where to put it" list has Cline gone, Codex CLI present
- [ ] After merge + npm publish 0.19.3:
  - \`npx agent-room-mcp@latest init claude-desktop\` writes BOTH the Claude Desktop config AND \`~/.claude/settings.json\` hooks
  - Interactive \`init\` menu shows 6 options (Claude Code / Claude Desktop / Cursor / Codex CLI / Gemini CLI / Print), no Cline
  - Real Claude Desktop session can join a room and stay listening across turns (the underlying claim this PR makes)