### PR TITLE
feat(web): add permanent report social previews

### DIFF
--- a/api/report-og.ts
+++ b/api/report-og.ts
@@ -1,0 +1,112 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient, getRoomReport } from '@agent-room/upstash-client';
+import type { RoomReport } from '@agent-room/shared';
+
+const FALLBACK_TITLE = 'Agent Room Report';
+const FALLBACK_DESCRIPTION = 'A shareable meeting asset from a multi-agent collaboration room.';
+
+function readUpstashEnv(): { url: string; token: string } | { missing: string[] } {
+  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.VITE_UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.VITE_UPSTASH_REDIS_REST_TOKEN;
+  const missing = [
+    !url ? 'UPSTASH_REDIS_REST_URL' : '',
+    !token ? 'UPSTASH_REDIS_REST_TOKEN' : '',
+  ].filter(Boolean);
+  if (missing.length) return { missing };
+  return { url: url!, token: token! };
+}
+
+function roomCode(value: unknown): string | null {
+  const code = typeof value === 'string' ? value.toUpperCase() : '';
+  return /^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{3}$/.test(code) ? code : null;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function clip(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}...` : value;
+}
+
+function reportSummary(report: RoomReport | null): { title: string; description: string; details: string[] } {
+  if (!report) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+      details: ['Permanent report link', 'Transcript, decisions, and action items', 'Human-steered agent collaboration'],
+    };
+  }
+
+  const agents = report.participants
+    .filter(p => p.client !== 'web')
+    .map(p => p.name)
+    .slice(0, 3);
+  const details = [
+    `${report.messageCount} messages`,
+    `${report.participants.length} participants`,
+    agents.length ? `Agents: ${agents.join(', ')}` : 'Meeting asset',
+  ];
+  return {
+    title: `${report.topic || 'Agent Room'} report`,
+    description: report.summary || FALLBACK_DESCRIPTION,
+    details,
+  };
+}
+
+function svgCard(report: RoomReport | null): string {
+  const summary = reportSummary(report);
+  const title = escapeXml(clip(summary.title, 72));
+  const description = escapeXml(clip(summary.description, 150));
+  const details = summary.details.map(d => escapeXml(clip(d, 48)));
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${title}">
+  <rect width="1200" height="630" fill="#F7F3EA"/>
+  <rect x="52" y="52" width="1096" height="526" rx="34" fill="#111318"/>
+  <circle cx="996" cy="128" r="54" fill="#5B6AFF"/>
+  <circle cx="1064" cy="186" r="34" fill="#23C55E"/>
+  <circle cx="932" cy="196" r="26" fill="#F59E0B"/>
+  <text x="104" y="126" fill="#F7F3EA" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="800" letter-spacing="4">AGENT ROOM REPORT</text>
+  <text x="104" y="238" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="850">${title}</text>
+  <foreignObject x="104" y="278" width="880" height="136">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Inter, Arial, sans-serif; font-size: 30px; line-height: 1.35; color: #D9DEE8;">${description}</div>
+  </foreignObject>
+  <g font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
+    <rect x="104" y="460" width="292" height="58" rx="29" fill="#F7F3EA"/>
+    <text x="132" y="498" fill="#111318">${details[0] ?? 'Permanent report'}</text>
+    <rect x="420" y="460" width="324" height="58" rx="29" fill="#E3E8F5"/>
+    <text x="448" y="498" fill="#111318">${details[1] ?? 'Share asset'}</text>
+    <rect x="768" y="460" width="328" height="58" rx="29" fill="#DDF7E8"/>
+    <text x="796" y="498" fill="#111318">${details[2] ?? 'Agent collaboration'}</text>
+  </g>
+</svg>`;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.status(405).json({ error: 'method_not_allowed', message: 'Use GET.' });
+    return;
+  }
+
+  const code = roomCode(req.query.code);
+  if (!code) {
+    res.status(400).json({ error: 'bad_room_code', message: 'Missing or malformed room code.' });
+    return;
+  }
+
+  const env = readUpstashEnv();
+  let report: RoomReport | null = null;
+  if (!('missing' in env)) {
+    report = await getRoomReport(createClient(env), code).catch(() => null);
+  }
+
+  res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+  res.status(200).send(req.method === 'HEAD' ? '' : svgCard(report));
+}

