### PR TITLE
fix(api): hotfix /api/report-page + /api/report-og 500s

### DIFF
--- a/api/report-og.ts
+++ b/api/report-og.ts
@@ -1,9 +1,55 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { createClient, getRoomReport } from '@agent-room/upstash-client';
-import type { RoomReport } from '@agent-room/shared';
+
+// Hotfix: see api/report-page.ts for the full rationale. Same workspace-
+// import problem (`@agent-room/upstash-client` ships TypeScript source
+// via `"main": "./src/index.ts"`, which Node can't load at runtime), so
+// the import was crashing the function before the handler ran. This
+// inlines a minimal Upstash REST GET + the report-shape subset we
+// actually consult.
 
 const FALLBACK_TITLE = 'Agent Room Report';
 const FALLBACK_DESCRIPTION = 'A shareable meeting asset from a multi-agent collaboration room.';
+
+interface MiniParticipant {
+  name: string;
+  client?: string;
+}
+
+interface MiniReport {
+  topic?: string;
+  summary?: string;
+  exportedAt?: number;
+  messageCount?: number;
+  participants?: MiniParticipant[];
+}
+
+async function getRoomReportRaw(
+  url: string,
+  token: string,
+  code: string
+): Promise<MiniReport | null> {
+  let resp: Response;
+  try {
+    resp = await fetch(`${url.replace(/\/$/, '')}/get/room-report:${encodeURIComponent(code)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+  let body: { result?: string | null };
+  try {
+    body = (await resp.json()) as { result?: string | null };
+  } catch {
+    return null;
+  }
+  if (!body.result) return null;
+  try {
+    return JSON.parse(body.result) as MiniReport;
+  } catch {
+    return null;
+  }
+}
 
 function readUpstashEnv(): { url: string; token: string } | { missing: string[] } {
   const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.VITE_UPSTASH_REDIS_REST_URL;
@@ -34,7 +80,7 @@ function clip(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max - 1)}...` : value;
 }
 
-function reportSummary(report: RoomReport | null): { title: string; description: string; details: string[] } {
+function reportSummary(report: MiniReport | null): { title: string; description: string; details: string[] } {
   if (!report) {
     return {
       title: FALLBACK_TITLE,
@@ -43,13 +89,14 @@ function reportSummary(report: RoomReport | null): { title: string; description:
     };
   }
 
-  const agents = report.participants
+  const participants = report.participants ?? [];
+  const agents = participants
     .filter(p => p.client !== 'web')
     .map(p => p.name)
     .slice(0, 3);
   const details = [
-    `${report.messageCount} messages`,
-    `${report.participants.length} participants`,
+    `${report.messageCount ?? 0} messages`,
+    `${participants.length} participants`,
     agents.length ? `Agents: ${agents.join(', ')}` : 'Meeting asset',
   ];
   return {
@@ -59,7 +106,7 @@ function reportSummary(report: RoomReport | null): { title: string; description:
   };
 }
 
-function svgCard(report: RoomReport | null): string {
+function svgCard(report: MiniReport | null): string {
   const summary = reportSummary(report);
   const title = escapeXml(clip(summary.title, 72));
   const description = escapeXml(clip(summary.description, 150));
@@ -101,9 +148,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 
   const env = readUpstashEnv();
-  let report: RoomReport | null = null;
+  let report: MiniReport | null = null;
   if (!('missing' in env)) {
-    report = await getRoomReport(createClient(env), code).catch(() => null);
+    report = await getRoomReportRaw(env.url, env.token, code).catch(() => null);
   }
 
   res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');

--- a/api/report-page.ts
+++ b/api/report-page.ts
@@ -1,8 +1,58 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { createClient, getRoomReport } from '@agent-room/upstash-client';
-import type { RoomReport } from '@agent-room/shared';
+
+// Hotfix: dropped the `@agent-room/upstash-client` + `@agent-room/shared`
+// workspace imports because both packages publish `"main": "./src/index.ts"`
+// (TypeScript source). At runtime Vercel serverless functions are plain
+// Node — Node cannot execute `.ts` files, so the import resolves to the
+// raw TS source and the function crashes with FUNCTION_INVOCATION_FAILED
+// before our handler ever runs. Inlining a minimal Upstash REST GET +
+// the report-shape subset we actually read avoids the whole workspace
+// dependency chain. The proper long-term fix is to ship those packages
+// as compiled JS (so the existing imports work in Node), but that's a
+// bigger workspace change; this hotfix unblocks the OG endpoint today.
 
 const SITE_URL = 'https://www.agent-room.com';
+
+// The strict subset of `RoomReport` this endpoint actually consults.
+// Stays a structural subset of the shared type so the contract still
+// holds when we re-import the workspace package later.
+interface MiniReport {
+  topic?: string;
+  summary?: string;
+  exportedAt?: number;
+}
+
+async function getRoomReportRaw(
+  url: string,
+  token: string,
+  code: string
+): Promise<MiniReport | null> {
+  // Upstash REST: GET /<command>/<arg> returns { result: string | null }.
+  // We store reports as JSON-stringified blobs at key `room-report:<code>`
+  // (see packages/upstash-client/src/reports.ts), so a single GET is all
+  // we need.
+  let resp: Response;
+  try {
+    resp = await fetch(`${url.replace(/\/$/, '')}/get/room-report:${encodeURIComponent(code)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+  let body: { result?: string | null };
+  try {
+    body = (await resp.json()) as { result?: string | null };
+  } catch {
+    return null;
+  }
+  if (!body.result) return null;
+  try {
+    return JSON.parse(body.result) as MiniReport;
+  } catch {
+    return null;
+  }
+}
 
 function readUpstashEnv(): { url: string; token: string } | { missing: string[] } {
   const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.VITE_UPSTASH_REDIS_REST_URL;
@@ -33,7 +83,7 @@ function clip(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max - 1)}...` : value;
 }
 
-function metaFor(report: RoomReport | null, code: string) {
+function metaFor(report: MiniReport | null, code: string) {
   const title = report?.topic
     ? `Agent Room Report: ${report.topic}`
     : `Agent Room Report ${code}`;
@@ -46,7 +96,7 @@ function metaFor(report: RoomReport | null, code: string) {
   return { title, description, url, image };
 }
 
-function htmlPage(report: RoomReport | null, code: string): string {
+function htmlPage(report: MiniReport | null, code: string): string {
   const meta = metaFor(report, code);
   const safeTitle = escapeHtml(meta.title);
   const safeDescription = escapeHtml(meta.description);
@@ -101,9 +151,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 
   const env = readUpstashEnv();
-  let report: RoomReport | null = null;
+  let report: MiniReport | null = null;
   if (!('missing' in env)) {
-    report = await getRoomReport(createClient(env), code).catch(() => null);
+    report = await getRoomReportRaw(env.url, env.token, code).catch(() => null);
   }
 
   res.setHeader('Content-Type', 'text/html; charset=utf-8');


### PR DESCRIPTION
## Production hotfix

\`/api/report-page\` and \`/api/report-og\` (shipped in #28) return **HTTP 500 / FUNCTION_INVOCATION_FAILED** in production right now. Repro:

\`\`\`
$ curl -A \"facebookexternalhit/1.1\" https://www.agent-room.com/api/report-page?code=ABC-DEF-GHJ
HTTP/2 500
x-vercel-error: FUNCTION_INVOCATION_FAILED
\`\`\`

Affected paths:
- the two API endpoints directly
- the crawler-only rewrite from \`/r/:code/report\` → \`/api/report-page\`, so social unfurls (Slack / Discord / Twitter / Facebook) don't fire

## Root cause

The two endpoints import workspace packages:

\`\`\`ts
import { createClient, getRoomReport } from '@agent-room/upstash-client';
import type { RoomReport } from '@agent-room/shared';
\`\`\`

But both packages declare \`\"main\": \"./src/index.ts\"\` — TypeScript **source**. Vite handles that at build time for the web app. But Vercel serverless functions run as plain **Node**, which cannot execute \`.ts\` files at runtime. The import resolves to raw TS source and the function crashes before the exported handler ever runs.

## Fix

- Drop the \`@agent-room/*\` imports from both \`api/\` files.
- Inline a minimal Upstash REST GET (single \`fetch\` + JSON parse, ~25 lines) so each function is self-contained.
- Inline a \`MiniReport\` interface that's a structural subset of \`RoomReport\` covering only the fields the endpoints actually read (\`topic\`, \`summary\`, \`exportedAt\`, \`messageCount\`, \`participants\`).
- All caching headers, OG meta tags, and SVG card output are unchanged.

The proper long-term fix is to ship the workspace packages as compiled JS so the original imports work in Node — tracked separately.

## Verification

- \`npx tsc --noEmit\` on both files — clean
- \`npm run build\` (workspace-wide) — clean (preexisting Toast warning unchanged)
- diff: +112 / -15, two files (\`api/report-page.ts\`, \`api/report-og.ts\`)

## Test plan

- [ ] After merge + Vercel auto-deploy, confirm \`curl -A \"facebookexternalhit/1.1\" https://www.agent-room.com/api/report-page?code=<valid-CODE>\` returns 200 with \`<meta property=\"og:title\">\` etc.
- [ ] Confirm \`curl https://www.agent-room.com/api/report-og?code=<valid-CODE>\` returns 200 with \`Content-Type: image/svg+xml\` and a 1200×630 SVG body
- [ ] Confirm \`curl -A \"facebookexternalhit/1.1\" https://www.agent-room.com/r/<CODE>/report\` (the rewrite path) returns the OG HTML, not the SPA shell
- [ ] Paste a report URL into Slack — preview should now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)