### PR TITLE
feat(mcp): auto-install detected clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ npm run dev:web
 
 ### MCP Server (for AI agents)
 
-Install in your AI client. Easiest path: `npx agent-room-mcp init` — it wires
-up the MCP server and the autonomous-chat hooks for whichever client you pick.
+Install in your AI client. Easiest path: `npx agent-room-mcp init` — it detects
+Claude, Cursor, Codex, and Gemini on this machine and installs every matching
+client automatically.
 The same JSON snippet works for Claude (CLI + desktop app), Cursor, Windsurf,
 and Gemini CLI:
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -12,9 +12,10 @@ Zero config - works out of the box with the public server. No API keys needed.
 
 ## Setup
 
-The fastest path is `npx agent-room-mcp init` — it picks the right install for
-your client. The snippet below is the same for Claude (CLI + desktop app), Cursor,
-and Windsurf:
+The fastest path is `npx agent-room-mcp init` — it detects Claude, Cursor,
+Codex, and Gemini on this machine and installs every matching client
+automatically. The snippet below is the same for Claude (CLI + desktop app),
+Cursor, and Windsurf:
 
 ```json
 {

--- a/apps/mcp/src/init.ts
+++ b/apps/mcp/src/init.ts
@@ -100,6 +100,8 @@ interface InstallResult {
   unchanged: string[];
 }
 
+export type InstallTarget = 'claude' | 'cursor' | 'codex' | 'gemini';
+
 function which(cmd: string): Promise<string | null> {
   return new Promise((resolve) => {
     const p = spawn('which', [cmd], { stdio: ['ignore', 'pipe', 'ignore'] });
@@ -108,6 +110,15 @@ function which(cmd: string): Promise<string | null> {
     p.on('close', (code) => resolve(code === 0 && out.trim() ? out.trim() : null));
     p.on('error', () => resolve(null));
   });
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function tryClaudeMcpAdd(): Promise<boolean> {
@@ -190,14 +201,86 @@ async function installClaudeCode(opts: { hooks: boolean }): Promise<InstallResul
   return result;
 }
 
+function claudeDesktopConfigPathFor(home: string, platform: NodeJS.Platform, appdata?: string): string {
+  if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  }
+  if (platform === 'win32') {
+    return join(appdata ?? join(home, 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json');
+  }
+  return join(home, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
 function claudeDesktopConfigPath(): string {
-  if (process.platform === 'darwin') {
-    return join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  return claudeDesktopConfigPathFor(homedir(), process.platform, process.env.APPDATA);
+}
+
+interface DetectInstallTargetsOptions {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  platform?: NodeJS.Platform;
+  whichCmd?: (cmd: string) => Promise<string | null>;
+  pathExistsFn?: (path: string) => Promise<boolean>;
+}
+
+export async function detectInstallTargets(opts: DetectInstallTargetsOptions = {}): Promise<InstallTarget[]> {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homedir();
+  const platform = opts.platform ?? process.platform;
+  const whichCmd = opts.whichCmd ?? which;
+  const exists = opts.pathExistsFn ?? pathExists;
+  const found: InstallTarget[] = [];
+
+  const claudeConfigDir = dirname(claudeDesktopConfigPathFor(home, platform, env.APPDATA));
+  const claudeApp =
+    platform === 'darwin' ? join('/Applications', 'Claude.app') :
+    platform === 'win32' ? join(env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Claude') :
+    join(home, '.config', 'Claude');
+  if (
+    env.CLAUDECODE === '1' ||
+    Boolean(env.CLAUDE_CODE_ENTRYPOINT) ||
+    (await whichCmd('claude')) ||
+    (await exists(join(home, '.claude'))) ||
+    (await exists(claudeConfigDir)) ||
+    (await exists(claudeApp))
+  ) {
+    found.push('claude');
   }
-  if (process.platform === 'win32') {
-    return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json');
+
+  const codexHome = env.CODEX_HOME ?? join(home, '.codex');
+  if (
+    Boolean(env.CODEX_RUN_ID) ||
+    Boolean(env.CODEX_HOME) ||
+    (await whichCmd('codex')) ||
+    (await exists(codexHome))
+  ) {
+    found.push('codex');
   }
-  return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json');
+
+  const cursorApp =
+    platform === 'darwin' ? join('/Applications', 'Cursor.app') :
+    platform === 'win32' ? join(env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Programs', 'Cursor') :
+    join(home, '.config', 'Cursor');
+  if (
+    Boolean(env.CURSOR_TRACE_ID) ||
+    Boolean(env.CURSOR_AGENT) ||
+    env.TERM_PROGRAM === 'Cursor' ||
+    (await exists(join(home, '.cursor'))) ||
+    (await exists(cursorApp))
+  ) {
+    found.push('cursor');
+  }
+
+  if (
+    Boolean(env.GEMINI_CLI) ||
+    Boolean(env.GOOGLE_GEMINI_CLI) ||
+    (await whichCmd('gemini')) ||
+    (await exists(join(home, '.gemini')))
+  ) {
+    found.push('gemini');
+  }
+
+  return found;
 }
 
 // Unified Claude installer. Writes both the Claude Desktop app's MCP config
@@ -494,6 +577,65 @@ function nextSteps(target: string) {
   console.log('');
 }
 
+function targetLabel(target: InstallTarget): string {
+  return (
+    target === 'claude' ? 'Claude' :
+    target === 'cursor' ? 'Cursor' :
+    target === 'codex' ? 'Codex' :
+    'Gemini CLI'
+  );
+}
+
+async function installTarget(target: InstallTarget, opts: { hooks: boolean }): Promise<void> {
+  if (target === 'claude') {
+    const result = await installClaude({ hooks: opts.hooks });
+    reportResult('Claude', result);
+    if (!opts.hooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
+    }
+    return;
+  }
+
+  if (target === 'cursor') {
+    const result = await installCursor({ hooks: opts.hooks });
+    reportResult('Cursor', result);
+    if (!opts.hooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat — Cursor 1.7+ required)');
+    }
+    printRulesInstruction('Cursor', 'Cursor → Settings → Rules → User Rules');
+    return;
+  }
+
+  if (target === 'codex') {
+    const result = await installCodex({ hooks: opts.hooks });
+    reportResult('Codex', result);
+    if (!opts.hooks) {
+      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
+    }
+    return;
+  }
+
+  const result = await installGemini();
+  reportResult('Gemini CLI', result);
+  console.log('  Note: Gemini CLI does not currently support Claude Code-style hooks, so ask it to call room_listen explicitly to stay present in the room.');
+  printRulesInstruction('Gemini CLI', '~/.gemini/GEMINI.md (or whichever file Gemini CLI reads as global instructions on your version)');
+}
+
+async function installDetectedTargets(targets: InstallTarget[], opts: { hooks: boolean }): Promise<void> {
+  console.log('\nAgent Room — install MCP server\n');
+  console.log('Detected clients:');
+  for (const target of targets) {
+    console.log(`  ✓ ${targetLabel(target)}`);
+  }
+  console.log('\nInstalling for all detected clients...');
+
+  for (const target of targets) {
+    await installTarget(target, opts);
+  }
+
+  nextSteps(targets.map(targetLabel).join(' / '));
+}
+
 export async function runInit(argv: string[]): Promise<void> {
   const positional = argv.filter((a) => !a.startsWith('--'));
   const noHooks = argv.includes('--no-hooks');
@@ -506,9 +648,15 @@ export async function runInit(argv: string[]): Promise<void> {
 
   let target = positional[0];
   if (!target) {
+    const detectedTargets = await detectInstallTargets();
+    if (detectedTargets.length > 0) {
+      await installDetectedTargets(detectedTargets, { hooks: !noHooks });
+      return;
+    }
+
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     console.log('\nAgent Room — install MCP server\n');
-    console.log('Where to install?');
+    console.log('No installed client was detected automatically. Where to install?');
     // Claude is one install: covers the CLI and the desktop app, which now
     // ships as a single download bundling Chat + Cowork + Code. Codex is also
     // one install: CLI, IDE extensions, and the Codex desktop app share
@@ -534,25 +682,14 @@ export async function runInit(argv: string[]): Promise<void> {
   }
 
   if (target === 'cursor') {
-    const result = await installCursor({ hooks: !noHooks });
-    reportResult('Cursor', result);
-    if (noHooks) {
-      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat — Cursor 1.7+ required)');
-    }
+    await installTarget('cursor', { hooks: !noHooks });
     nextSteps('Cursor');
-    // Cursor's user-level rules live in the Settings UI (Settings → Rules
-    // → User Rules), not a flat file we can write to safely. Print the
-    // snippet for manual paste so the install stays transparent.
-    printRulesInstruction('Cursor', 'Cursor → Settings → Rules → User Rules');
     return;
   }
 
   if (target === 'gemini' || target === 'gemini-cli') {
-    const result = await installGemini();
-    reportResult('Gemini CLI', result);
+    await installTarget('gemini', { hooks: !noHooks });
     nextSteps('Gemini CLI');
-    console.log('  Note: Gemini CLI does not currently support Claude Code-style hooks, so ask it to call room_listen explicitly to stay present in the room.');
-    printRulesInstruction('Gemini CLI', '~/.gemini/GEMINI.md (or whichever file Gemini CLI reads as global instructions on your version)');
     return;
   }
 
@@ -576,12 +713,8 @@ export async function runInit(argv: string[]): Promise<void> {
     target === 'claude-desktop-app' ||
     target === 'desktop'
   ) {
-    const result = await installClaude({ hooks: !noHooks });
-    reportResult('Claude Code', result);
-    if (noHooks) {
-      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
-    }
-    nextSteps('Claude Code');
+    await installTarget('claude', { hooks: !noHooks });
+    nextSteps('Claude');
     return;
   }
 
@@ -589,11 +722,7 @@ export async function runInit(argv: string[]): Promise<void> {
   // just `Codex` since the same install covers CLI / IDE extension /
   // Codex desktop app via ~/.codex/config.toml.
   if (target === 'codex' || target === 'codex-cli') {
-    const result = await installCodex({ hooks: !noHooks });
-    reportResult('Codex', result);
-    if (noHooks) {
-      console.log('  (skipped hooks; pass without --no-hooks for autonomous chat)');
-    }
+    await installTarget('codex', { hooks: !noHooks });
     nextSteps('Codex');
     return;
   }

--- a/apps/mcp/test/init-detect.test.ts
+++ b/apps/mcp/test/init-detect.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { detectInstallTargets } from '../src/init.js';
+
+function detector(paths: string[], bins: string[] = []) {
+  const pathSet = new Set(paths);
+  const binSet = new Set(bins);
+  return detectInstallTargets({
+    home: '/home/agent',
+    platform: 'linux',
+    env: {},
+    whichCmd: async (cmd) => (binSet.has(cmd) ? `/usr/bin/${cmd}` : null),
+    pathExistsFn: async (path) => pathSet.has(path),
+  });
+}
+
+describe('detectInstallTargets', () => {
+  it('detects all installed clients without requiring a manual target choice', async () => {
+    await expect(detector([
+      '/home/agent/.claude',
+      '/home/agent/.codex',
+      '/home/agent/.cursor',
+      '/home/agent/.gemini',
+    ])).resolves.toEqual(['claude', 'codex', 'cursor', 'gemini']);
+  });
+
+  it('detects clients from binaries and harness environment signals', async () => {
+    await expect(detectInstallTargets({
+      home: '/home/agent',
+      platform: 'linux',
+      env: {
+        CODEX_RUN_ID: 'run_123',
+        CURSOR_TRACE_ID: 'trace_123',
+      },
+      whichCmd: async (cmd) => (cmd === 'claude' ? '/usr/bin/claude' : null),
+      pathExistsFn: async () => false,
+    })).resolves.toEqual(['claude', 'codex', 'cursor']);
+  });
+
+  it('returns an empty list when no supported client is detected', async () => {
+    await expect(detector([])).resolves.toEqual([]);
+  });
+});

--- a/apps/web/src/components/AgentJoinQuickstart.tsx
+++ b/apps/web/src/components/AgentJoinQuickstart.tsx
@@ -85,11 +85,11 @@ export function AgentJoinQuickstart({ roomCode }: Props) {
     [roomCode],
   );
 
-  const initBlock = `npx agent-room-mcp init`;
+  const initBlock = client === 'print' ? `npx agent-room-mcp init print` : `npx agent-room-mcp init`;
   const initHint =
     client === 'print'
-      ? 'At the first prompt, type 5 and press Enter (Print configs) — do not press Enter alone, that selects Claude.'
-      : `At the first prompt, type ${row.initMenuKey} and press Enter (${row.label}). Do not pass --no-hooks if you want the agent to stay in the room.`;
+      ? 'Prints pasteable configs instead of installing automatically.'
+      : 'Run this once. It detects installed clients on this machine and installs every match automatically.';
 
   const agentPrompt = `Join agent-room ${roomCode} as <your agent name>. After room_join, stay in a room_listen loop: on quiet timeout, call room_listen again with the same cursor; use room_send when you need to speak. Stop only if the host ends the room, removes you, or tells you to leave.`;
 

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -338,7 +338,7 @@ export function Home() {
               <button onClick={() => copyText('npx agent-room-mcp init', 'Command copied')} className="text-xs font-semibold text-accent bg-accent/15 hover:bg-accent/25 px-3 py-1 rounded-md transition">Copy</button>
             </div>
             <code className="text-xl sm:text-2xl text-emerald-400 font-mono break-all">$ npx agent-room-mcp init</code>
-            <p className="text-sm text-slate-500 mt-4">One command — pick Claude, Cursor, Codex, or Gemini CLI. Idempotent and safe to re-run.</p>
+            <p className="text-sm text-slate-500 mt-4">One command — detects Claude, Cursor, Codex, and Gemini CLI, then installs every match. Idempotent and safe to re-run.</p>
           </div>
 
           {/* Manual config — consolidated. Claude (CLI + desktop) and Cursor


### PR DESCRIPTION
## Summary
- make bare `npx agent-room-mcp init` detect installed Claude, Codex, Cursor, and Gemini clients and install every detected match automatically
- keep explicit targets like `init codex`, `init claude`, and `init print` for scripts and manual flows
- update install docs and web quickstart copy to remove the manual picker expectation
- add unit coverage for multi-client detection, env/binary detection, and no-detection fallback

## Tests
- npm -w apps/mcp test
- npm -w apps/mcp run typecheck
- npm -w apps/mcp run build
- npm -w apps/web run build
- npm -w apps/web test
- git diff --check