--- a/api/report-page.ts
+++ b/api/report-page.ts
@@ -1,0 +1,112 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient, getRoomReport } from '@agent-room/upstash-client';
+import type { RoomReport } from '@agent-room/shared';
+
+const SITE_URL = 'https://www.agent-room.com';
+
+function readUpstashEnv(): { url: string; token: string } | { missing: string[] } {
+  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.VITE_UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.VITE_UPSTASH_REDIS_REST_TOKEN;
+  const missing = [
+    !url ? 'UPSTASH_REDIS_REST_URL' : '',
+    !token ? 'UPSTASH_REDIS_REST_TOKEN' : '',
+  ].filter(Boolean);
+  if (missing.length) return { missing };
+  return { url: url!, token: token! };
+}
+
+function roomCode(value: unknown): string | null {
+  const code = typeof value === 'string' ? value.toUpperCase() : '';
+  return /^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{3}$/.test(code) ? code : null;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function clip(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}...` : value;
+}
+
+function metaFor(report: RoomReport | null, code: string) {
+  const title = report?.topic
+    ? `Agent Room Report: ${report.topic}`
+    : `Agent Room Report ${code}`;
+  const description = report?.summary
+    ? clip(report.summary, 220)
+    : 'A permanent, shareable meeting asset from an AI-agent collaboration room.';
+  const url = `${SITE_URL}/r/${code}/report`;
+  const image = `${SITE_URL}/api/report-og?code=${encodeURIComponent(code)}${report ? `&v=${encodeURIComponent(String(report.exportedAt))}` : ''}`;
+
+  return { title, description, url, image };
+}
+
+function htmlPage(report: RoomReport | null, code: string): string {
+  const meta = metaFor(report, code);
+  const safeTitle = escapeHtml(meta.title);
+  const safeDescription = escapeHtml(meta.description);
+  const safeUrl = escapeHtml(meta.url);
+  const safeImage = escapeHtml(meta.image);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="${safeUrl}" />
+    <title>${safeTitle}</title>
+    <meta name="description" content="${safeDescription}" />
+    <meta property="og:site_name" content="Agent Room" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="${safeUrl}" />
+    <meta property="og:title" content="${safeTitle}" />
+    <meta property="og:description" content="${safeDescription}" />
+    <meta property="og:image" content="${safeImage}" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="${safeTitle}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="${safeTitle}" />
+    <meta name="twitter:description" content="${safeDescription}" />
+    <meta name="twitter:image" content="${safeImage}" />
+    <meta http-equiv="refresh" content="0; url=${safeUrl}" />
+  </head>
+  <body>
+    <main>
+      <h1>${safeTitle}</h1>
+      <p>${safeDescription}</p>
+      <p><a href="${safeUrl}">Open the report</a></p>
+    </main>
+  </body>
+</html>`;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.status(405).json({ error: 'method_not_allowed', message: 'Use GET.' });
+    return;
+  }
+
+  const code = roomCode(req.query.code);
+  if (!code) {
+    res.status(400).send('Missing or malformed room code.');
+    return;
+  }
+
+  const env = readUpstashEnv();
+  let report: RoomReport | null = null;
+  if (!('missing' in env)) {
+    report = await getRoomReport(createClient(env), code).catch(() => null);
+  }
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+  res.status(200).send(req.method === 'HEAD' ? '' : htmlPage(report, code));
+}

--- a/packages/upstash-client/src/reports.ts
+++ b/packages/upstash-client/src/reports.ts
@@ -3,6 +3,8 @@ import type { UpstashClient } from './client.js';
 
 function reportKey(code: string): string { return `room-report:${code}`; }
 
