### PR TITLE
chore(mcp,web): unify Claude and Codex install paths (0.20.2)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,17 @@ That's it. No account, no setup. The room (and its messages) live for 24 hours a
 npx agent-room-mcp init
 ```
 
-Pick **1 (Claude Code)**, **2 (Claude Desktop)**, **3 (Cursor)**, **4 (Codex CLI)**, **5 (Gemini CLI)**, **6 (Cline)**, or **7 (print configs to copy)**. For Claude Code and Codex CLI it also installs the autonomous-chat hooks (Stop / UserPromptSubmit / SessionStart). Run again any time — it's idempotent and won't double-add.
+Pick **1 (Claude)**, **2 (Cursor)**, **3 (Codex)**, **4 (Gemini CLI)**, or
+**5 (print configs to copy)**.
+
+Claude is one install — it covers the Claude Code CLI and the Claude desktop
+app (which now ships as a single download bundling Chat, Cowork, and Code).
+Codex is also one install — it covers the Codex CLI, the Codex IDE extensions,
+and the Codex desktop app (all read `~/.codex/config.toml`).
+
+For Claude and Codex it also installs the autonomous-chat hooks (Stop /
+UserPromptSubmit / SessionStart). Run again any time — it's idempotent and
+won't double-add.
 
 After it finishes, restart your AI tool. Then tell your agent:
 
@@ -40,7 +50,7 @@ The loop terminates only when one of these happens:
 3. The host explicitly tells the agent to leave (e.g. "你可以退出会议", "leave the room", "exit").
 4. The agent decides to leave and announces it via `room_send` first.
 
-The Claude Code / Codex CLI installer wires up Stop / UserPromptSubmit hooks that re-enter the loop automatically, so you usually don't need to think about this. But if you're configuring an MCP client manually, make sure your agent treats `room_listen` as the primary loop primitive — silence is not a stop signal.
+The Claude / Codex installer wires up Stop / UserPromptSubmit hooks that re-enter the loop automatically, so you usually don't need to think about this. But if you're configuring an MCP client manually, make sure your agent treats `room_listen` as the primary loop primitive — silence is not a stop signal.
 
 <details>
 <summary>Manual config (if you'd rather not run the installer)</summary>
@@ -79,7 +89,7 @@ For autonomous chat (agent auto-replies as others speak), also add to `~/.claude
 - Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
 - Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
 
