### PR TITLE
fix(rooms): dedupe duplicate "falling back to open" on concurrent sweeps

### DIFF
--- a/packages/upstash-client/src/turnState.ts
+++ b/packages/upstash-client/src/turnState.ts
@@ -670,10 +670,23 @@ export interface SweepResult {
 // see what happened.
 //
 // Concurrency: a CAS-then-write race is possible (two listen polls both
-// see the same expired deadline and both write). Idempotency comes from
-// `spoken.at` being monotonically advanced: a second writer who lost the
-// race will append duplicates only if both fired at the exact same ms,
-// which is rare and self-healing on the next read.
+// see the same expired deadline and both write). The state writes are
+// idempotent, but the caller emits one sys message per returned skip and
+// fallback — so two concurrent sweeps of the same dead-end would post the
+// "falling back to open mode" notice (and the moderator skip) TWICE. The
+// fallback emission is therefore gated on `claimDeadEndNotice`: only the
+// sweep that wins the SET NX claim returns the fallback; the loser
+// suppresses it (state still converges via the winner's write).
+async function claimDeadEndNotice(
+  client: UpstashClient,
+  code: string,
+  identity: string,
+): Promise<boolean> {
+  const key = `sweepDeadEnd:${code}:${identity}`;
+  const won = await client.command<string | null>(['SET', key, '1', 'NX', 'EX', '30']);
+  return won === 'OK';
+}
+
 export async function sweepTimeouts(
   client: UpstashClient,
   code: string,
@@ -726,6 +739,18 @@ export async function sweepTimeouts(
   }
 
   if (fallback) {
+    // Dedupe concurrent sweeps of the same dead-end so the caller emits the
+    // fallback notice once. The key is derived purely from `prev` (the absent
+    // role + the deadline that lapsed), so every racer computes the same key
+    // and exactly one SET NX wins. Loser suppresses skip + fallback (the
+    // winner's room CAS + turn clear below still converge the state).
+    // Best-effort: if the lock client errors, fall through and emit (a rare
+    // duplicate beats a silently-dropped fallback notice).
+    const claimed = await claimDeadEndNotice(
+      client, code,
+      `${fallback.reason}:${fallback.agentName}:${fallback.agentClient}:${prev.deadline ?? 'none'}`,
+    ).catch(() => true);
+    if (!claimed) return { state, skipped: [] };
     // Flip replyMode to 'open' and clear turnState. Best-effort: if the
     // room CAS fails (concurrent setReplyMode), we still clear local
     // state and surface the event — the room write will eventually

--- a/packages/upstash-client/test/sweepDedupe.test.ts
+++ b/packages/upstash-client/test/sweepDedupe.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Participant, Room } from '@agent-room/shared';
+import {
+  createClient,
+  sweepTimeouts,
+  getRoom,
+  getTurnState,
+  type TurnState,
+} from '../src/index.js';
+
+const ENV = { url: 'https://example.upstash.io', token: 't' };
+const CODE = 'TST-CDE-FGH';
+
+// In-memory Upstash fake that honors SET ... NX, so the dedupe claim (the only
+// NX writer) round-trips: a second SET NX on an existing key returns null.
+function installFakeRedis(seed: Record<string, string> = {}): Map<string, string> {
+  const store = new Map<string, string>(Object.entries(seed));
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init: any) => {
+    const args = JSON.parse(init.body) as string[];
+    const [op, key, val] = args;
+    let result: unknown = null;
+    if (op === 'GET') result = store.has(key) ? store.get(key) : null;
+    else if (op === 'SET') {
+      if (args.includes('NX') && store.has(key)) { result = null; }
+      else { store.set(key, val as string); result = 'OK'; }
+    }
+    else if (op === 'DEL') { result = store.delete(key) ? 1 : 0; }
+    return new Response(JSON.stringify({ result }), { headers: { 'Content-Type': 'application/json' } });
+  }));
+  return store;
+}
+
+function part(name: string, joinedAt: number, client: 'web' | 'cc' = 'cc', canSpeak = true): Participant {
+  return { name, client, role: '', color: '#fff', initials: 'XX', joinedAt, lastSeenAt: joinedAt, canSpeak };
+}
+
+function moderatorRoom(participants: Participant[], moderator: string): Room {
+  return {
+    code: CODE, topic: 'discussion', createdAt: 0, createdBy: 'host', status: 'active',
+    version: 1, participants, replyMode: 'moderator',
+    modeConfig: { moderatorAgentName: moderator, moderatorAgentClient: 'cc' },
+  };
+}
+
+// A moderator turn whose deadline is already in the past, so the sweep skips it.
+function expiredModeratorTurn(moderator: string): TurnState {
+  return {
+    turnId: 100, mode: 'moderator',
+    moderatorName: moderator, moderatorClient: 'cc',
+    currentName: moderator, currentClient: 'cc', currentRole: 'moderator',
+    deadline: 500, queue: [], spoken: [],
+  };
+}
+
+describe('sweepTimeouts dead-end dedupe', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('falls a timed-out moderator back to open and reports it', async () => {
+    const r = moderatorRoom([part('Human', 0, 'web'), part('ModA', 1)], 'ModA');
+    installFakeRedis({
+      [`room:${CODE}`]: JSON.stringify(r),
+      [`turn-state:${CODE}`]: JSON.stringify(expiredModeratorTurn('ModA')),
+    });
+    const client = createClient(ENV);
+
+    const sweep = await sweepTimeouts(client, CODE, r, 10_000);
+
+    expect(sweep.fallback?.reason).toBe('moderator_timeout');
+    const room = await getRoom(client, CODE);
+    expect(room.replyMode).toBe('open');
+    expect(await getTurnState(client, CODE)).toBeNull();
+  });
+
+  it('dedupes concurrent sweeps of the same dead-end: only the first emits the fallback', async () => {
+    // Two listen polls observe the SAME expired moderator deadline. The first
+    // claims the dead-end and returns the skip + fallback; the second must
+    // suppress them so the caller does not post duplicate sys messages. We
+    // re-seed the pre-fallback state both racers saw between calls, while the
+    // shared store keeps the dedupe lock so the second claim loses.
+    const r = moderatorRoom([part('Human', 0, 'web'), part('ModA', 1)], 'ModA');
+    const store = installFakeRedis({
+      [`room:${CODE}`]: JSON.stringify(r),
+      [`turn-state:${CODE}`]: JSON.stringify(expiredModeratorTurn('ModA')),
+    });
+    const client = createClient(ENV);
+
+    const first = await sweepTimeouts(client, CODE, r, 10_000);
+    expect(first.fallback?.reason).toBe('moderator_timeout');
+    expect(first.skipped.length).toBe(1);
+
+    // Reset to the pre-fallback state both racers saw; keep the dedupe lock.
+    store.set(`room:${CODE}`, JSON.stringify(r));
+    store.set(`turn-state:${CODE}`, JSON.stringify(expiredModeratorTurn('ModA')));
+
+    const second = await sweepTimeouts(client, CODE, r, 10_000);
+    expect(second.fallback).toBeUndefined();
+    expect(second.skipped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem
Two long-poll listeners observing the **same** expired moderator (or sequential Lead) both ran `sweepTimeouts` and each returned the skip + fallback. The state writes were already idempotent, but the **caller emits one sys message per returned skip/fallback** — so the room posted `"… falling back to open mode"` (and the moderator skip) **twice**.

## Fix
Gate the fallback emission on a `SET NX` claim keyed on the absent role + the deadline that lapsed (identical for both racers), so only the winning sweep returns the fallback; the loser suppresses it. State still converges via the winner's room CAS + turn clear. Best-effort: if the lock client errors, it falls through and emits (a rare duplicate beats a silently-dropped notice).

## Scope
- `packages/upstash-client/src/turnState.ts` (+30/-4)
- `packages/upstash-client/test/sweepDedupe.test.ts` (new — concurrent-dedupe regression)

## Tests
`upstash-client` 78 passed (incl. 2 new), `tsc` clean, package build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)