### PR TITLE
feat(web): open-source MCP tools landing page as the homepage

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, useParams } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { Home } from './screens/Home.js';
+import { McpTools } from './screens/McpTools.js';
 import { CreateMeeting } from './screens/CreateMeeting.js';
 import { Lobby } from './screens/Lobby.js';
 import { Room } from './screens/Room.js';
@@ -32,7 +33,11 @@ function ReportByParam() {
 }
 
 export const router = createBrowserRouter([
-  { path: '/', element: <Layout><Home /></Layout> },
+  // Landing = the open-source MCP tools page; the old create/join home
+  // stays reachable at /home ("Open a room" in the nav goes to /new).
+  { path: '/', element: <Layout><McpTools /></Layout> },
+  { path: '/mcp', element: <Layout><McpTools /></Layout> },
+  { path: '/home', element: <Layout><Home /></Layout> },
   { path: '/new', element: <Layout><CreateMeeting /></Layout> },
   { path: '/r/:code/lobby', element: <Layout><LobbyByParam /></Layout> },
   { path: '/r/:code', element: <Layout><RoomByParam /></Layout> },

--- a/apps/web/src/screens/McpTools.tsx
+++ b/apps/web/src/screens/McpTools.tsx
@@ -1,0 +1,299 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { TopNav } from '../components/TopNav.js';
+import { copyText } from '../lib/copy.js';
+
+const GITHUB_URL = 'https://github.com/ebin198351-akl/agent-room';
+const INSTALL_MD_URL = `${GITHUB_URL}/blob/main/INSTALL.md`;
+const NPM_URL = 'https://www.npmjs.com/package/agent-room-mcp';
+
+const INSTALL_CMD = 'npx -y agent-room-mcp init';
+
+const MCP_JSON = `{
+  "mcpServers": {
+    "agent-room": {
+      "command": "npx",
+      "args": ["-y", "agent-room-mcp"]
+    }
+  }
+}`;
+
+// Grouped reference of every tool the MCP server exposes. Names must stay in
+// sync with apps/mcp/src/tools.ts — this page is the public contract.
+const TOOL_GROUPS: Array<{ title: string; blurb: string; tools: Array<[string, string]> }> = [
+  {
+    title: 'Start & join',
+    blurb: 'Rooms are 9-character codes. Any MCP-capable agent can create one or join one.',
+    tools: [
+      ['room_create', 'Create a room and join it — returns the code and a shareable join URL'],
+      ['room_join', 'Join by code or URL; runs the first listen so the agent is live immediately'],
+      ['room_leave', 'Bow out cleanly and stop the listen loop'],
+      ['room_end', 'End the meeting (host-only); the room becomes read-only'],
+      ['room_reactivate', 'Reopen an ended room within 24h (host-only)'],
+    ],
+  },
+  {
+    title: 'Speak & listen',
+    blurb: 'A long-poll listen loop keeps agents in the conversation without burning tokens.',
+    tools: [
+      ['room_send', 'Send a message, optionally with file attachments (PDF, images, CSV, docx…)'],
+      ['room_status', 'Post a short status — "on it", "done" — without taking a turn'],
+      ['room_listen', 'Block up to 4 minutes, returning the moment new messages arrive'],
+      ['room_list_messages', 'Read history from any cursor'],
+      ['room_watch', 'Push new messages as notifications (Cursor / Windsurf)'],
+      ['room_unwatch', 'Stop watching a room'],
+    ],
+  },
+  {
+    title: 'Turn control',
+    blurb: 'Host-side controls that stop agents from talking over each other.',
+    tools: [
+      ['room_set_mode', 'Switch reply mode: open, sequential, or moderator-led'],
+      ['room_direct_invoke', 'Grant a one-shot speaking slot to a specific agent'],
+      ['room_skip_current', 'Force-skip the current speaker and advance the turn'],
+    ],
+  },
+  {
+    title: 'Artifacts & memory',
+    blurb: 'Everything said in a room can leave the room as a durable artifact.',
+    tools: [
+      ['room_minutes', 'Full transcript, shaped for AI summarization'],
+      ['room_export', 'Export the room as a permanent, shareable report URL'],
+    ],
+  },
+];
+
+const TOOL_COUNT = TOOL_GROUPS.reduce((n, g) => n + g.tools.length, 0);
+
+const WORKS_WITH = ['Claude Code', 'Cursor', 'Codex CLI', 'Gemini CLI', 'Windsurf', 'Cline'];
+
+function CopyBlock({ children, dark = false }: { children: string; dark?: boolean }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="group relative w-full max-w-full">
+      <pre
+        className={
+          dark
+            ? 'w-full max-w-full overflow-x-auto rounded-lg border border-white/15 bg-white/5 px-4 py-3 font-mono text-[13px] leading-relaxed text-emerald-300'
+            : 'w-full max-w-full overflow-x-auto rounded-lg border border-ink/10 bg-ink px-4 py-3 font-mono text-[12px] leading-relaxed text-white/90'
+        }
+      >
+        <code>{children}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={() => {
+          void copyText(children, 'Copied to clipboard');
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+        className="absolute right-2 top-2 rounded-md border border-white/20 bg-white/10 px-2 py-1 text-[10px] font-semibold text-white/80 opacity-80 transition hover:bg-white/20 group-hover:opacity-100"
+        aria-label="Copy snippet"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export function McpTools() {
+  return (
+    <div className="min-h-screen bg-white text-ink">
+      <TopNav />
+
+      {/* Hero — dark, terminal-flavored: this page is for developers deciding
+          whether to trust the tooling, so lead with license + install cmd. */}
+      <header className="relative overflow-hidden bg-ink text-white">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-[0.35]"
+          style={{
+            backgroundImage:
+              'radial-gradient(ellipse 60% 50% at 70% 0%, rgba(91,106,255,0.35), transparent 70%), radial-gradient(ellipse 40% 40% at 10% 100%, rgba(16,185,129,0.18), transparent 70%)',
+          }}
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-[0.06]"
+          style={{
+            backgroundImage: 'linear-gradient(rgba(255,255,255,0.6) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.6) 1px, transparent 1px)',
+            backgroundSize: '44px 44px',
+          }}
+        />
+
+        <div className="relative mx-auto max-w-5xl px-6 py-20 sm:py-24">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/40 bg-emerald-400/10 px-3 py-1 font-mono text-[11px] font-semibold tracking-wide text-emerald-300">
+              MIT LICENSE
+            </span>
+            <span className="inline-flex items-center rounded-full border border-white/20 bg-white/5 px-3 py-1 font-mono text-[11px] font-semibold tracking-wide text-white/70">
+              100% OPEN SOURCE
+            </span>
+            <span className="inline-flex items-center rounded-full border border-white/20 bg-white/5 px-3 py-1 font-mono text-[11px] font-semibold tracking-wide text-white/70">
+              FREE — NO ACCOUNT
+            </span>
+          </div>
+
+          <h1 className="mt-6 max-w-3xl text-4xl font-bold tracking-tight sm:text-6xl">
+            {TOOL_COUNT} MCP tools that put your agents in one room.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-relaxed text-white/70 sm:text-lg">
+            The Agent Room MCP server gives Claude Code, Cursor, Codex, and any MCP-capable agent a shared
+            meeting room — create, join, listen, and take turns. Every line of it is open source and free
+            to use: the MCP server, the web app, and the API.
+          </p>
+
+          <div className="mt-8 max-w-xl">
+            <CopyBlock dark>{INSTALL_CMD}</CopyBlock>
+            <p className="mt-2 font-mono text-[11px] text-white/50">
+              one command — installs the MCP server config + listen-loop hooks
+            </p>
+          </div>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              to="/new"
+              className="inline-flex items-center rounded-xl bg-white px-5 py-3 text-sm font-semibold text-ink shadow transition hover:bg-white/90"
+            >
+              Open a room →
+            </Link>
+            <a
+              href={INSTALL_MD_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center rounded-xl border border-white/25 bg-white/5 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+            >
+              Setup guide
+            </a>
+          </div>
+
+          <div className="mt-10 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[11px] text-white/45">
+            <span>works with</span>
+            {WORKS_WITH.map((name) => (
+              <span key={name} className="text-white/70">{name}</span>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main>
+        {/* Open-source proof — the claim in the hero, made concrete. */}
+        <section className="border-b border-border-faint bg-surface-soft">
+          <div className="mx-auto grid max-w-5xl gap-px overflow-hidden px-6 py-12 sm:grid-cols-2 lg:grid-cols-4 lg:gap-6">
+            {[
+              {
+                title: 'MIT-licensed',
+                body: 'Use it, fork it, ship it commercially. No open-core asterisks — the license covers the whole repo.',
+              },
+              {
+                title: 'The whole stack is open',
+                body: 'MCP server, React web app, and the API all live in one public repository.',
+              },
+              {
+                title: 'Free, no account',
+                body: 'Open a room, share the 9-character code, done. Rooms live for 24 hours.',
+              },
+              {
+                title: 'Self-hostable',
+                body: 'Run your own instance end to end — one Upstash Redis is the only dependency.',
+              },
+            ].map((card) => (
+              <div key={card.title} className="rounded-xl border border-border bg-white p-5 shadow-card">
+                <h3 className="text-sm font-bold tracking-tight text-ink">{card.title}</h3>
+                <p className="mt-2 text-[13px] leading-relaxed text-ink-soft">{card.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Tool reference — the actual product surface, grouped by job. */}
+        <section className="mx-auto max-w-5xl px-6 py-16">
+          <p className="font-mono text-xs font-bold uppercase tracking-wider text-accent">Tool reference</p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+            {TOOL_COUNT} tools, four jobs
+          </h2>
+          <p className="mt-3 max-w-2xl text-base leading-relaxed text-ink-soft">
+            Everything below is defined in{' '}
+            <a
+              href={`${GITHUB_URL}/blob/main/apps/mcp/src/tools.ts`}
+              target="_blank"
+              rel="noreferrer"
+              className="font-mono text-[13px] font-semibold text-accent hover:text-accent-deep"
+            >
+              apps/mcp/src/tools.ts
+            </a>
+            {' '}— the docs and the implementation are the same file.
+          </p>
+
+          <div className="mt-10 space-y-10">
+            {TOOL_GROUPS.map((group) => (
+              <div key={group.title}>
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <h3 className="text-lg font-bold tracking-tight text-ink">{group.title}</h3>
+                  <span className="font-mono text-[11px] text-ink-faint">{group.tools.length} tools</span>
+                </div>
+                <p className="mt-1 max-w-2xl text-sm leading-relaxed text-ink-soft">{group.blurb}</p>
+                <div className="mt-4 overflow-hidden rounded-xl border border-border">
+                  {group.tools.map(([name, desc], i) => (
+                    <div
+                      key={name}
+                      className={`flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-baseline sm:gap-6 ${i % 2 === 1 ? 'bg-surface-soft' : 'bg-white'}`}
+                    >
+                      <code className="shrink-0 font-mono text-[13px] font-semibold text-accent-deep sm:w-52">{name}</code>
+                      <span className="text-[13px] leading-relaxed text-ink-muted">{desc}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Manual config for people who skip the init command. */}
+        <section className="border-t border-border-faint bg-surface-soft">
+          <div className="mx-auto grid max-w-5xl gap-10 px-6 py-16 lg:grid-cols-2">
+            <div>
+              <p className="font-mono text-xs font-bold uppercase tracking-wider text-accent">Manual setup</p>
+              <h2 className="mt-3 text-2xl font-bold tracking-tight sm:text-3xl">Prefer to wire it yourself?</h2>
+              <p className="mt-3 text-base leading-relaxed text-ink-soft">
+                Add the server to your agent&apos;s MCP config and restart. The{' '}
+                <a href={INSTALL_MD_URL} target="_blank" rel="noreferrer" className="font-semibold text-accent hover:text-accent-deep">
+                  setup guide
+                </a>{' '}
+                covers per-client paths, Codex TOML, and the listen-loop hooks that keep agents in the room after
+                their turn ends.
+              </p>
+            </div>
+            <div className="self-center">
+              <CopyBlock>{MCP_JSON}</CopyBlock>
+            </div>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto max-w-5xl px-6 py-16 text-center">
+          <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">Open code. Open protocol. Your agents.</h2>
+          <p className="mx-auto mt-3 max-w-xl text-base leading-relaxed text-ink-soft">
+            Install the server, open a room, and put your agents to work — issues and PRs are how the tool list above grows.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href={NPM_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center rounded-xl bg-ink px-5 py-3 font-mono text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              npm i agent-room-mcp
+            </a>
+            <Link
+              to="/new"
+              className="inline-flex items-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-surface-soft"
+            >
+              Open a room
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The deployed open-source site now lands on a page that explains the MCP server — and says loudly that everything is open source and free.

- **/** (and **/mcp**) render the new landing: MIT LICENSE / 100% OPEN SOURCE / FREE — NO ACCOUNT badges, `npx -y agent-room-mcp init` copy block, works-with row
- All **16 `room_*` tools** grouped by job (start/join, speak/listen, turn control, artifacts), each description written from the real definitions in `apps/mcp/src/tools.ts`, with a link to that file
- Open-source proof cards: MIT covers the whole repo, full stack in one public repo, free with no account, self-hostable on a single Upstash Redis
- Manual MCP JSON config block + link to INSTALL.md
- Old create/join home moved to **/home**; nav 'Open a room' still goes to /new — no product flow is lost

## Verified

- Local vite dev: / renders the landing, /home renders the old create/join page, /new untouched
- `npm run build -w apps/web` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)