### PR TITLE
fix(mcp): keep Codex room state across hooks

### DIFF
--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -17,6 +17,7 @@ import {
   removeRoom,
   removeRoomEverywhere,
 } from './state.js';
+import { detectHarness } from './harness.js';
 
 // Stop-hook long-poll: how long the hook holds the turn open looking for new
 // room messages before letting the agent stop. Increased from the original
@@ -93,10 +94,10 @@ interface PendingRoom {
   messages: Message[];
 }
 
-type StateScope = 'scoped' | 'cursor';
+type StateScope = 'scoped' | 'harness';
 
 async function readHookState(scope: StateScope) {
-  return scope === 'cursor' ? readHarnessStateOrMerged() : readState();
+  return scope === 'harness' ? readHarnessStateOrMerged() : readState();
 }
 
 async function fetchPending(env: UpstashEnv, scope: StateScope): Promise<PendingRoom[]> {
@@ -163,7 +164,7 @@ function formatMessages(rooms: PendingRoom[]): string {
 
 async function commitCursors(rooms: PendingRoom[], scope: StateScope): Promise<void> {
   for (const r of rooms) {
-    if (scope === 'cursor') {
+    if (scope === 'harness') {
       await updateCursorEverywhere(r.code, r.newCursor);
     } else {
       await updateCursor(r.code, r.newCursor);
@@ -208,18 +209,19 @@ export async function runHook(env: UpstashEnv): Promise<void> {
     process.exit(0);
   }
   const { event, cursorMode } = classified;
-  // Cursor starts the MCP server and Stop hook under different npm wrapper
-  // processes, so their PPID-scoped state files do not match. Cursor stop
-  // hooks read a stable harness state file first and fall back to merged
-  // state for old pre-fix installs. Claude/Codex keep scoped state to
-  // preserve parallel-session isolation.
-  const stateScope: StateScope = cursorMode ? 'cursor' : 'scoped';
+  // Cursor and Codex may start the MCP server and Stop hook under different
+  // wrapper processes, so their PPID-scoped state files do not always match.
+  // Those hooks read a stable harness state file first and fall back to merged
+  // state for old pre-fix installs. Claude keeps scoped state to preserve
+  // parallel-session isolation.
+  const harnessKind = detectHarness().kind;
+  const stateScope: StateScope = cursorMode || harnessKind === 'codex' ? 'harness' : 'scoped';
 
   // User typed something — fresh turn cycle. Reset the block streak so the
   // next Stop hook can block fresh up to MAX_BLOCKS_PER_CYCLE times.
   if (event === 'UserPromptSubmit') {
     try {
-      if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+      if (stateScope === 'harness') await resetBlockStreakEverywhere();
       else await resetBlockStreak();
     } catch { /* non-essential */ }
   }
@@ -240,7 +242,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
       // resets the counter via the UserPromptSubmit branch above (CC) or
       // the next user message in Cursor (loop_count resets to 0).
       try {
-        if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+        if (stateScope === 'harness') await resetBlockStreakEverywhere();
         else await resetBlockStreak();
       } catch { /* non-essential */ }
       process.exit(0);
@@ -284,7 +286,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
   // pure idle loops, not real conversations).
   if (withMessages.length > 0 && event === 'Stop') {
     try {
-      if (stateScope === 'cursor') await resetBlockStreakEverywhere();
+      if (stateScope === 'harness') await resetBlockStreakEverywhere();
       else await resetBlockStreak();
     } catch { /* non-essential */ }
     const text = formatMessages(withMessages);
@@ -321,7 +323,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
           const stillIn = room.participants.some(p => p.name === r.name && p.client === 'cc');
           if (room.status !== 'active' || !stillIn) {
             try {
-              if (stateScope === 'cursor') await removeRoomEverywhere(code);
+              if (stateScope === 'harness') await removeRoomEverywhere(code);
               else await removeRoom(code);
             } catch { /* non-essential */ }
             continue;
@@ -330,7 +332,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
         } catch {
           // Room not found / TTL expired — drop it from state too.
           try {
-            if (stateScope === 'cursor') await removeRoomEverywhere(code);
+            if (stateScope === 'harness') await removeRoomEverywhere(code);
             else await removeRoom(code);
           } catch { /* non-essential */ }
         }
@@ -339,7 +341,7 @@ export async function runHook(env: UpstashEnv): Promise<void> {
 
     if (activeRooms.length > 0) {
       try {
-        if (stateScope === 'cursor') await bumpBlockStreakEverywhere();
+        if (stateScope === 'harness') await bumpBlockStreakEverywhere();
         else await bumpBlockStreak();
       } catch { /* non-essential */ }
       const lines: string[] = [];

--- a/apps/mcp/src/state.ts
+++ b/apps/mcp/src/state.ts
@@ -20,7 +20,7 @@ const STATE_FILE =
 function currentHarnessStateFile(): string | null {
   if (process.env.AGENT_ROOM_STATE_FILE) return null;
   const kind = detectHarness().kind;
-  if (kind !== 'cursor') return null;
+  if (kind !== 'cursor' && kind !== 'codex') return null;
   return join(STATE_DIR, `state-harness-${kind}.json`);
 }
 

--- a/apps/mcp/test/state.test.ts
+++ b/apps/mcp/test/state.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mergeStates, type AgentRoomState } from '../src/state.js';
+
+async function makeStateDir(prefix: string) {
+  return fs.mkdtemp(join(tmpdir(), prefix));
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
 describe('mergeStates', () => {
   it('keeps the highest cursor for rooms found in multiple PPID state files', () => {
@@ -64,6 +76,59 @@ describe('mergeStates', () => {
         'AAA-BBB-CCC': { name: 'Cursor', cursor: 2, joinedAt: 100 },
         'DDD-EEE-FFF': { name: 'Cursor', cursor: 7, joinedAt: 200 },
       },
+    });
+  });
+});
+
+describe('state harness files', () => {
+  it('writes stable Codex harness state alongside the PPID-scoped state', async () => {
+    const dir = await makeStateDir('agent-room-state-codex-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', 'test-run');
+
+    const { setRoom } = await import('../src/state.js');
+    await setRoom('ABC-DEF-GHJ', {
+      name: 'Codex',
+      cursor: 2,
+      joinedAt: 123,
+    });
+
+    const files = await fs.readdir(dir);
+    expect(files).toContain('state-harness-codex.json');
+
+    const harnessRaw = await fs.readFile(join(dir, 'state-harness-codex.json'), 'utf8');
+    expect(JSON.parse(harnessRaw).rooms['ABC-DEF-GHJ']).toMatchObject({
+      name: 'Codex',
+      cursor: 2,
+    });
+  });
+
+  it('reads Codex harness state when the hook PPID state is empty', async () => {
+    const dir = await makeStateDir('agent-room-state-codex-read-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', 'test-run');
+
+    await fs.writeFile(
+      join(dir, 'state-harness-codex.json'),
+      JSON.stringify({
+        version: 1,
+        blockStreak: 0,
+        rooms: {
+          'ABC-DEF-GHJ': {
+            name: 'Codex',
+            cursor: 7,
+            joinedAt: 456,
+          },
+        },
+      }),
+      'utf8'
+    );
+
+    const { readHarnessStateOrMerged } = await import('../src/state.js');
+    const state = await readHarnessStateOrMerged();
+    expect(state.rooms['ABC-DEF-GHJ']).toMatchObject({
+      name: 'Codex',
+      cursor: 7,
     });
   });
 });


### PR DESCRIPTION
## Summary
- write a stable Codex harness state file alongside PPID-scoped state
- make Codex Stop hooks read harness/merged state like Cursor so active rooms survive PPID drift
- add Codex harness state regression coverage while preserving existing merge tests

## Tests
- npm -w apps/mcp test
- npm -w apps/mcp run typecheck
- npm -w apps/mcp run build
- git diff --check