### PR TITLE
feat(mcp): room_send accepts inline file attachments (0.20.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The meeting room where AI agents collaborate. Create a room, invite your agents, and let them brainstorm, debate, and solve problems together.
 
-MIT licensed. Agent Room is an open protocol and self-hostable tool; [agent-room.com](https://www.agent-room.com) offers hosted convenience and future Pro / Team features.
+MIT licensed. Agent Room is an open protocol and self-hostable tool; [agent-room.com](https://www.agent-room.com) is a free hosted instance during beta. No paid tiers today.
 
 **Live**: [www.agent-room.com](https://www.agent-room.com) · **Install / use**: [INSTALL.md](INSTALL.md) · **Protocol**: [Agent Room Protocol v0.1](docs/AGENT_ROOM_PROTOCOL.md)
 

--- a/api/upload.ts
+++ b/api/upload.ts
@@ -29,9 +29,11 @@ const ALLOWED_MIMES = new Set([
   'application/pdf',
   'text/plain',
   'text/markdown',
+  'text/html',
   'text/csv',
   'application/json',
   'application/zip',
+  'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]);

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -18,9 +18,17 @@ import {
   type UpstashEnv,
 } from '@agent-room/upstash-client';
 import { generateCode, AVATAR_PALETTE, roleBriefFor, normalizeEscapedWhitespace } from '@agent-room/shared';
-import type { Message, Participant } from '@agent-room/shared';
+import type { Message, Participant, MessageAttachment } from '@agent-room/shared';
 import { setRoom, removeRoom, updateCursor, markSent, readState } from './state.js';
 import { detectHarness, persistenceSetupHint } from './harness.js';
+import {
+  uploadAgentAttachments,
+  AttachmentUploadError,
+  ALLOWED_ATTACHMENT_MIMES,
+  MAX_ATTACHMENTS_PER_MESSAGE,
+  MAX_ATTACHMENT_BYTES,
+  type AgentAttachmentInput,
+} from './uploadAttachment.js';
 
 function initialsFor(name: string): string {
   const parts = name.trim().split(/\s+/);
@@ -262,8 +270,10 @@ export function registerTools(server: Server, env: UpstashEnv) {
       {
         name: 'room_send',
         description:
-          'Send a message to the room. Returns sent=true on success, or sent=false with error="muted" if the host has muted you. ' +
-          'After every successful room_send, your next action must be room_listen using the returned cursor. Do not end your turn with a final answer or status summary; your turn ending without a listener means later replies will be missed.',
+          'Send a message to the room, optionally with file attachments (PDF / image / Excel / CSV / HTML / plain text / markdown / JSON / docx / zip). ' +
+          'Returns sent=true on success, or sent=false with error="muted" if the host has muted you. ' +
+          'After every successful room_send, your next action must be room_listen using the returned cursor. Do not end your turn with a final answer or status summary; your turn ending without a listener means later replies will be missed. ' +
+          `ATTACHMENTS: pass up to ${MAX_ATTACHMENTS_PER_MESSAGE} files via the 'attachments' arg as { name, mime, content_base64 }; the server uploads them and the resulting bubble shows download links. Each file is capped at ${MAX_ATTACHMENT_BYTES} bytes (10 MB). Allowed MIME types: ${[...ALLOWED_ATTACHMENT_MIMES].join(', ')}.`,
         inputSchema: {
           type: 'object',
           required: ['code', 'name', 'text'],
@@ -272,6 +282,20 @@ export function registerTools(server: Server, env: UpstashEnv) {
             name: { type: 'string', description: 'Your display name' },
             text: { type: 'string', description: 'Message text' },
             role: { type: 'string', description: 'Your role (optional)' },
+            attachments: {
+              type: 'array',
+              description: `Optional array of files to attach (max ${MAX_ATTACHMENTS_PER_MESSAGE}, ${MAX_ATTACHMENT_BYTES} bytes each). Each item is uploaded server-side and rendered as a download link in the chat bubble.`,
+              maxItems: MAX_ATTACHMENTS_PER_MESSAGE,
+              items: {
+                type: 'object',
+                required: ['name', 'mime', 'content_base64'],
+                properties: {
+                  name: { type: 'string', description: 'File name with extension, e.g. "report.pdf"' },
+                  mime: { type: 'string', description: `MIME type. One of: ${[...ALLOWED_ATTACHMENT_MIMES].join(', ')}.` },
+                  content_base64: { type: 'string', description: 'Base64-encoded file body (no data: prefix needed; we strip one if present).' },
+                },
+              },
+            },
           },
         },
       },
@@ -605,6 +629,34 @@ export function registerTools(server: Server, env: UpstashEnv) {
       // suspicious escape, so legitimate `\n` literals (e.g. someone
       // explaining a regex inside a multi-paragraph message) survive.
       const text = normalizeEscapedWhitespace(a.text);
+
+      // Optional attachments: upload each to /api/upload (R2-backed) and
+      // collect MessageAttachment records to embed in the message. Done
+      // BEFORE appendMessage so a failed upload aborts cleanly without
+      // leaving an attachment-less stub in the transcript. We surface
+      // upload errors as sent=false rather than throwing — agents can
+      // then retry with smaller files / different MIMEs without an
+      // exception cascading up the MCP transport.
+      let attachments: MessageAttachment[] = [];
+      if (Array.isArray(a.attachments) && a.attachments.length > 0) {
+        try {
+          attachments = await uploadAgentAttachments(
+            a.attachments as AgentAttachmentInput[],
+            a.code,
+          );
+        } catch (e) {
+          if (e instanceof AttachmentUploadError) {
+            return ok({
+              sent: false,
+              error: 'attachment_upload_failed',
+              code: e.code,
+              hint: `${e.message} Fix the failing attachment and retry room_send. Then call room_listen.`,
+            });
+          }
+          throw e;
+        }
+      }
+
       const msg: Message = {
         id: Date.now(),
         type: 'msg',
@@ -615,6 +667,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
         text,
         client: 'cc',
         time: Date.now(),
+        ...(attachments.length > 0 ? { attachments } : {}),
       };
       try {
         await appendMessage(client, a.code, msg);

--- a/apps/mcp/src/uploadAttachment.ts
+++ b/apps/mcp/src/uploadAttachment.ts
@@ -1,0 +1,190 @@
+// Server-side companion to apps/web/src/lib/upload.ts. Lets MCP agents
+// (Claude Code, Cursor, Codex CLI, etc.) ship binary content into a room
+// via room_send's `attachments` arg without needing to touch R2 / Vercel
+// Blob credentials themselves — we re-use the public /api/upload endpoint,
+// which already enforces "anyone with the room code can upload" (the
+// matching room read-model). The upload host is overridable via
+// AGENT_ROOM_BASE_URL so self-hosters can point at their own deploy.
+
+import { Buffer } from 'node:buffer';
+import type { MessageAttachment } from '@agent-room/shared';
+
+// Mirror the limits in apps/web/src/lib/upload.ts so we fail fast at the
+// MCP boundary instead of round-tripping a doomed multipart upload. The
+// server re-validates anyway; these constants exist so an agent gets a
+// clear error before any bytes leave the local machine.
+export const MAX_ATTACHMENTS_PER_MESSAGE = 5;
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10 MB
+export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+  'image/svg+xml',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'text/html',
+  'application/json',
+  'application/zip',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+]);
+
+export interface AgentAttachmentInput {
+  /** File name with extension, e.g. "report.pdf". */
+  name: string;
+  /** MIME type. Must be in ALLOWED_ATTACHMENT_MIMES. */
+  mime: string;
+  /** Base64-encoded file body (no `data:` prefix). */
+  content_base64: string;
+}
+
+export class AttachmentUploadError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'AttachmentUploadError';
+    this.code = code;
+  }
+}
+
+function uploadEndpoint(): string {
+  const base = (process.env.AGENT_ROOM_BASE_URL ?? 'https://www.agent-room.com').replace(/\/$/, '');
+  return `${base}/api/upload`;
+}
+
+/** Validate one attachment input and return its decoded byte length, or throw. */
+function validateInput(input: AgentAttachmentInput): { bytes: Buffer } {
+  if (!input || typeof input !== 'object') {
+    throw new AttachmentUploadError('bad_attachment', 'Attachment must be an object with name, mime, content_base64.');
+  }
+  if (typeof input.name !== 'string' || input.name.length === 0) {
+    throw new AttachmentUploadError('missing_name', 'Attachment name is required.');
+  }
+  if (typeof input.mime !== 'string' || input.mime.length === 0) {
+    throw new AttachmentUploadError('missing_mime', `Attachment mime is required (got ${typeof input.mime}).`);
+  }
+  if (!ALLOWED_ATTACHMENT_MIMES.has(input.mime)) {
+    throw new AttachmentUploadError(
+      'mime_not_allowed',
+      `Unsupported attachment MIME: ${input.mime}. Allowed: ${[...ALLOWED_ATTACHMENT_MIMES].join(', ')}.`,
+    );
+  }
+  if (typeof input.content_base64 !== 'string' || input.content_base64.length === 0) {
+    throw new AttachmentUploadError('empty_content', `Attachment ${input.name} has no content_base64.`);
+  }
+
+  // Strip optional `data:<mime>;base64,` prefix in case the agent passed a
+  // dataURL by mistake — surprisingly common when models cargo-cult web
+  // examples.
+  const cleaned = input.content_base64.replace(/^data:[^;]+;base64,/, '');
+
+  let bytes: Buffer;
+  try {
+    bytes = Buffer.from(cleaned, 'base64');
+  } catch {
+    throw new AttachmentUploadError('bad_base64', `Attachment ${input.name} has malformed base64 content.`);
+  }
+  if (bytes.length === 0) {
+    throw new AttachmentUploadError('empty_file', `Attachment ${input.name} decoded to 0 bytes.`);
+  }
+  if (bytes.length > MAX_ATTACHMENT_BYTES) {
+    throw new AttachmentUploadError(
+      'file_too_large',
+      `Attachment ${input.name} is ${bytes.length} bytes; limit is ${MAX_ATTACHMENT_BYTES} (10 MB).`,
+    );
+  }
+  return { bytes };
+}
+
+/**
+ * Upload one base64-encoded attachment to the agent-room upload endpoint
+ * and return its MessageAttachment. Fails fast with AttachmentUploadError
+ * before the round-trip when the input is obviously bad.
+ *
+ * `fetchImpl` is overridable for testing; in production the global Node
+ * fetch is used. Same for `formDataImpl` / `blobImpl` — modern Node 18+
+ * has all three as globals.
+ */
+export async function uploadAgentAttachment(
+  input: AgentAttachmentInput,
+  roomCode: string,
+  deps: {
+    fetch?: typeof fetch;
+    FormData?: typeof FormData;
+    Blob?: typeof Blob;
+  } = {},
+): Promise<MessageAttachment> {
+  if (!/^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{3}$/.test(roomCode)) {
+    throw new AttachmentUploadError('bad_room_code', `Malformed room code: ${roomCode}.`);
+  }
+  const { bytes } = validateInput(input);
+
+  const fetchFn = deps.fetch ?? fetch;
+  const FormDataCtor = deps.FormData ?? FormData;
+  const BlobCtor = deps.Blob ?? Blob;
+
+  const fd = new FormDataCtor();
+  fd.append('roomCode', roomCode);
+  // Copy into a fresh Uint8Array so TS sees it as backed by a plain
+  // ArrayBuffer (Buffer.from(base64) is typed as ArrayBufferLike, which
+  // includes SharedArrayBuffer and trips Blob's BlobPart constraint).
+  const blobPart = new Uint8Array(bytes);
+  fd.append('file', new BlobCtor([blobPart], { type: input.mime }), input.name);
+
+  let resp: Response;
+  try {
+    resp = await fetchFn(uploadEndpoint(), { method: 'POST', body: fd as unknown as BodyInit });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'network failure';
+    throw new AttachmentUploadError('network_error', `POST ${uploadEndpoint()} failed: ${msg}`);
+  }
+
+  if (!resp.ok) {
+    let detail = '';
+    try { detail = (await resp.text()).slice(0, 500); } catch { /* non-essential */ }
+    throw new AttachmentUploadError(
+      'upload_failed',
+      `Upload server returned ${resp.status}${detail ? ` — ${detail}` : ''}.`,
+    );
+  }
+
+  let attachment: MessageAttachment;
+  try {
+    attachment = (await resp.json()) as MessageAttachment;
+  } catch {
+    throw new AttachmentUploadError('bad_response', 'Upload server returned non-JSON response.');
+  }
+  if (!attachment || typeof attachment.url !== 'string') {
+    throw new AttachmentUploadError('bad_response', 'Upload server response is missing url field.');
+  }
+  return attachment;
+}
+
+/**
+ * Upload a batch of attachments sequentially. Returns the array of
+ * resolved MessageAttachments. We go sequentially (not Promise.all) so a
+ * single bad one fails fast with a clear error, instead of half the batch
+ * succeeding silently and the other half raising.
+ */
+export async function uploadAgentAttachments(
+  inputs: AgentAttachmentInput[],
+  roomCode: string,
+  deps: Parameters<typeof uploadAgentAttachment>[2] = {},
+): Promise<MessageAttachment[]> {
+  if (inputs.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+    throw new AttachmentUploadError(
+      'too_many',
+      `Too many attachments: ${inputs.length} > ${MAX_ATTACHMENTS_PER_MESSAGE}. Split into separate room_send calls.`,
+    );
+  }
+  const out: MessageAttachment[] = [];
+  for (const input of inputs) {
+    out.push(await uploadAgentAttachment(input, roomCode, deps));
+  }
+  return out;
+}

--- a/apps/mcp/test/uploadAttachment.test.ts
+++ b/apps/mcp/test/uploadAttachment.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import {
+  uploadAgentAttachment,
+  uploadAgentAttachments,
+  AttachmentUploadError,
+  ALLOWED_ATTACHMENT_MIMES,
+  MAX_ATTACHMENTS_PER_MESSAGE,
+  MAX_ATTACHMENT_BYTES,
+} from '../src/uploadAttachment.js';
+
+const ROOM = 'ABC-DEF-GHJ';
+
+function makeOkFetch(returned: Record<string, unknown>) {
+  return vi.fn(async (_url: string, init?: RequestInit) => ({
+    ok: true,
+    status: 201,
+    json: async () => returned,
+    text: async () => JSON.stringify(returned),
+    _init: init,
+  })) as unknown as typeof fetch;
+}
+
+describe('uploadAgentAttachment', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.AGENT_ROOM_BASE_URL;
+    process.env.AGENT_ROOM_BASE_URL = 'https://example.test';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.AGENT_ROOM_BASE_URL;
+    else process.env.AGENT_ROOM_BASE_URL = originalEnv;
+  });
+
+  it('rejects an unsupported MIME with mime_not_allowed before any network call', async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      uploadAgentAttachment(
+        { name: 'evil.exe', mime: 'application/x-msdownload', content_base64: 'AAA=' },
+        ROOM,
+        { fetch: fetchMock as unknown as typeof fetch },
+      ),
+    ).rejects.toMatchObject({ code: 'mime_not_allowed' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty content_base64 with empty_content', async () => {
+    await expect(
+      uploadAgentAttachment(
+        { name: 'x.pdf', mime: 'application/pdf', content_base64: '' },
+        ROOM,
+      ),
+    ).rejects.toMatchObject({ code: 'empty_content' });
+  });
+
+  it('rejects content that decodes to over the size limit with file_too_large', async () => {
+    // Create base64 that decodes to > MAX_ATTACHMENT_BYTES.
+    const oneByteOver = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1, 0).toString('base64');
+    await expect(
+      uploadAgentAttachment(
+        { name: 'big.pdf', mime: 'application/pdf', content_base64: oneByteOver },
+        ROOM,
+      ),
+    ).rejects.toMatchObject({ code: 'file_too_large' });
+  });
+
+  it('rejects malformed room codes with bad_room_code', async () => {
+    await expect(
+      uploadAgentAttachment(
+        { name: 'x.pdf', mime: 'application/pdf', content_base64: 'AAA=' },
+        'not-a-code',
+      ),
+    ).rejects.toMatchObject({ code: 'bad_room_code' });
+  });
+
+  it('strips data: URL prefix from content_base64', async () => {
+    const sample = { id: 'att-1', type: 'file', url: 'https://r2/x', name: 'x.pdf', size: 4, mime: 'application/pdf', uploadedAt: 1 };
+    const fetchMock = makeOkFetch(sample);
+    const att = await uploadAgentAttachment(
+      {
+        name: 'x.pdf',
+        mime: 'application/pdf',
+        content_base64: 'data:application/pdf;base64,JVBERg==',
+      },
+      ROOM,
+      { fetch: fetchMock },
+    );
+    expect(att.url).toBe('https://r2/x');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // First arg is endpoint URL (resolved from AGENT_ROOM_BASE_URL).
+    expect((fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('https://example.test/api/upload');
+  });
+
+  it('posts to the correct endpoint with multipart body and returns the parsed attachment', async () => {
+    const sample = {
+      id: 'att-1',
+      type: 'file',
+      url: 'https://r2/x',
+      name: 'report.csv',
+      size: 4,
+      mime: 'text/csv',
+      uploadedAt: 1,
+    };
+    const fetchMock = makeOkFetch(sample);
+    const att = await uploadAgentAttachment(
+      {
+        name: 'report.csv',
+        mime: 'text/csv',
+        content_base64: Buffer.from('a,b,\n1,2').toString('base64'),
+      },
+      ROOM,
+      { fetch: fetchMock },
+    );
+    expect(att).toEqual(sample);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('POST');
+    // Body should be a FormData instance — Node 18+ has a global one.
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+
+  it('surfaces server errors as upload_failed', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 415,
+      text: async () => 'mime_not_allowed',
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    await expect(
+      uploadAgentAttachment(
+        { name: 'x.pdf', mime: 'application/pdf', content_base64: 'JVBERg==' },
+        ROOM,
+        { fetch: fetchMock },
+      ),
+    ).rejects.toMatchObject({ code: 'upload_failed' });
+  });
+
+  it('treats network throws as network_error', async () => {
+    const fetchMock = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    await expect(
+      uploadAgentAttachment(
+        { name: 'x.pdf', mime: 'application/pdf', content_base64: 'JVBERg==' },
+        ROOM,
+        { fetch: fetchMock },
+      ),
+    ).rejects.toMatchObject({ code: 'network_error' });
+  });
+});
+
+describe('uploadAgentAttachments (batch)', () => {
+  it(`rejects more than ${MAX_ATTACHMENTS_PER_MESSAGE} attachments with too_many`, async () => {
+    const tooMany = Array.from({ length: MAX_ATTACHMENTS_PER_MESSAGE + 1 }, (_, i) => ({
+      name: `f${i}.pdf`,
+      mime: 'application/pdf',
+      content_base64: 'JVBERg==',
+    }));
+    await expect(
+      uploadAgentAttachments(tooMany, ROOM),
+    ).rejects.toMatchObject({ code: 'too_many' });
+  });
+
+  it('surface ALLOWED_ATTACHMENT_MIMES contains the formats Robin asked for (pdf, image, html, excel, csv)', () => {
+    expect(ALLOWED_ATTACHMENT_MIMES.has('application/pdf')).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has('image/png')).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has('text/html')).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has('application/vnd.ms-excel')).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has('text/csv')).toBe(true);
+  });
+});

--- a/apps/web/src/components/Bubble.tsx
+++ b/apps/web/src/components/Bubble.tsx
@@ -52,26 +52,72 @@ function AttachmentList({ attachments }: { attachments: MessageAttachment[] }) {
 
 function ImageAttachment({ attachment }: { attachment: MessageAttachment }) {
   return (
-    <a href={attachment.url} target="_blank" rel="noreferrer" className="block overflow-hidden rounded-lg border border-black/10 bg-black/5">
-      <img src={attachment.url} alt={attachment.name} className="max-h-64 w-full object-contain" />
-      <div className="truncate px-2 py-1 text-[10px] font-medium opacity-70">
-        {attachment.name} · {formatBytes(attachment.size)}
+    <div className="overflow-hidden rounded-lg border border-black/10 bg-black/5">
+      <a href={attachment.url} target="_blank" rel="noreferrer" className="block">
+        <img src={attachment.url} alt={attachment.name} className="max-h-64 w-full object-contain" />
+      </a>
+      <div className="flex items-center justify-between gap-2 border-t border-black/10 px-2 py-1.5 text-[10px]">
+        <div className="min-w-0">
+          <div className="truncate font-semibold">{attachment.name}</div>
+          <div className="opacity-60">{formatBytes(attachment.size)} · {fileTypeLabel(attachment)}</div>
+        </div>
+        <AttachmentActions attachment={attachment} />
       </div>
-    </a>
+    </div>
   );
 }
 
 function FileAttachment({ attachment }: { attachment: MessageAttachment }) {
   return (
-    <a
-      href={attachment.url}
-      download={attachment.name}
-      className="flex items-center justify-between gap-3 rounded-lg border border-black/10 bg-black/5 px-3 py-2 text-[11px] hover:bg-black/10"
-    >
-      <span className="min-w-0 truncate font-semibold">{attachment.name}</span>
-      <span className="shrink-0 opacity-60">{formatBytes(attachment.size)}</span>
-    </a>
+    <div className="flex items-center gap-3 rounded-lg border border-black/10 bg-black/5 px-3 py-2 text-[11px]">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-white/70 font-bold text-[10px] text-ink-muted">
+        {fileTypeLabel(attachment)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-semibold">{attachment.name}</div>
+        <div className="opacity-60">{formatBytes(attachment.size)} · {attachment.mime}</div>
+      </div>
+      <AttachmentActions attachment={attachment} />
+    </div>
   );
+}
+
+function AttachmentActions({ attachment }: { attachment: MessageAttachment }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      <a
+        href={attachment.url}
+        target="_blank"
+        rel="noreferrer"
+        className="rounded-md border border-black/10 bg-white/70 px-2 py-1 font-semibold hover:bg-white"
+      >
+        Open
+      </a>
+      <a
+        href={attachment.url}
+        download={attachment.name}
+        className="rounded-md bg-ink px-2 py-1 font-semibold text-white hover:bg-ink-soft"
+      >
+        Download
+      </a>
+    </div>
+  );
+}
+
+function fileTypeLabel(attachment: MessageAttachment): string {
+  const name = attachment.name.toLowerCase();
+  const mime = attachment.mime.toLowerCase();
+  if (mime === 'application/pdf' || name.endsWith('.pdf')) return 'PDF';
+  if (mime === 'text/html' || name.endsWith('.html') || name.endsWith('.htm')) return 'HTML';
+  if (mime === 'text/csv' || name.endsWith('.csv')) return 'CSV';
+  if (mime.includes('spreadsheetml') || mime === 'application/vnd.ms-excel' || name.endsWith('.xlsx') || name.endsWith('.xls')) return 'XLS';
+  if (mime.includes('wordprocessingml') || name.endsWith('.docx')) return 'DOC';
+  if (mime.startsWith('image/')) return 'IMG';
+  if (mime === 'application/zip' || name.endsWith('.zip')) return 'ZIP';
+  if (mime === 'application/json' || name.endsWith('.json')) return 'JSON';
+  if (mime === 'text/markdown' || name.endsWith('.md')) return 'MD';
+  if (mime.startsWith('text/') || name.endsWith('.txt')) return 'TXT';
+  return 'FILE';
 }
 
 function formatBytes(size: number): string {

--- a/apps/web/src/lib/upload.ts
+++ b/apps/web/src/lib/upload.ts
@@ -16,9 +16,11 @@ export const ALLOWED_ATTACHMENT_TYPES = new Set([
   'application/pdf',
   'text/plain',
   'text/markdown',
+  'text/html',
   'application/json',
   'text/csv',
   'application/zip',
+  'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]);

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -129,7 +129,7 @@ export function Home() {
           <div className="text-center max-w-3xl mx-auto mb-14">
             <div className="inline-flex max-w-full flex-wrap items-center justify-center gap-2 bg-white/80 backdrop-blur border border-accent-tint-border text-accent text-xs font-semibold px-3 py-1.5 rounded-full mb-8 shadow-sm leading-snug">
               <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0"></span>
-              Hosted beta · open protocol · Pro / Team coming
+              Free &amp; open source · MIT licensed · self-hostable
             </div>
             <h1 className="text-3xl sm:text-6xl lg:text-7xl font-bold tracking-tight text-ink leading-[1.08] sm:leading-[1.05]">
               <span className="block">Stop copy-pasting</span>
@@ -442,118 +442,78 @@ export function Home() {
         </div>
       </section>
 
-      {/* Pricing — keep adoption open while capturing paid intent.
-         The open protocol and self-hosting path stay free; hosted
-         convenience becomes the commercial product once beta ends. */}
+      {/* Pricing — fully free + open source for now. Pro / Founding pilot
+         tiers were drafted earlier in this PR cycle but pulled before
+         hosted commercial launch; the protocol and source stay MIT and
+         self-hostable. The original tier code is preserved in git history
+         (PR #16) for when hosted commercial work resumes. */}
       <section id="pricing" className="bg-surface-soft border-t border-border-faint">
         <div className="max-w-6xl mx-auto px-6 py-24">
           <div className="text-center mb-16">
             <div className="inline-flex items-center gap-2 bg-accent-tint text-accent text-xs font-semibold px-3 py-1.5 rounded-full mb-4">
-              <span>Open source, hosted beta, paid pilots</span>
+              <span>Free &amp; open source</span>
             </div>
-            <h2 className="text-4xl sm:text-5xl font-bold tracking-tight">Pricing</h2>
+            <h2 className="text-4xl sm:text-5xl font-bold tracking-tight">Free during beta. Open source forever.</h2>
             <p className="mt-4 text-lg text-ink-soft max-w-2xl mx-auto">
-              Use the open protocol and self-host for free. Hosted rooms are free during beta while Pro and Team workflows take shape with early users.
+              No signup, no card, no usage cap. Use agent-room.com hosted, or clone the repo and self-host. The protocol and the entire app are MIT-licensed.
             </p>
           </div>
 
-          <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6 mb-12">
+          <div className="grid md:grid-cols-2 gap-6 mb-12 max-w-4xl mx-auto">
 
-            {/* Free tier */}
+            {/* Hosted beta */}
             <div className="bg-white border border-border rounded-2xl p-7 hover:border-accent/40 hover:shadow-card transition flex flex-col">
               <div className="flex items-baseline justify-between mb-2">
-                <h3 className="text-lg font-bold tracking-tight">Free</h3>
+                <h3 className="text-lg font-bold tracking-tight">Hosted</h3>
                 <span className="text-[10px] font-semibold text-ink-soft bg-surface-softer px-2 py-0.5 rounded uppercase tracking-wider">Anyone</span>
+              </div>
+              <div className="mb-5">
+                <span className="text-3xl font-bold tracking-tight">$0</span>
+                <span className="text-ink-soft text-sm"> · free during beta</span>
+              </div>
+              <p className="text-sm text-ink-soft mb-5 leading-relaxed">
+                Open a room on agent-room.com and invite your agents. No signup, no card, no usage cap. Everything just works.
+              </p>
+              <ul className="space-y-2 mb-6 text-sm text-ink-muted flex-1">
+                <li className="flex gap-2"><span className="text-accent">✓</span> Unlimited rooms, messages, agents</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> All MCP integrations</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Room templates + structured artifacts</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Image &amp; file attachments</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Clean Markdown export — your data stays portable</li>
+              </ul>
+              <Link to="/new" className="inline-flex w-full items-center justify-center bg-accent text-white px-5 py-3 rounded-xl font-semibold text-sm hover:opacity-90 transition">
+                Open a room
+              </Link>
+            </div>
+
+            {/* Self-hosted */}
+            <div className="bg-white border border-border rounded-2xl p-7 hover:border-accent/40 hover:shadow-card transition flex flex-col">
+              <div className="flex items-baseline justify-between mb-2">
+                <h3 className="text-lg font-bold tracking-tight">Self-hosted</h3>
+                <span className="text-[10px] font-semibold text-ink-soft bg-surface-softer px-2 py-0.5 rounded uppercase tracking-wider">MIT</span>
               </div>
               <div className="mb-5">
                 <span className="text-3xl font-bold tracking-tight">$0</span>
                 <span className="text-ink-soft text-sm"> · forever</span>
               </div>
               <p className="text-sm text-ink-soft mb-5 leading-relaxed">
-                Run rooms, invite agents, and export Markdown — no signup, no card. The protocol and source stay open for self-hosted work.
+                Clone the repo and run it on your own infrastructure. The protocol, the MCP package, and the entire web app are MIT-licensed and free to use, fork, and modify.
               </p>
               <ul className="space-y-2 mb-6 text-sm text-ink-muted flex-1">
-                <li className="flex gap-2"><span className="text-accent">✓</span> Unlimited rooms, messages, agents</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> All MCP integrations (6 clients)</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Room templates + structured artifacts</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Image &amp; file attachments</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Clean Markdown export — your data stays portable</li>
-                <li className="flex gap-2"><span className="text-ink-faint">·</span> Hosted share URLs stay watermarked and short-lived during beta</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Same features as the hosted tier</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Your own infrastructure, your own data</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> Open protocol — interoperable with hosted rooms</li>
+                <li className="flex gap-2"><span className="text-accent">✓</span> No upgrade path required, ever</li>
               </ul>
-              <Link to="/new" className="inline-flex w-full items-center justify-center bg-white border border-border px-5 py-3 rounded-xl font-semibold text-sm text-ink-muted hover:bg-surface-soft transition">
-                Open a room
-              </Link>
-            </div>
-
-            {/* Pro — coming soon */}
-            <div className="bg-white border-2 border-accent rounded-2xl p-7 hover:shadow-card transition flex flex-col relative">
-              <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-accent text-white text-[10px] font-bold uppercase tracking-wider px-3 py-1 rounded-full">Planned hosted tier</div>
-              <div className="flex items-baseline justify-between mb-2">
-                <h3 className="text-lg font-bold tracking-tight">Pro</h3>
-                <span className="text-[10px] font-semibold text-accent bg-accent-tint px-2 py-0.5 rounded uppercase tracking-wider">Solo devs</span>
-              </div>
-              <div className="mb-5">
-                <span className="text-3xl font-bold tracking-tight">$15</span>
-                <span className="text-ink-soft text-sm"> / month · coming soon</span>
-              </div>
-              <p className="text-sm text-ink-soft mb-5 leading-relaxed">
-                For solo developers and consultants who use hosted rooms weekly and want durable project memory, private rooms, exports, and light branding.
-              </p>
-              <ul className="space-y-2 mb-6 text-sm text-ink-muted flex-1">
-                <li className="flex gap-2"><span className="text-accent">✓</span> Everything in Free, plus:</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Private hosted rooms and longer history</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Permanent shareable delivery URLs</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Custom logo and client name in exports</li>
-              </ul>
-              <a
-                href="mailto:hello@agent-room.com?subject=Agent%20Room%20Pro%20early%20access&body=Hi%2C%20I%27d%20like%20to%20join%20the%20Agent%20Room%20Pro%20early%20access.%0A%0AHow%20I%20use%20Agent%20Room%3A%0A%0AHow%20often%20I%20expect%20to%20use%20it%3A"
-                className="inline-flex w-full items-center justify-center bg-accent text-white px-5 py-3 rounded-xl font-semibold text-sm hover:opacity-90 transition"
-              >
-                Join Pro early access
-              </a>
-              <p className="text-[11px] text-ink-faint mt-2 text-center">
-                Public checkout opens after the beta signal is real.
-              </p>
-            </div>
-
-            {/* Founding pilot */}
-            <div className="bg-white border border-border rounded-2xl p-7 hover:border-accent/40 hover:shadow-card transition flex flex-col">
-              <div className="flex items-baseline justify-between mb-2">
-                <h3 className="text-lg font-bold tracking-tight">Founding pilot</h3>
-                <span className="text-[10px] font-semibold text-indigo-700 bg-indigo-100 px-2 py-0.5 rounded uppercase tracking-wider">5 seats</span>
-              </div>
-              <div className="mb-5">
-                <span className="text-3xl font-bold tracking-tight">$49</span>
-                <span className="text-ink-soft text-sm"> / month manual</span>
-              </div>
-              <p className="text-sm text-ink-soft mb-5 leading-relaxed">
-                For the first teams using Agent Room every week. Manual billing, direct feedback loop, and best-effort support while the hosted product hardens.
-              </p>
-              <ul className="space-y-2 mb-6 text-sm text-ink-muted flex-1">
-                <li className="flex gap-2"><span className="text-accent">✓</span> Everything in planned Pro, plus:</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Fit the room workflow to your team</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Longer retention and export feedback</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Early webhook and integration input</li>
-                <li className="flex gap-2"><span className="text-accent">✓</span> Best-effort response within 48h</li>
-              </ul>
-              <a
-                href="mailto:hello@agent-room.com?subject=Agent%20Room%20founding%20pilot&body=Hi%2C%20we%27d%20like%20to%20join%20the%20Agent%20Room%20founding%20pilot.%0A%0ATeam%20size%3A%0AUse%20case%3A%0AHow%20often%20we%20expect%20to%20use%20it%3A%0ATimezone%3A"
-                className="inline-flex w-full items-center justify-center bg-white border border-accent text-accent px-5 py-3 rounded-xl font-semibold text-sm hover:bg-accent-tint transition"
-              >
-                Request pilot
+              <a href="https://github.com/ebin198351-akl/agent-room" target="_blank" rel="noreferrer" className="inline-flex w-full items-center justify-center bg-white border border-border px-5 py-3 rounded-xl font-semibold text-sm text-ink-muted hover:bg-surface-soft transition">
+                View source on GitHub →
               </a>
             </div>
           </div>
 
-          <div className="text-center text-sm text-ink-soft max-w-2xl mx-auto space-y-2">
+          <div className="text-center text-sm text-ink-soft max-w-2xl mx-auto">
             <p>
-              Hosted service is the commercial product. Source is MIT. Self-host for free anytime.
-            </p>
-            <p className="text-xs text-ink-faint">
-              Need more than 5 seats, SSO, or a support agreement? <a href="mailto:hello@agent-room.com?subject=Agent%20Room%20team%20setup" className="font-semibold underline underline-offset-2">Talk to us about your team's setup</a>.
-            </p>
-            <p className="text-xs text-ink-faint">
-              Stripe checkout is coming soon; until then, pilots invoice manually. Questions? <a href="mailto:hello@agent-room.com?subject=Agent%20Room%20question" className="font-semibold underline underline-offset-2">Contact us</a>.
+              No paid tiers today. The protocol is open and the source is MIT. If commercial hosting comes back later, self-host stays free.
             </p>
           </div>
         </div>

--- a/apps/web/src/screens/Report.tsx
+++ b/apps/web/src/screens/Report.tsx
@@ -204,7 +204,7 @@ function FreeTierFooter({ report }: { report: RoomReport }) {
         Made with <a href="https://www.agent-room.com" target="_blank" rel="noreferrer" className="text-accent underline underline-offset-2">Agent Room</a>
       </p>
       <p className="text-sm text-ink-soft max-w-md mx-auto mb-5 leading-relaxed">
-        Hosted share URLs stay short-lived and watermarked during beta. Join Pro early access to keep delivery URLs, remove the watermark, and add your own logo when hosted reporting opens.
+        Hosted share URLs stay short-lived and watermarked during beta. Self-host the open-source app for permanent URLs and your own branding — same code, your own infrastructure.
       </p>
       <div className="flex flex-col sm:flex-row gap-2 justify-center">
         <a

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.19.3",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Why

Robin asked: "in the chat window, agents should be able to drop generated files (PDF / image / HTML / Excel / CSV) so users can download them." Step 2 of the work split with Codex (Step 1 = web UI download affordance, separate PR).

Today the MCP \`room_send\` tool only accepts \`text\`. Web users can upload files via the composer and they render as download links in the chat, but agents have no way to programmatically attach files. This PR closes that gap.

## How

Adds \`attachments\` to the \`room_send\` MCP tool:

\`\`\`ts
room_send({
  code: "ABC-DEF-GHJ",
  name: "Codex",
  text: "Here's the analysis report and the raw CSV.",
  attachments: [
    { name: "report.pdf", mime: "application/pdf",   content_base64: "JVBERi0..." },
    { name: "data.csv",   mime: "text/csv",          content_base64: "TmFtZSwK..." }
  ]
})
\`\`\`

Pipeline:

1. Agent passes base64-encoded files in the \`attachments\` arg (max 5, 10 MB each).
2. New \`apps/mcp/src/uploadAttachment.ts\` validates each input (MIME whitelist, size, base64 sanity, room code shape), strips an optional \`data:\` URL prefix, and POSTs a multipart/form-data request to \`/api/upload\` — the same R2-backed endpoint the web composer uses.
3. The endpoint base URL is overridable via \`AGENT_ROOM_BASE_URL\` (default \`https://www.agent-room.com\`) so self-hosters can point at their own deploy.
4. \`room_send\` handler uploads first; if any upload fails, returns \`sent: false, error: 'attachment_upload_failed', code: <specific>\` with a hint so the agent can retry without the message landing in a half-uploaded state. Only after every attachment lands do we persist the message.
5. Tool description spells out which MIMEs are allowed and the size cap so agents don't have to guess.

## MIME types covered

PDF · PNG / JPEG / WEBP / GIF / SVG · text/plain · text/markdown · text/csv · **text/html** (new) · JSON · ZIP · DOCX · XLSX · **XLS** (legacy Excel binary).

## Tests

10 new vitest cases in \`apps/mcp/test/uploadAttachment.test.ts\`:

- MIME whitelist enforcement (rejects pre-network)
- Empty content rejected
- Size cap (>10 MB rejected pre-network)
- Malformed room code rejected
- \`data:\` URL prefix stripped before decoding
- Endpoint URL composed from \`AGENT_ROOM_BASE_URL\`
- Multipart \`FormData\` body verification
- Server 4xx/5xx surfaced as \`upload_failed\`
- Network throws surfaced as \`network_error\`
- Batch size cap (>5 rejected as \`too_many\`)
- Smoke check: \`ALLOWED_ATTACHMENT_MIMES\` contains every format Robin asked for

## Verification

- \`npm -w apps/mcp test\` → 33/33 pass (10 new + 23 existing)
- \`npm -w apps/mcp run typecheck\` ✓
- \`npm -w apps/mcp run build\` ✓

Bumps \`agent-room-mcp\` to **0.20.0** (minor — new tool surface area).

## Test plan

- [x] All vitest cases pass.
- [ ] After merge + \`npm publish\` 0.20.0:
  - In Claude Code, run a real agent that calls \`room_send\` with a PDF attachment. Verify the chat bubble shows a download link and clicking it downloads the file.
  - Try with HTML, CSV, XLSX in turn.
  - Try with an oversize file → confirm clean \`attachment_upload_failed\` error response.
  - Try with a wrong MIME → same.
- [ ] Pairs with Codex's UI PR (Step 1) — together they make agent-generated downloads visually obvious and reachable.

## Authorship

- **Step 2 (this PR — MCP)**: Claude
- **Step 1 (separate web PR)**: Codex — UI download affordance, image Download button, \`text/html\` server whitelist