+export const REPORT_RETENTION = 'permanent' as const;
+
 export function buildRoomReport(room: Room, messages: Message[]): RoomReport {
   const userMessages = messages.filter(m => m.type === 'msg' && m.text.trim());
   const artifacts = extractArtifacts(userMessages);
@@ -42,6 +44,8 @@ export async function createRoomReport(
   messages: Message[]
 ): Promise<RoomReport> {
   const report = buildRoomReport(room, messages);
+  // Reports are shareable meeting assets, so they intentionally outlive
+  // the 24h room TTL. Redis SET without EX/PX clears any prior TTL.
   await client.command(['SET', reportKey(room.code), JSON.stringify(report)]);
   return report;
 }

--- a/packages/upstash-client/test/reports.test.ts
+++ b/packages/upstash-client/test/reports.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message, Room } from '@agent-room/shared';
+import { createClient, createRoomReport, getRoomReport, REPORT_RETENTION } from '../src/index.js';
+
+const ENV = { url: 'https://example.upstash.io', token: 't' };
+
+function mockResp(body: unknown) {
+  return new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+}
+
+function sampleRoom(): Room {
+  return {
+    code: 'ABC-DEF-GHJ',
+    topic: 'Ship report assets',
+    createdAt: 1,
+    createdBy: 'Robin',
+    status: 'ended',
+    version: 2,
+    participants: [
+      { name: 'Robin', role: 'Facilitator', color: '#F59E0B', initials: 'RO', client: 'web', joinedAt: 1, lastSeenAt: 2, canSpeak: true },
+      { name: 'Codex', role: 'Platform', color: '#5B6AFF', initials: 'CO', client: 'cc', joinedAt: 1, lastSeenAt: 2, canSpeak: true },
+    ],
+  };
+}
+
+function sampleMessages(): Message[] {
+  return [
+    {
+      id: 10,
+      type: 'msg',
+      name: 'Codex',
+      role: 'Platform',
+      text: '[DECISION] Store exported reports as permanent share assets.',
+      time: 3,
+      client: 'cc',
+    },
+  ];
+}
+
+describe('reports', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('documents exported report retention as permanent', () => {
+    expect(REPORT_RETENTION).toBe('permanent');
+  });
+
+  it('stores exported reports without any Redis TTL modifier', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResp({ result: 'OK' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createClient(ENV);
+    const report = await createRoomReport(client, sampleRoom(), sampleMessages());
+
+    expect(report.code).toBe('ABC-DEF-GHJ');
+    const [, init] = fetchMock.mock.calls[0]!;
+    const cmd = JSON.parse((init as RequestInit).body as string);
+    expect(cmd[0]).toBe('SET');
+    expect(cmd[1]).toBe('room-report:ABC-DEF-GHJ');
+    expect(JSON.parse(cmd[2]).topic).toBe('Ship report assets');
+    expect(cmd.slice(3)).toEqual([]);
+    expect(cmd).not.toContain('EX');
+    expect(cmd).not.toContain('PX');
+    expect(cmd).not.toContain('EXAT');
+    expect(cmd).not.toContain('PXAT');
+    expect(cmd).not.toContain('KEEPTTL');
+  });
+
+  it('reads a previously exported report by code', async () => {
+    const stored = {
+      ...await createRoomReport(
+        { command: vi.fn().mockResolvedValue('OK'), pipeline: vi.fn() },
+        sampleRoom(),
+        sampleMessages()
+      ),
+      exportedAt: 100,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResp({ result: JSON.stringify(stored) })));
+
+    const client = createClient(ENV);
+    await expect(getRoomReport(client, 'ABC-DEF-GHJ')).resolves.toMatchObject({
+      code: 'ABC-DEF-GHJ',
+      topic: 'Ship report assets',
+      exportedAt: 100,
+    });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,17 @@
   "outputDirectory": "apps/web/dist",
   "framework": null,
   "rewrites": [
+    {
+      "source": "/r/:code/report",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(bot|Bot|crawler|Crawler|spider|Spider|facebookexternalhit|Twitterbot|Slackbot|LinkedInBot|Discordbot|WhatsApp|TelegramBot).*"
+        }
+      ],
+      "destination": "/api/report-page?code=:code"
+    },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- document exported room reports as permanent assets and add a regression test that forbids Redis TTL modifiers
- add crawler-only Vercel rewrite for /r/:code/report so social crawlers receive report-specific OG/Twitter meta
- add /api/report-page and /api/report-og endpoints for share preview HTML and dynamic report card SVGs

## Tests
- npm -w packages/upstash-client test
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck api/report-og.ts api/report-page.ts
- npm run build