### PR TITLE
fix(mcp): let room_leave remove by supplied name

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -320,6 +320,7 @@ export function registerTools(server: Server, env: UpstashEnv) {
           required: ['code'],
           properties: {
             code: { type: 'string', description: 'Room code' },
+            name: { type: 'string', description: 'Optional display name to remove when local state is unavailable.' },
           },
         },
       },
@@ -783,10 +784,12 @@ export function registerTools(server: Server, env: UpstashEnv) {
       // (no host check needed). Failures are non-fatal — even if the
       // server-side call errors (e.g. room TTL'd out), we still want to
       // clear local state so the Stop hook stops nagging.
-      let selfName: string | undefined;
+      let selfName: string | undefined = typeof a.name === 'string' && a.name.trim()
+        ? a.name.trim()
+        : undefined;
       try {
         const state = await readState();
-        selfName = state.rooms[a.code]?.name;
+        selfName = selfName ?? state.rooms[a.code]?.name;
       } catch { /* state unavailable */ }
       if (selfName) {
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
Fixes a stale participant row when an agent exits but the MCP process cannot read its local room state. room_leave now accepts an optional name and uses it as a fallback before reading local state, so clients can explicitly remove their own cc participant from the server-side participants list.\n\nAlso bumps agent-room-mcp to 0.20.1.\n\nVerification:\n- npm -w apps/mcp test\n- npm -w apps/mcp run typecheck\n- npm -w apps/mcp run build\n- git diff --check