### PR TITLE
feat(web,A1): primary Save & Share CTA on ended room

### DIFF
--- a/apps/web/src/screens/Room.tsx
+++ b/apps/web/src/screens/Room.tsx
@@ -269,6 +269,13 @@ export function Room() {
     try {
       const client = createClient(ENV.upstash);
       await createRoomReport(client, room, messages);
+      // A1: copy the permanent share link to clipboard alongside navigating.
+      // The report key is stored without TTL (see packages/upstash-client/src/reports.ts),
+      // so the link survives past the 24h room TTL — that's exactly the "Save"
+      // half of "Save & Share". Copy first so the toast lives across the
+      // route change (ToastHost is mounted at router level).
+      const reportUrl = `${window.location.origin}/r/${code}/report`;
+      await copyText(reportUrl, 'Saved — share link copied to clipboard');
       navigate(`/r/${code}/report`);
     } catch (e) {
       const { showToast } = await import('../components/Toast.js');
@@ -604,9 +611,26 @@ export function Room() {
             </div>
 
             {ended ? (
-              <div className="border-t border-border-faint p-4 bg-surface-softer text-center">
-                <p className="text-xs text-ink-soft mb-2">This meeting has ended.</p>
-                <div className="flex gap-3 justify-center">
+              // A1: ended-room CTA pivots from "Reactivate-only" to a primary
+              // "Save & Share" call-to-action. Once the meeting wraps, the most
+              // valuable next step is to freeze it into a permanent shareable
+              // report (creates the asset + copies the link to clipboard);
+              // Reactivate stays available as a secondary option, Back-to-home
+              // tertiary. This makes share-link generation a one-click move
+              // and feeds the viral loop: every shared link is also a demo of
+              // the product.
+              <div className="border-t border-border-faint p-4 bg-surface-softer">
+                <p className="text-xs text-ink-soft mb-3 text-center">
+                  This meeting has ended. Save it as a permanent report you can share with your team or client.
+                </p>
+                <div className="flex flex-wrap gap-3 justify-center items-center">
+                  <button
+                    onClick={handleExportReport}
+                    disabled={reportBusy || messages.length === 0}
+                    className="text-xs font-semibold text-white bg-accent px-4 py-1.5 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {reportBusy ? 'Saving…' : 'Save & Share'}
+                  </button>
                   <button
                     onClick={async () => {
                       try {
@@ -626,11 +650,11 @@ export function Room() {
                         await refreshRoom();
                       } catch {}
                     }}
-                    className="text-xs font-semibold text-white bg-accent px-4 py-1.5 rounded-lg"
+                    className="text-xs font-semibold text-ink-muted bg-surface border border-border px-4 py-1.5 rounded-lg hover:border-accent/40 hover:text-accent transition"
                   >
                     Reactivate
                   </button>
-                  <button onClick={() => navigate('/')} className="text-xs font-semibold text-ink-muted">Back to home</button>
+                  <button onClick={() => navigate('/')} className="text-xs font-semibold text-ink-faint hover:text-ink-muted">Back to home</button>
                 </div>
               </div>
             ) : !myCanSpeak ? (


### PR DESCRIPTION
## Track A1 of the 5/9 v2 roadmap (Asset Layer 做厚)

When a meeting ends the most valuable next step is to freeze it into a permanent shareable report — that asset is the viral surface for the product. Previously the ended-room block only offered Reactivate + Back-to-home; Save & Share was hidden in the side-panel 'Outputs' tab.

## Changes

- Ended-room block gains a primary **Save & Share** button calling the existing `handleExportReport` handler.
- Reactivate becomes secondary (outline-style); Back-to-home becomes tertiary text.
- `handleExportReport` now also copies the permanent report URL (`\${origin}/r/\${code}/report`) to the clipboard before navigating. The report key is already \`SET\` without TTL ([packages/upstash-client/src/reports.ts](packages/upstash-client/src/reports.ts)), so the link survives the 24h room TTL — A2 will tighten the explicit semantics, this commit just surfaces it in the UI.
- Toast survives navigation (ToastHost is mounted at router level).

The same handler powers the side-panel Save & Share button, so both entry points now copy + toast + navigate identically.

## Verification

- \`npm -w apps/web run build\` — clean (preexisting Toast dynamic-import warning unchanged)
- \`npm -w apps/web run test\` — 6/6 (\`colors.test.ts\`; no Room.tsx tests exist in repo)

## Test plan

- [ ] Open a room as host, end it (idle timeout / explicit end), confirm new ended block shows Save & Share as primary
- [ ] Click Save & Share → toast \"Saved — share link copied to clipboard\" → page navigates to /r/<code>/report
- [ ] Paste from clipboard → URL is the report URL, not the join URL
- [ ] Confirm Reactivate still works (secondary button); Back-to-home still works
- [ ] Same flow on the side-panel Save & Share button (Outputs tab) also copies + toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)