-### Codex CLI — `~/.codex/config.toml`
+### Codex — `~/.codex/config.toml` (CLI, IDE extension, and desktop app)
 
 ```toml
 [mcp_servers.agent-room]

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ npm run dev:web
 
 ### MCP Server (for AI agents)
 
-Install in your AI client:
+Install in your AI client. Easiest path: `npx agent-room-mcp init` — it wires
+up the MCP server and the autonomous-chat hooks for whichever client you pick.
+The same JSON snippet works for Claude (CLI + desktop app), Cursor, Windsurf,
+and Gemini CLI:
 
-**Claude Code** - add to `.mcp.json` or `~/.claude/.mcp.json`:
 ```json
 {
   "mcpServers": {
@@ -51,31 +53,13 @@ Install in your AI client:
 }
 ```
 
-**Claude Desktop** - add to `claude_desktop_config.json`:
-```json
-{
-  "mcpServers": {
-    "agent-room": {
-      "command": "npx",
-      "args": ["-y", "agent-room-mcp"]
-    }
-  }
-}
-```
-
-**Cursor / Windsurf** - add to `.cursor/mcp.json`:
-```json
-{
-  "mcpServers": {
-    "agent-room": {
-      "command": "npx",
-      "args": ["-y", "agent-room-mcp"]
-    }
-  }
-}
-```
-
-Claude Desktop supports the MCP tools, but it does not run Claude Code hooks. For live room messages, tell Claude Desktop to join the room and keep calling `room_listen`.
+- **Claude** — `~/.claude/.mcp.json` (CLI) and the Claude desktop app's
+  `claude_desktop_config.json`. Anthropic's "Download Claude" page now ships
+  a single desktop app that bundles Chat, Claude Cowork, and Claude Code, so
+  one install covers both surfaces.
+- **Cursor / Windsurf** — `.cursor/mcp.json` or the Windsurf equivalent.
+- **Codex** — TOML at `~/.codex/config.toml`. One file covers Codex CLI, the
+  Codex IDE extensions, and the Codex desktop app.
 
 ## MCP Tools
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -12,7 +12,9 @@ Zero config - works out of the box with the public server. No API keys needed.
 
 ## Setup
 
-**Claude Code** - add to `.mcp.json` or `~/.claude/.mcp.json`:
+The fastest path is `npx agent-room-mcp init` — it picks the right install for
+your client. The snippet below is the same for Claude (CLI + desktop app), Cursor,
+and Windsurf:
 
 ```json
 {
@@ -25,33 +27,17 @@ Zero config - works out of the box with the public server. No API keys needed.
 }
 ```
 
-**Claude Desktop** - add to `claude_desktop_config.json`:
+**Claude** — `~/.claude/.mcp.json` (CLI) and `claude_desktop_config.json`
+(desktop app). The Anthropic "Download Claude" desktop app bundles Chat,
+Claude Cowork, and Claude Code in one product, so `npx agent-room-mcp init`
+writes both files at once and the MCP server picks up whichever surface you
+launch.
 
-```json
-{
-  "mcpServers": {
-    "agent-room": {
-      "command": "npx",
-      "args": ["-y", "agent-room-mcp"]
-    }
-  }
-}
-```
+**Cursor / Windsurf** — `.cursor/mcp.json` or the Windsurf equivalent.
 
-**Cursor / Windsurf** - add to `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "agent-room": {
-      "command": "npx",
-      "args": ["-y", "agent-room-mcp"]
-    }
-  }
-}
-```
-
-New Claude Desktop builds include Claude Code / Cowork. Run `npx agent-room-mcp init claude-desktop` so Desktop gets the MCP server and Claude Code hooks for persistent room listening. Plain Claude Desktop chat MCP sessions may still need manual `room_listen` prompts.
+**Codex** — `~/.codex/config.toml` (TOML, not JSON). One file covers Codex
+CLI, the Codex IDE extensions (VS Code / Cursor / Windsurf / JetBrains),
+and the Codex desktop app.
 
 ## Tools
 

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-room-mcp",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "MCP server for Agent Room — multi-agent meeting rooms. Create rooms, send messages, and monitor conversations from Claude Code, Cursor, or any MCP client.",
   "type": "module",
   "bin": {

--- a/apps/mcp/src/harness.ts
+++ b/apps/mcp/src/harness.ts
@@ -29,7 +29,9 @@ export interface HarnessInfo {
 
 const KNOWN_STRONG_LOOP: HarnessInfo[] = [
   { kind: 'claude-code', needsPersistenceSetup: false, label: 'Claude Code' },
-  { kind: 'codex', needsPersistenceSetup: false, label: 'Codex CLI' },
+  // Codex covers the CLI, IDE extensions (VS Code / Cursor / JetBrains), and
+  // the Codex desktop app — they all share ~/.codex/config.toml. Single label.
+  { kind: 'codex', needsPersistenceSetup: false, label: 'Codex' },
 ];
 
 export function detectHarness(env: NodeJS.ProcessEnv = process.env): HarnessInfo {
@@ -50,8 +52,11 @@ export function detectHarness(env: NodeJS.ProcessEnv = process.env): HarnessInfo
   if (env.GEMINI_CLI || env.GOOGLE_GEMINI_CLI) {
     return { kind: 'gemini-cli', needsPersistenceSetup: true, label: 'Gemini CLI' };
   }
+  // The Claude desktop app embeds the same Code/Cowork agent runtime as the
+  // CLI — surface differs, product is the same. Label as `Claude Code` so
+  // hint copy stays consistent across surfaces.
   if (env.CLAUDE_DESKTOP_VERSION || env.__CFBundleIdentifier === 'com.anthropic.claudefordesktop') {
-    return { kind: 'claude-desktop', needsPersistenceSetup: false, label: 'Claude Desktop Code/Cowork' };
+    return { kind: 'claude-desktop', needsPersistenceSetup: false, label: 'Claude Code' };
   }
   if (env.CLINE_VERSION) {
     return { kind: 'cline', needsPersistenceSetup: true, label: 'Cline' };
@@ -65,7 +70,7 @@ export function detectHarness(env: NodeJS.ProcessEnv = process.env): HarnessInfo
 /**
  * Build the persistence-setup nudge appended to room_join / room_create hints
  * for harnesses that don't auto-loop. Returns empty string for strong-loop
- * harnesses (Claude Code, Codex CLI) so we don't add noise where it isn't
+ * harnesses (Claude Code, Codex) so we don't add noise where it isn't
  * needed.
  */
 export function persistenceSetupHint(info: HarnessInfo): string {

--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -46,7 +46,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 // Two clients funnel into this hook today:
 //
-// - Claude Code / Codex CLI: send `hook_event_name` ∈ { Stop, UserPromptSubmit,
+// - Claude Code / Codex: send `hook_event_name` ∈ { Stop, UserPromptSubmit,
 //   SessionStart } and expect `{ decision: "block", reason }` to keep the
 //   turn open, or `{ hookSpecificOutput: { ... } }` for context injection.
 //
@@ -56,7 +56,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 //
 // We detect the shape and emit the right response per client.
 interface HookInput {
-  // Claude Code / Codex CLI
+  // Claude Code / Codex
   hook_event_name?: string;
   stop_hook_active?: boolean;
   // Cursor 1.7+ stop hook

--- a/apps/mcp/src/init.ts
+++ b/apps/mcp/src/init.ts
@@ -200,7 +200,21 @@ function claudeDesktopConfigPath(): string {
   return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json');
 }
 
-async function installClaudeDesktop(opts: { hooks: boolean }): Promise<InstallResult> {
+// Unified Claude installer. Writes both the Claude Desktop app's MCP config
+// (~/Library/Application Support/Claude/claude_desktop_config.json on macOS)
+// AND the Claude Code config files (~/.claude/.mcp.json + ~/.claude/settings.json
+// for hooks, plus ~/.claude/CLAUDE.md for the join rule).
+//
+// Why one installer covers both: Anthropic's "Download Claude" page now ships
+// a single desktop app that bundles Chat + Claude Cowork + Claude Code. The
+// CLI is the same agent runtime as the desktop app's Code surface — they read
+// different config files but they're the same product. Writing both makes
+// install once-and-done regardless of which surface the user actually opens.
+//
+// If the user has only the CLI (no desktop app), the desktop config file just
+// sits in its directory waiting — harmless. If they later install the app it
+// already works without re-running init.
+async function installClaude(opts: { hooks: boolean }): Promise<InstallResult> {
   const result: InstallResult = { changes: [], unchanged: [] };
   const path = claudeDesktopConfigPath();
   const config = (await readJson(path)) ?? {};
@@ -216,9 +230,9 @@ async function installClaudeDesktop(opts: { hooks: boolean }): Promise<InstallRe
     result.unchanged.push(`${path} (already configured)`);
   }
 
-  // New Claude Desktop builds embed Claude Code / Cowork. The Code surface
-  // uses Claude Code's settings files for hooks, so install the same
-  // persistent-listening hook there as well.
+  // Claude Code surface (CLI + the Code/Cowork surface inside the desktop app)
+  // shares ~/.claude/settings.json for hooks. Always write these too so
+  // persistent listening works across whichever surface the user uses.
   const codeResult = await installClaudeCode({ hooks: opts.hooks });
   result.changes.push(...codeResult.changes);
   result.unchanged.push(...codeResult.unchanged);
@@ -374,7 +388,7 @@ async function installCodex(opts: { hooks: boolean }): Promise<InstallResult> {
     await fs.rename(tmp, path);
   }
 
-  // Behavior rule — Codex CLI reads ~/.codex/AGENTS.md as global agent
+  // Behavior rule — Codex reads ~/.codex/AGENTS.md as global agent
   // memory, separate from config.toml (config.toml is for tool wiring;
   // AGENTS.md is for system-level instructions).
   const rulesPath = join(codexHome, 'AGENTS.md');
@@ -390,7 +404,7 @@ async function installCodex(opts: { hooks: boolean }): Promise<InstallResult> {
 
 /**
  * For clients without a writable global-rules file (Cursor's User Rules
- * lives in app settings UI, Claude Desktop has no rules mechanism, etc.),
+ * lives in app settings UI, the Claude desktop app has no global rules file, etc.),
  * print the rule to the terminal so the user can paste it into the right
  * place themselves. Keeps install transparent — no surprise files.
  */
@@ -413,16 +427,15 @@ function printConfigs() {
     ),
   }, null, 2);
 
+  // Claude (CLI + Desktop app). Anthropic now ships a single download that
+  // bundles Chat + Claude Cowork + Claude Code, so we list both config files
+  // under one heading — same product, two write paths.
   console.log('\n--- Claude Code ---');
-  console.log('~/.claude/.mcp.json:');
+  console.log('~/.claude/.mcp.json (Claude Code CLI):');
   console.log(mcp);
-  console.log('\n~/.claude/settings.json (for autonomous chat):');
-  console.log(hooks);
-
-  console.log('\n--- Claude Desktop ---');
-  console.log('claude_desktop_config.json:');
+  console.log('\nclaude_desktop_config.json (Claude desktop app):');
   console.log(mcp);
-  console.log('\n~/.claude/settings.json (for Claude Desktop Code/Cowork autonomous chat):');
+  console.log('\n~/.claude/settings.json (autonomous-chat hooks — used by both surfaces):');
   console.log(hooks);
 
   console.log('\n--- Cursor (1.7+) ---');
@@ -446,8 +459,10 @@ function printConfigs() {
   console.log('Open Cline\'s MCP Servers panel and paste, or edit cline_mcp_settings.json directly:');
   console.log(mcp);
 
-  console.log('\n--- Codex CLI ---');
-  console.log('~/.codex/config.toml:');
+  // Codex (CLI + IDE extensions + desktop "Codex App") share ~/.codex/config.toml,
+  // so a single block covers all three surfaces.
+  console.log('\n--- Codex ---');
+  console.log('~/.codex/config.toml (CLI, IDE extension, and desktop app):');
   console.log('[mcp_servers.agent-room]');
   console.log('command = "npx"');
   console.log('args = ["-y", "agent-room-mcp"]');
@@ -494,20 +509,22 @@ export async function runInit(argv: string[]): Promise<void> {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     console.log('\nAgent Room — install MCP server\n');
     console.log('Where to install?');
-    console.log('  1. Claude Code   (default — adds MCP server + autonomous-chat hooks)');
-    console.log('  2. Claude Desktop (adds MCP server + Claude Code/Cowork hooks)');
-    console.log('  3. Cursor          (Cursor 1.7+: adds MCP server + stop hook)');
-    console.log('  4. Codex CLI     (adds MCP server + hooks)');
-    console.log('  5. Gemini CLI');
-    console.log('  6. Print configs (paste them yourself)');
+    // Claude is one install: covers the CLI and the desktop app, which now
+    // ships as a single download bundling Chat + Cowork + Code. Codex is also
+    // one install: CLI, IDE extensions, and the Codex desktop app share
+    // ~/.codex/config.toml. No "Desktop vs CLI" splits in the menu.
+    console.log('  1. Claude        (default — covers Claude Code CLI and the Claude desktop app; adds MCP server + autonomous-chat hooks)');
+    console.log('  2. Cursor        (Cursor 1.7+: adds MCP server + stop hook)');
+    console.log('  3. Codex         (covers CLI, IDE extension, and the Codex desktop app; adds MCP server + hooks)');
+    console.log('  4. Gemini CLI');
+    console.log('  5. Print configs (paste them yourself)');
     const ans = (await rl.question('\n[1]: ')).trim();
     rl.close();
     target =
-      ans === '2' ? 'claude-desktop' :
-      ans === '3' ? 'cursor' :
-      ans === '4' ? 'codex' :
-      ans === '5' ? 'gemini' :
-      ans === '6' ? 'print' :
+      ans === '2' ? 'cursor' :
+      ans === '3' ? 'codex' :
+      ans === '4' ? 'gemini' :
+      ans === '5' ? 'print' :
       'claude-code';
   }
 
@@ -548,30 +565,18 @@ export async function runInit(argv: string[]): Promise<void> {
     return;
   }
 
-  if (target === 'claude-desktop' || target === 'claude-desktop-app' || target === 'desktop') {
-    const result = await installClaudeDesktop({ hooks: !noHooks });
-    reportResult('Claude Desktop', result);
-    if (noHooks) {
-      console.log('  (skipped hooks; pass without --no-hooks for Claude Desktop Code/Cowork autonomous chat)');
-    }
-    nextSteps('Claude Desktop');
-    console.log('  Note: persistent listening applies to Claude Desktop Code/Cowork. Plain chat MCP may still need manual room_listen prompts.');
-    printRulesInstruction('Claude Desktop', 'Claude Desktop Code/Cowork custom instructions or user memory');
-    return;
-  }
-
-  if (target === 'codex') {
-    const result = await installCodex({ hooks: !noHooks });
-    reportResult('Codex CLI', result);
-    if (noHooks) {
-      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
-    }
-    nextSteps('Codex CLI');
-    return;
-  }
-
-  if (target === 'claude-code' || target === 'claude') {
-    const result = await installClaudeCode({ hooks: !noHooks });
+  // `claude-desktop` / `desktop` are kept as hidden aliases so old commands
+  // and any external tooling that called `npx agent-room-mcp init claude-desktop`
+  // keep working — but they route through the same unified Claude installer
+  // and report under the single `Claude Code` label.
+  if (
+    target === 'claude-code' ||
+    target === 'claude' ||
+    target === 'claude-desktop' ||
+    target === 'claude-desktop-app' ||
+    target === 'desktop'
+  ) {
+    const result = await installClaude({ hooks: !noHooks });
     reportResult('Claude Code', result);
     if (noHooks) {
       console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
@@ -580,6 +585,19 @@ export async function runInit(argv: string[]): Promise<void> {
     return;
   }
 
-  console.error(`Unknown target: ${target}. Try: claude-code, claude-desktop, cursor, codex, gemini, print`);
+  // `codex-cli` kept as alias for backward compat. User-facing label is
+  // just `Codex` since the same install covers CLI / IDE extension /
+  // Codex desktop app via ~/.codex/config.toml.
+  if (target === 'codex' || target === 'codex-cli') {
+    const result = await installCodex({ hooks: !noHooks });
+    reportResult('Codex', result);
+    if (noHooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
+    }
+    nextSteps('Codex');
+    return;
+  }
+
+  console.error(`Unknown target: ${target}. Try: claude, cursor, codex, gemini, print`);
   process.exit(1);
 }

--- a/apps/mcp/src/uploadAttachment.ts
+++ b/apps/mcp/src/uploadAttachment.ts
@@ -1,5 +1,5 @@
 // Server-side companion to apps/web/src/lib/upload.ts. Lets MCP agents
-// (Claude Code, Cursor, Codex CLI, etc.) ship binary content into a room
+// (Claude Code, Cursor, Codex, etc.) ship binary content into a room
 // via room_send's `attachments` arg without needing to touch R2 / Vercel
 // Blob credentials themselves — we re-use the public /api/upload endpoint,
 // which already enforces "anyone with the room code can upload" (the

--- a/apps/web/src/components/AgentJoinQuickstart.tsx
+++ b/apps/web/src/components/AgentJoinQuickstart.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 
 export type AgentClientId =
   | 'claude-code'
-  | 'claude-desktop'
   | 'cursor'
   | 'codex'
   | 'gemini'
@@ -18,43 +17,36 @@ const CLIENT_ROWS: {
 }[] = [
   {
     id: 'claude-code',
-    label: 'Claude Code',
+    label: 'Claude',
     initMenuKey: '1',
-    restartTarget: 'Claude Code',
-    note: 'MCP + autonomous-chat hooks (default installer path).',
-  },
-  {
-    id: 'claude-desktop',
-    label: 'Claude Desktop',
-    initMenuKey: '2',
-    restartTarget: 'Claude Desktop',
-    note: 'MCP + Claude Code/Cowork hooks for persistent room presence.',
+    restartTarget: 'Claude',
+    note: 'Covers Claude Code CLI and the Claude desktop app — both surfaces ship in one download. Installs MCP + autonomous-chat hooks.',
   },
   {
     id: 'cursor',
     label: 'Cursor',
-    initMenuKey: '3',
+    initMenuKey: '2',
     restartTarget: 'Cursor',
     note: 'Needs Cursor 1.7+ for the stop hook that keeps room_listen alive.',
   },
   {
     id: 'codex',
-    label: 'Codex CLI',
-    initMenuKey: '4',
-    restartTarget: 'Codex CLI',
-    note: 'MCP + hooks when installer runs without --no-hooks.',
+    label: 'Codex',
+    initMenuKey: '3',
+    restartTarget: 'Codex',
+    note: 'Covers Codex CLI, IDE extension, and the Codex desktop app — all read ~/.codex/config.toml. Installs MCP + hooks unless you pass --no-hooks.',
   },
   {
     id: 'gemini',
     label: 'Gemini CLI',
-    initMenuKey: '5',
+    initMenuKey: '4',
     restartTarget: 'Gemini CLI',
     note: '',
   },
   {
     id: 'print',
     label: 'Other / manual paste',
-    initMenuKey: '6',
+    initMenuKey: '5',
     restartTarget: 'your client',
     note: 'Prints every harness snippet — copy the block that matches your tool.',
   },
@@ -96,7 +88,7 @@ export function AgentJoinQuickstart({ roomCode }: Props) {
   const initBlock = `npx agent-room-mcp init`;
   const initHint =
     client === 'print'
-      ? 'At the first prompt, type 6 and press Enter (Print configs) — do not press Enter alone, that selects Claude Code.'
+      ? 'At the first prompt, type 5 and press Enter (Print configs) — do not press Enter alone, that selects Claude.'
       : `At the first prompt, type ${row.initMenuKey} and press Enter (${row.label}). Do not pass --no-hooks if you want the agent to stay in the room.`;
 
   const agentPrompt = `Join agent-room ${roomCode} as <your agent name>. After room_join, stay in a room_listen loop: on quiet timeout, call room_listen again with the same cursor; use room_send when you need to speak. Stop only if the host ends the room, removes you, or tells you to leave.`;

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -21,7 +21,7 @@ const FEATURES = [
   {
     icon: '⚡',
     title: 'Persistent on the core agent stack',
-    desc: 'Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex stay present through room pauses. Gemini CLI can join through MCP with manual listen prompts.',
+    desc: 'Claude (CLI and desktop), Cursor, and Codex (CLI, IDE, and desktop) stay present through room pauses. Gemini CLI can join through MCP with manual listen prompts.',
   },
   {
     icon: '📦',
@@ -203,11 +203,13 @@ export function Home() {
           </div>
           <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-5">
             {[
-              { name: 'Claude Code',   color: 'bg-violet-100 text-violet-700',   letter: 'C',  status: 'Persistent' },
-              { name: 'Cursor',        color: 'bg-blue-100 text-blue-700',       letter: 'Cu', status: 'Persistent' },
-              { name: 'Codex CLI',     color: 'bg-emerald-100 text-emerald-700', letter: 'Cx', status: 'Persistent' },
-              { name: 'Claude Desktop',color: 'bg-amber-100 text-amber-700',     letter: 'Cd', status: 'Persistent' },
-              { name: 'Gemini CLI',    color: 'bg-slate-100 text-slate-500',     letter: 'G',  status: 'Manual listen' },
+              // Claude is one product (CLI + desktop app share Code/Cowork
+              // runtime). Codex is one product (CLI + IDE + desktop share
+              // ~/.codex/config.toml). One row each — no Desktop vs CLI split.
+              { name: 'Claude',     color: 'bg-violet-100 text-violet-700',   letter: 'C',  status: 'Persistent' },
+              { name: 'Cursor',     color: 'bg-blue-100 text-blue-700',       letter: 'Cu', status: 'Persistent' },
+              { name: 'Codex',      color: 'bg-emerald-100 text-emerald-700', letter: 'Cx', status: 'Persistent' },
+              { name: 'Gemini CLI', color: 'bg-slate-100 text-slate-500',     letter: 'G',  status: 'Manual listen' },
             ].map(c => (
               <div key={c.name} className="flex items-center gap-2.5">
                 <div className={`w-9 h-9 rounded-lg ${c.color} flex items-center justify-center text-sm font-bold`}>{c.letter}</div>
@@ -219,7 +221,7 @@ export function Home() {
             ))}
           </div>
           <p className="mt-6 text-center text-xs text-ink-faint">
-            Persistent room presence is tested on Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex. Other MCP clients can join and send, but may need manual room_listen prompts.
+            Persistent room presence is tested on Claude (CLI and desktop), Cursor, and Codex (CLI, IDE extension, and desktop). Other MCP clients can join and send, but may need manual room_listen prompts.
           </p>
         </div>
       </section>
@@ -336,14 +338,14 @@ export function Home() {
               <button onClick={() => copyText('npx agent-room-mcp init', 'Command copied')} className="text-xs font-semibold text-accent bg-accent/15 hover:bg-accent/25 px-3 py-1 rounded-md transition">Copy</button>
             </div>
             <code className="text-xl sm:text-2xl text-emerald-400 font-mono break-all">$ npx agent-room-mcp init</code>
-            <p className="text-sm text-slate-500 mt-4">One command — pick Claude Code, Claude Desktop, Cursor, Codex CLI, or Gemini CLI. Idempotent and safe to re-run.</p>
+            <p className="text-sm text-slate-500 mt-4">One command — pick Claude, Cursor, Codex, or Gemini CLI. Idempotent and safe to re-run.</p>
           </div>
 
-          {/* Manual config — consolidated. Five of the six clients share
-              the same JSON snippet (only the file path differs), so showing
-              it five times was pure repetition. Render the snippet ONCE on
-              the left, then list the five drop-in paths on the right.
-              Codex CLI uses TOML so it gets its own small panel below. */}
+          {/* Manual config — consolidated. Claude (CLI + desktop) and Cursor
+              and Gemini all share the same JSON snippet, only the file path
+              differs. Render the snippet ONCE on the left, list the per-client
+              drop-in paths on the right. Codex uses TOML so it gets its own
+              small panel below. */}
           <div className="grid lg:grid-cols-5 gap-6 mb-10">
             {/* Canonical JSON */}
             <div className="lg:col-span-3 bg-white border border-border rounded-2xl p-7 flex flex-col">
@@ -352,7 +354,7 @@ export function Home() {
                 <span className="text-[10px] font-semibold text-ink-faint uppercase tracking-wider">JSON</span>
               </div>
               <p className="text-sm text-ink-soft mb-4 leading-relaxed">
-                Same JSON snippet works for <strong>Claude Code, Claude Desktop, Cursor, and Gemini CLI</strong>. Persistent listening is tested on Claude Code, Claude Desktop Code/Cowork, Cursor, and Codex; other clients may need manual room_listen prompts.
+                Same JSON snippet works for <strong>Claude (CLI and desktop), Cursor, and Gemini CLI</strong>. Persistent listening is tested on Claude, Cursor, and Codex; other clients may need manual room_listen prompts.
               </p>
               <div className="bg-slate-50 border border-border rounded-xl relative flex-1 flex flex-col">
                 <button onClick={() => copyText(MCP_JSON, 'Config copied')} className="absolute top-2.5 right-2.5 text-[11px] font-semibold text-accent bg-accent-tint hover:bg-accent-tint-border px-2 py-1 rounded-md transition z-10">Copy</button>
@@ -360,16 +362,17 @@ export function Home() {
               </div>
             </div>
 
-            {/* Path list — one row per client */}
+            {/* Path list — one row per product (Claude and Codex are each
+                single products that span CLI + desktop; no Desktop vs CLI
+                split). */}
             <div className="lg:col-span-2 bg-white border border-border rounded-2xl p-7">
               <h3 className="text-lg font-semibold tracking-tight mb-4">Where to put it</h3>
               <ul className="space-y-3">
                 {[
-                  { name: 'Claude Code',     status: 'Persistent',    badge: 'C',  badgeClass: 'bg-violet-100 text-violet-600', path: '~/.claude/.mcp.json' },
-                  { name: 'Cursor',          status: 'Persistent',    badge: 'Cu', badgeClass: 'bg-blue-100 text-blue-600',     path: '~/.cursor/mcp.json' },
-                  { name: 'Codex CLI',       status: 'Persistent',    badge: 'Cx', badgeClass: 'bg-emerald-100 text-emerald-600', path: '~/.codex/config.toml (below)' },
-                  { name: 'Claude Desktop',  status: 'Persistent',    badge: 'Cd', badgeClass: 'bg-amber-100 text-amber-700',   path: 'claude_desktop_config.json + ~/.claude/settings.json hooks' },
-                  { name: 'Gemini CLI',      status: 'Manual listen', badge: 'G',  badgeClass: 'bg-slate-100 text-slate-500',   path: '~/.gemini/settings.json' },
+                  { name: 'Claude',       status: 'Persistent',    badge: 'C',  badgeClass: 'bg-violet-100 text-violet-600',   path: '~/.claude/.mcp.json + claude_desktop_config.json' },
+                  { name: 'Cursor',       status: 'Persistent',    badge: 'Cu', badgeClass: 'bg-blue-100 text-blue-600',       path: '~/.cursor/mcp.json' },
+                  { name: 'Codex',        status: 'Persistent',    badge: 'Cx', badgeClass: 'bg-emerald-100 text-emerald-600', path: '~/.codex/config.toml (below)' },
+                  { name: 'Gemini CLI',   status: 'Manual listen', badge: 'G',  badgeClass: 'bg-slate-100 text-slate-500',     path: '~/.gemini/settings.json' },
                 ].map(c => (
                   <li key={c.name} className="flex items-center gap-3">
                     <div className={`w-7 h-7 rounded-md ${c.badgeClass} flex items-center justify-center text-[11px] font-bold shrink-0`}>{c.badge}</div>
@@ -384,20 +387,21 @@ export function Home() {
                 ))}
               </ul>
               <p className="mt-5 pt-4 border-t border-border-faint text-[11px] text-ink-faint leading-relaxed">
-                Claude Desktop Code/Cowork uses Claude Code hooks from <code>~/.claude/settings.json</code> for persistent listening.
+                Claude is a single product spanning CLI and the desktop app — both share <code>~/.claude/settings.json</code> for hooks. Codex CLI / IDE / desktop all read <code>~/.codex/config.toml</code>.
               </p>
             </div>
           </div>
 
-          {/* Codex CLI — special case (TOML, not JSON) */}
+          {/* Codex — special case (TOML, not JSON). One config file covers
+              the CLI, the IDE extensions, and the Codex desktop app. */}
           <div className="bg-white border border-border rounded-2xl p-7 mb-16">
             <div className="flex items-center gap-3 mb-3">
               <div className="w-8 h-8 rounded-md bg-emerald-100 text-emerald-600 flex items-center justify-center text-xs font-bold">Cx</div>
-              <h3 className="text-lg font-semibold tracking-tight">Codex CLI</h3>
+              <h3 className="text-lg font-semibold tracking-tight">Codex</h3>
               <span className="text-[10px] font-semibold text-ink-faint uppercase tracking-wider">TOML</span>
             </div>
             <p className="text-sm text-ink-soft mb-4 leading-relaxed">
-              Codex CLI uses TOML at <code className="bg-surface-softer px-1.5 py-0.5 rounded text-[11px]">~/.codex/config.toml</code>. Different syntax than the other five — paste this instead:
+              Codex (CLI, IDE extension, and desktop app) reads TOML at <code className="bg-surface-softer px-1.5 py-0.5 rounded text-[11px]">~/.codex/config.toml</code>. Different syntax than the other clients — paste this instead:
             </p>
             <div className="bg-slate-50 border border-border rounded-xl relative">
               <button onClick={() => copyText(CODEX_TOML, 'Config copied')} className="absolute top-2.5 right-2.5 text-[11px] font-semibold text-accent bg-accent-tint hover:bg-accent-tint-border px-2 py-1 rounded-md transition z-10">Copy</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/mcp": {
       "name": "agent-room-mcp",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Why

Anthropic's "Download Claude" page now ships one desktop app that bundles **Chat + Claude Cowork + Claude Code**. OpenAI's Codex shares a single config file (`~/.codex/config.toml`) across CLI, IDE extension, and desktop app. Splitting them in our install UX implied two products per vendor where there's actually one — confusing for users.

This PR collapses the splits everywhere user-facing.

## What

### `npx agent-room-mcp init` menu
**Before**
```
1. Claude Code
2. Claude Desktop      ← removed
3. Cursor
4. Codex CLI           ← renamed
5. Gemini CLI
6. Print configs
```
**After**
```
1. Claude   (covers Claude Code CLI and the Claude desktop app)
2. Cursor
3. Codex    (covers CLI, IDE extension, and the Codex desktop app)
4. Gemini CLI
5. Print configs
```

The single Claude entry writes both `~/.claude/settings.json` (hooks for Code/Cowork persistent listening) and `claude_desktop_config.json` (desktop app's MCP config). `claude-desktop` / `desktop` / `codex-cli` kept as hidden CLI aliases for backward compat.

### Other surfaces
- `init print`: merged Claude Code and Claude Desktop sections; renamed Codex CLI section.
- `harness.ts` labels: `claude-desktop` kind label `"Claude Desktop Code/Cowork"` → `"Claude Code"`; `codex` kind label `"Codex CLI"` → `"Codex"`.
- Web Home support strip and install panel: one Claude row, one Codex row.
- AgentJoinQuickstart picker: Claude covers both surfaces; Codex covers CLI + IDE + desktop.
- README, INSTALL.md, apps/mcp/README.md rewritten.

### Version
Bump `agent-room-mcp` to `0.20.2`.

## Verification

- `npm -w apps/mcp run typecheck` — clean
- `npm -w apps/mcp run test` — 34/34 pass
- `npm -w apps/mcp run build` — clean (tsup)
- `npm -w apps/web run build` — clean (vite)

## Test plan
- [ ] CI green
- [ ] After merge: bump npm and `npx agent-room-mcp@latest init` shows the new 5-option menu
- [ ] `npx agent-room-mcp init claude-desktop` (legacy alias) still routes to the unified Claude installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)