### PR TITLE
feat(web,A4): viral CTA on shared report + topic prefill in /new

### DIFF
--- a/apps/web/src/screens/CreateMeeting.tsx
+++ b/apps/web/src/screens/CreateMeeting.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { createClient, createRoom } from '@agent-room/upstash-client';
 import { generateCode, ROLE_PRESETS } from '@agent-room/shared';
 import { ENV } from '../env.js';
@@ -9,8 +9,16 @@ import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
 const TEMPLATE_KEY = 'room:pending-template:';
 
 export function CreateMeeting() {
+  // A4: optional `?topic=...&from=<code>` query params let the report
+  // page deep-link a reader straight into a new-room flow with the topic
+  // pre-seeded. `from` is preserved purely for downstream attribution /
+  // debugging — no UI behavior reads it today, but it lives in the URL
+  // so the upcoming room ever needs to know "which shared report
+  // converted you", we don't have to refactor the wire format.
+  const [searchParams] = useSearchParams();
+  const initialTopic = searchParams.get('topic') ?? '';
   const [templateId, setTemplateId] = useState<string>('blank');
-  const [topic, setTopic] = useState('');
+  const [topic, setTopic] = useState(initialTopic);
   const [name, setName] = useState('');
   const [role, setRole] = useState('');
   const [busy, setBusy] = useState(false);

--- a/apps/web/src/screens/Report.tsx
+++ b/apps/web/src/screens/Report.tsx
@@ -177,11 +177,57 @@ export function Report() {
           </div>
         </section>
 
+        <CreateYourOwnCTA report={report} />
+
         {unlockStatus === 'unlocked'
           ? <UnlockedFooter report={report} />
           : <FreeTierFooter report={report} />}
       </main>
     </div>
+  );
+}
+
+// A4: viral-loop hook on the report page. The most natural conversion
+// surface in the entire product is the moment a reader finishes a shared
+// report and thinks "I want my own AI agents to do this for me." Every
+// shared link is an implicit demo of the format; this CTA turns that
+// passive demo into a one-click new-room flow with the source room's
+// topic pre-seeded so the reader doesn't have to guess what to type.
+//
+// The card sits between the body sections and the free-tier / unlocked
+// footer so it's the last positive thing the reader sees before any
+// pricing copy. Deep-link query params (`topic`, `from`) are consumed by
+// CreateMeeting.tsx — `from` is preserved purely for downstream
+// attribution / debugging, no behavior depends on it today.
+function CreateYourOwnCTA({ report }: { report: RoomReport }) {
+  const agentParticipants = report.participants.filter(
+    p => p.client && p.client !== 'web'
+  );
+  const agentNames = agentParticipants.length
+    ? agentParticipants.map(p => p.name).slice(0, 3).join(' · ')
+    : null;
+  const newUrl = `/new?topic=${encodeURIComponent(report.topic)}&from=${encodeURIComponent(report.code)}`;
+
+  return (
+    <section className="bg-gradient-to-br from-accent/5 via-white to-white border border-accent-tint-border rounded-xl p-6">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="text-[11px] uppercase tracking-widest font-semibold text-accent-deep mb-1">
+            Want to run your own session like this?
+          </div>
+          <p className="text-sm text-ink leading-relaxed">
+            Open a room about <strong>{report.topic}</strong>
+            {agentNames ? <> — invite agents like <strong>{agentNames}</strong> the same way the host did here.</> : ' and bring your own agents.'}
+          </p>
+        </div>
+        <Link
+          to={newUrl}
+          className="inline-flex items-center justify-center bg-accent text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:opacity-90 transition shrink-0"
+        >
+          Create your own room →
+        </Link>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Track A4 of the 5/9 v2 roadmap (Asset Layer 做厚 / viral loop)

The most natural conversion surface in the product is the moment a reader finishes a shared report and thinks **"I want my own AI agents to do this for me."** Every shared link is an implicit demo; this PR turns the passive demo into a one-click new-room flow with the source room's topic pre-seeded.

## Changes

- **\`Report.tsx\`** — new \`<CreateYourOwnCTA>\` card between body sections and the free-tier / unlocked footer. Mentions the report topic verbatim and (when available) names a few of the AI agents that participated, so the deep-link feels like "do what they did" — not a generic ad. Primary button links to \`/new?topic=...&from=<code>\`.
- **\`CreateMeeting.tsx\`** — reads \`?topic=...\` query param and seeds the topic field; \`?from=<code>\` is preserved in the URL for downstream attribution (no UI behavior depends on it today, but the wire format is locked in so the upcoming room can later answer "which shared report converted you" without a refactor).

## Verification

- \`npm -w apps/web run build\` — clean (preexisting Toast warning unchanged)
- \`npm -w apps/web run test\` — 6/6

## Test plan

- [ ] Open any \`/r/<code>/report\` page. Confirm the new CTA card appears below \"Transcript\" and above the free-tier footer.
- [ ] Click \"Create your own room →\". Confirm topic field on /new is pre-seeded with the report topic.
- [ ] Confirm \`?from=<code>\` is in the URL on /new (preserved query string).
- [ ] Verify the agent names in the CTA copy are limited to 3 (no overflow on rooms with many participants).
- [ ] On a room with 0 cc participants, confirm the fallback copy (\"and bring your own agents\") renders without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)