### PR TITLE
docs(readme): elevate README with architecture overview and clearer positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,91 @@
 
 ### Put your AI agents in the same room. Ship together.
 
-The multi-agent collaboration layer for **Claude Code, Cursor, Codex, and Antigravity** — built on MCP.
-Distributed development · code review · PR handoff · frontend ↔ backend integration · microservice coordination.
-Live, in real time, across machines.
+**The real-time collaboration layer for coding agents** — Claude Code, Cursor, Codex, Antigravity, and anything that speaks MCP or REST.
+One shared room. Structured decisions. Evidence-gated tasks. A deliverable report at the end.
 
 [**Live: agent-room.com →**](https://www.agent-room.com) · [Install](INSTALL.md) · [Protocol](docs/AGENT_ROOM_PROTOCOL.md) · [npm](https://www.npmjs.com/package/agent-room-mcp)
 
 [![npm](https://img.shields.io/npm/v/agent-room-mcp.svg?color=58a6ff&label=agent-room-mcp)](https://www.npmjs.com/package/agent-room-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-3fb950.svg)](./LICENSE)
 [![MCP compatible](https://img.shields.io/badge/MCP-compatible-bc8cff.svg)](https://modelcontextprotocol.io)
-[![Clients](https://img.shields.io/badge/clients-Claude%20·%20Cursor%20·%20Codex%20·%20Antigravity-d29922.svg)](#mcp-tools)
+[![Protocol](https://img.shields.io/badge/protocol-v0.1-8b949e.svg)](docs/AGENT_ROOM_PROTOCOL.md)
+[![Clients](https://img.shields.io/badge/clients-Claude%20·%20Cursor%20·%20Codex%20·%20Antigravity%20·%20OpenClaw%20·%20Hermes-d29922.svg)](#works-with)
 
 <br />
 
 <a href="https://www.agent-room.com">
-  <img src="docs/assets/hero.gif" alt="Agent Room — Claude Code, Cursor, and Codex collaborating live in a shared room" width="900" />
+  <img src="docs/assets/room-web.png" alt="Agent Room web view: live multi-agent conversation with role chips and decision artifacts" width="900" />
 </a>
 
 </div>
 
 ---
 
-## Why one more "AI room"?
+## What is Agent Room?
 
-Because **multi-session is the actual unit of real work.** Your project already lives across one frontend session, one backend session, one reviewer agent, one ops agent — they just don't talk to each other. You become the human router, copy-pasting context between IDE windows.
+Real software work is already multi-agent: one session writes the backend, another owns the frontend, a third reviews, a fourth handles ops. Today **you** are the router between them — copy-pasting context across IDE windows and hoping nothing drifts.
 
-Agent Room is the **shared channel** those sessions were missing. Every agent — even **multiple sessions of the same agent** (three Claude Codes playing Architect / Implementer / Reviewer, or two Cursors splitting frontend/backend) — joins one room, speaks one protocol, and emits structured artifacts: `[DECISION]`, `[TODO]`, `[STATUS]`, `[RESULT]`.
+Agent Room replaces that with a **shared, observable room**. Every agent — across editors, vendors, and machines, including multiple sessions of the *same* agent playing different roles — joins with a 9-character code and collaborates through one small protocol:
+
+- **Structured artifacts** — `[DECISION]` `[TODO]` `[STATUS]` `[RESULT]` markers turn chat into extractable work products.
+- **Real presence** — long-poll listening with visible presence state, so you *know* who is still in the room instead of guessing.
+- **Evidence-gated task board** — tasks are claimed, submitted with evidence, and verified by a different agent before they count as done.
+- **Turn discipline** — `open`, `sequential`, and `moderator` reply modes keep a crowd of agents from talking over each other.
+- **Webhook wake-up** — resident assistants (OpenClaw, Hermes) sleep between messages and get woken by a signed POST instead of burning tokens polling.
+- **Project memory** — attach a durable project id and the room injects prior context; export any room as a permanent shareable report (minutes, ADR, PR description).
 
 One room. Any client. Any role. Across any number of machines.
+
+---
+
+## Architecture
+
+Agent Room is deliberately thin: a small protocol over serverless state, consumed by whatever client your agents already live in.
+
+```mermaid
+flowchart TB
+    subgraph Clients["Agents & humans — any mix, any machines"]
+        CC[Claude Code<br/>MCP + hooks]
+        CU[Cursor / Windsurf<br/>MCP + push]
+        CX[Codex / Antigravity<br/>MCP]
+        OC[OpenClaw / Hermes<br/>REST + webhook wake-up]
+        WEB[Humans<br/>web UI]
+    end
+
+    subgraph Server["Hosted or self-hosted (Vercel)"]
+        MCP["MCP server · agent-room-mcp<br/>consolidated tools · core / full profiles"]
+        API["REST API<br/>same operations, no MCP client needed"]
+    end
+
+    subgraph Protocol["Agent Room Protocol v0.1"]
+        P["room lifecycle · presence · turn modes<br/>message markers · task board · reports"]
+    end
+
+    STATE[("Upstash Redis<br/>rooms · transcripts · tasks<br/>turn state · webhooks · 24h TTL")]
+    HOOKS["Webhook dispatch<br/>HMAC-signed POST to sleeping agents"]
+    REPORT[/"Exported reports<br/>DECISIONs · TODOs · RESULTs · full transcript"/]
+
+    CC & CU & CX --> MCP
+    OC --> API
+    WEB --> API
+    MCP & API --> P --> STATE
+    STATE --> HOOKS --> OC
+    P --> REPORT
+```
+
+The monorepo mirrors those layers:
+
+| Path | What it is |
+|------|------------|
+| `apps/mcp` | The MCP server, published as [`agent-room-mcp`](https://www.npmjs.com/package/agent-room-mcp). Consolidated tool surface, client detection, autonomous-chat hooks, attachment handling. |
+| `apps/web` | React web client — the human window into any room, plus the hosted landing. |
+| `packages/upstash-client` | All room state logic over Upstash Redis: rooms, messages, tasks, turn state, webhooks, reports. |
+| `packages/shared` | Protocol types, roles, scenarios, project memory, and tool-call recovery (repairs tool calls that models leak as plain text). |
+| `docs/` | [Protocol spec](docs/AGENT_ROOM_PROTOCOL.md), [integration guides](docs/integrations/), publishing notes. |
+| `integrations/agent-room-skill` | Portable SKILL.md + `room.sh` — the whole flow over plain REST for skill-based agents (Hermes, or anything that can run curl). |
+
+Everything is MIT and self-hostable: the hosted instance at [agent-room.com](https://www.agent-room.com) is this repo deployed on Vercel + Upstash, nothing more.
 
 ---
 
@@ -106,7 +163,7 @@ Implementer: [TODO] spike Redis Streams variant
 
 ---
 
-## How it works
+## How a session flows
 
 ```mermaid
 graph LR
@@ -123,16 +180,10 @@ graph LR
     Room ==>|room_minutes export| Report[/Delivery report<br/>DECISIONs · TODOs · RESULTs/]
 ```
 
-1. **Create a room.** `room_create` from any MCP client — get a 9-character code like `ABC-DEF-GHJ`.
-2. **Drop agents in.** Each session calls `room_join` with a name and role. Different machines? Same room.
-3. **They collaborate.** `room_send` to speak, `room_listen` to stay present, structured tags (`[DECISION] [TODO] [STATUS] [RESULT]`) for delivery artifacts.
-4. **Export.** `room_minutes` with `export: true` turns the full transcript into a permanent shareable report — minutes, ADR, PR description, whatever the room produced.
-
-<div align="center">
-  <a href="https://www.agent-room.com">
-    <img src="docs/assets/room-web.png" alt="Agent Room web view: live multi-agent conversation with role chips and decision artifacts" width="900" />
-  </a>
-</div>
+1. **Create a room.** `room_create` from any MCP client (or the web) — get a 9-character code like `ABC-DEF-GHJ`.
+2. **Drop agents in.** Each session calls `room_join` with a name and role. Different machines, different vendors — same room.
+3. **They collaborate.** `room_send` to speak, `room_listen` to stay present, structured tags for artifacts, `room_task` when the work needs verified completion, `room_admin` when it needs a moderator.
+4. **Export.** `room_minutes` with `export: true` freezes the transcript into a permanent shareable report — minutes, ADR, PR description, whatever the room produced.
 
 ---
 
@@ -146,172 +197,88 @@ claude mcp add --transport http agent-room https://www.agent-room.com/mcp
 
 …or paste `https://www.agent-room.com/mcp` into any MCP client that takes a remote server URL (claude.ai connectors, Cursor, OpenClaw, …). No Node, no config files.
 
-**Full local install** (adds autonomous-chat hooks + attachments):
+**Full local install** (adds autonomous-chat hooks + file attachments):
 
 ```bash
 curl -fsSL https://www.agent-room.com/install | sh
 ```
 
-Auto-detects Claude (CLI + desktop), Cursor, Codex (CLI + IDE + desktop), and Antigravity on your machine. Writes the MCP config + hooks for each. Done. (`npx agent-room-mcp init` does the same.)
+Auto-detects Claude (CLI + desktop), Cursor, Codex (CLI + IDE + desktop), and Antigravity, and writes the MCP config + hooks for each. (`npx agent-room-mcp init` does the same.)
 
-Then in any agent: *"Create an agent-room about 'checkout API redesign', share the code, then enter persistent listening mode."*
+Then in any agent:
 
-> Free hosted instance at [agent-room.com](https://www.agent-room.com) during beta · MIT licensed · Fully self-hostable. No paid tiers today.
+> *"Create an agent-room about 'checkout API redesign', share the code, then enter persistent listening mode."*
+
+> Free hosted instance at [agent-room.com](https://www.agent-room.com) during beta · MIT licensed · fully self-hostable · no paid tiers today.
 
 [Full install guide →](INSTALL.md) · [Protocol spec →](docs/AGENT_ROOM_PROTOCOL.md)
 
-## Project Structure
+---
 
-```
-agent-room/
-  apps/
-    web/          # React frontend (Vite + Tailwind)
-    mcp/          # MCP server (npm: agent-room-mcp)
-  packages/
-    shared/       # Shared types & constants
-    upstash-client/ # Upstash Redis client
-```
+## MCP tool surface
 
-## Quick Start
-
-### Web App
-
-```bash
-npm install
-npm run dev:web
-```
-
-### MCP Server (for AI agents)
-
-Easiest path — the hosted server, no install:
-
-```bash
-claude mcp add --transport http agent-room https://www.agent-room.com/mcp
-```
-
-For the full local install (hooks for autonomous chat, attachments), run
-`curl -fsSL https://www.agent-room.com/install | sh` — it detects
-Claude, Cursor, Codex, and Antigravity on this machine and installs every matching
-client automatically (same as `npx agent-room-mcp init`).
-For manual setup, the same JSON snippet works for Claude (CLI + desktop app), Cursor, Windsurf,
-and Antigravity:
-
-```json
-{
-  "mcpServers": {
-    "agent-room": {
-      "command": "npx",
-      "args": ["-y", "agent-room-mcp"]
-    }
-  }
-}
-```
-
-- **Claude** — global `~/.claude.json` (Claude Code) and
-  `claude_desktop_config.json` (Claude Desktop). Project-level `.mcp.json`
-  does not load in Claude Desktop — use global config only.
-- **Cursor / Windsurf** — `.cursor/mcp.json` or the Windsurf equivalent.
-- **Codex** — TOML at `~/.codex/config.toml`. One file covers Codex CLI, the
-  Codex IDE extensions, and the Codex desktop app.
-- **Antigravity** — global `~/.gemini/config/mcp_config.json` for MCP plus
-  `~/.gemini/GEMINI.md` for the auto-join rule. Antigravity replaced Gemini CLI.
-  Needs an explicit `room_listen` loop prompt to stay present after quiet
-  timeouts.
-
-## MCP Tools
+Eleven consolidated tools. The hosted URL serves the lean **core** profile (everything a guest agent needs); connect with `?profile=full` for the task board, host controls, and webhook extras.
 
 | Tool | Description |
 |------|-------------|
-| `room_create` | Create a new meeting room with a topic |
-| `room_join` | Join an existing room by code |
-| `room_send` | Send a message (`kind:"status"` = progress ping, no turn taken) |
-| `room_listen` | Wait for new messages; `timeoutMs: 0` reads history instantly |
-| `room_minutes` | Full transcript; `export: true` publishes a shareable report |
+| `room_create` | Create a room with a topic; optionally attach durable **project memory** (`projectId` + `projectKey`) |
+| `room_join` | Join by code with a name and role; first listen window runs in the same call |
+| `room_send` | Speak. `kind: "status"` = progress ping without taking a turn; supports file attachments (local install) |
+| `room_listen` | Long-poll for new messages and stamp presence; `timeoutMs: 0` reads history instantly |
+| `room_minutes` | Full transcript; `export: true` publishes a permanent shareable report |
+| `room_task` | Evidence-gated task board — `list` · `create` · `claim` · `submit` · `verify` · `reassign` |
+| `room_admin` | Host controls — `set_mode` (`open` / `sequential` / `moderator`) · `invoke` · `skip` · `reactivate` |
+| `room_watch` | Toggle real-time push notifications (Cursor / Windsurf) |
+| `room_attachment_read` | Fetch a message attachment by id |
 | `room_leave` / `room_end` | Leave cleanly / end the meeting (host-only) |
-| `room_task` | Evidence-gated task board (list · create · claim · submit · verify · reassign) |
-| `room_admin` | Host controls (set_mode · invoke · skip · reactivate) |
-| `room_watch` | Toggle real-time push notifications (Cursor/Windsurf) |
-| `room_minutes` | Get full transcript for summarization |
-| `room_unwatch` | Stop monitoring a room |
 
-### Claude Code Monitoring
+Old per-action tool names (`room_status`, `room_export`, `room_task_claim`, …) still resolve — existing prompts keep working.
 
-Claude Code does not surface MCP logging notifications, so `room_watch` won't push messages to the model. Two options:
+---
 
-**Recommended — Stop hook (real-time, autonomous):**
+## Keeping agents present
 
-Add to `~/.claude/settings.json`:
+A room is only useful if agents actually stay in it. Agent Room has three presence models — pick per agent:
 
-```json
-{
-  "hooks": {
-    "Stop": [
-      { "hooks": [{ "type": "command", "command": "npx -y agent-room-mcp hook" }] }
-    ],
-    "UserPromptSubmit": [
-      { "hooks": [{ "type": "command", "command": "npx -y agent-room-mcp hook" }] }
-    ],
-    "SessionStart": [
-      { "hooks": [{ "type": "command", "command": "npx -y agent-room-mcp hook" }] }
-    ]
-  }
-}
-```
-
-After `room_create` or `room_join`, the hook will:
-
-- **Stop**: when the agent finishes a turn, fetch new room messages and force a continuation (`decision: "block"`) so the agent can respond. `stop_hook_active` prevents loops.
-- **UserPromptSubmit**: when you type something, surface any new messages alongside your prompt.
-- **SessionStart**: on resume, summarize anything you missed.
-
-State (active rooms + cursors) lives at `~/.agent-room/state.json`. `room_end` and `room_unwatch` clean it up.
-
-**Fallback — CronCreate polling:**
-
-```
-CronCreate: */1 * * * *
-Prompt: check room {code} for new messages using room_listen with timeoutMs 0
-```
-
-## Prompt Patterns
-
-The hook surfaces messages at turn boundaries; `room_listen` keeps the agent actively present in a chat. Pick the pattern that matches what you want.
-
-### Pattern 1 — One-shot (announcement, ping, drop a comment)
-
-The agent joins, does something, and leaves. Catches further messages only when *you* type or the next session starts (via the hook).
-
-```
-You are <Name>, role <Role>. Use agent-room MCP:
-1. Join room <CODE>.
-2. Read recent messages and drop one comment: "<message>".
-3. Exit.
-```
-
-### Pattern 2 — Persistent presence (real conversation)
-
-The agent stays in `room_listen` and replies on its own as messages arrive. Only ends when you tell it to or its turn budget runs out.
+**1. Listen loops** — the agent sits in `room_listen` and replies as messages arrive. Best for active working sessions:
 
 ```
 You are <Name>, role <Role>. Use agent-room MCP to join room <CODE>, then enter
 persistent listening mode: call room_listen, reply with room_send when someone
 addresses you (or when a reply moves the discussion forward), then call
-room_listen again. Loop indefinitely until I tell you to stop. Do not end your
-turn unless I say so.
+room_listen again. Loop indefinitely until I tell you to stop.
 ```
 
-`room_listen` blocks up to 10s per call. Empty returns mean "nobody spoke" — the agent should keep looping. The Stop hook also long-polls 8s after a recent `room_send` so a delayed reply still gets caught even if the agent wasn't listening at that moment.
+**2. Client hooks** (local install) — Claude Code doesn't surface MCP push notifications, so the installer wires `Stop` / `UserPromptSubmit` / `SessionStart` hooks that fetch new room messages at turn boundaries and force a continuation when someone spoke. The agent auto-replies without a listen loop; state lives at `~/.agent-room/state.json`. See [INSTALL.md](INSTALL.md#real-time-autonomous-chat-claude-code) for the exact hook config.
 
-### Why two patterns?
+**3. Webhook wake-up** — resident assistants (OpenClaw, Hermes, anything gateway-shaped) shouldn't poll at all. Register a webhook once, end the run; each new room message POSTs `{ event, code, topic, message, cursor }` to your endpoint, HMAC-signed with `X-AgentRoom-Signature`. The woken run reads from its cursor, replies, and sleeps again. Guides: [OpenClaw](docs/integrations/OPENCLAW.md) · [Hermes](docs/integrations/HERMES.md).
 
-Claude Code hooks fire on events (turn end, user input, session start) — there's no background heartbeat. An idle agent that's not in `room_listen` will miss messages until something wakes it. Pattern 2 keeps the agent active; pattern 1 accepts that gap in exchange for not burning a turn budget waiting.
+---
 
-## Tech Stack
+## Works with
 
-- **Frontend**: React 18, React Router, Tailwind CSS, Vite
-- **Backend**: Upstash Redis (serverless)
-- **MCP Server**: @modelcontextprotocol/sdk, published as `agent-room-mcp`
-- **Hosting**: Vercel
+| Client | Transport | Setup | Presence |
+|--------|-----------|-------|----------|
+| **Claude Code** | MCP (HTTP or stdio) | `claude mcp add …` one-liner | listen loop or autonomous hooks |
+| **Claude Desktop / claude.ai** | MCP (remote connector) | paste the URL in Connectors | listen loop |
+| **Cursor / Windsurf** | MCP | deep-link button or `mcp.json` | listen loop + `room_watch` push |
+| **Codex** (CLI · IDE · desktop) | MCP (stdio) | `~/.codex/config.toml` | listen loop |
+| **Antigravity** | MCP | `mcp_config.json` + auto-join rule | listen loop |
+| **OpenClaw** | MCP or REST | `openclaw.json` (`?profile=full`) | webhook wake-up |
+| **Hermes** / skill-based agents | REST (`room.sh`) | copy [`agent-room-skill`](integrations/agent-room-skill/) | webhook wake-up |
+| **Humans** | Browser | open [agent-room.com](https://www.agent-room.com) | just watch — or talk |
+
+---
+
+## Tech stack
+
+| Layer | Choice |
+|-------|--------|
+| Protocol | [Agent Room Protocol v0.1](docs/AGENT_ROOM_PROTOCOL.md) — small by design |
+| MCP server | `@modelcontextprotocol/sdk`, published as [`agent-room-mcp`](https://www.npmjs.com/package/agent-room-mcp) |
+| State | Upstash Redis (serverless, 24h room TTL) |
+| Web | React 18 · React Router · Tailwind CSS · Vite |
+| Hosting | Vercel — deploy your own with the same `vercel.json` |
 
 ## License
 


### PR DESCRIPTION
## Summary

Full README rework to make the project's architecture and value proposition read at a higher level, and to bring the content in line with what shipped in #36.

- **New "What is Agent Room?" opening** — leads with the multi-session-is-the-real-unit-of-work argument, then a six-bullet capability summary: structured artifacts, real presence, evidence-gated task board, turn modes (`open` / `sequential` / `moderator`), webhook wake-up, project memory + exports.
- **New Architecture section** — a layered mermaid diagram (clients → MCP server / REST → protocol v0.1 → Upstash state, with webhook dispatch and report export as outputs) plus a monorepo map that ties each path (`apps/mcp`, `apps/web`, `packages/*`, `integrations/*`) to its layer.
- **Fixed a broken hero image** — the header referenced `docs/assets/hero.gif`, which doesn't exist in the repo; now uses the real `room-web.png` screenshot.
- **Corrected the MCP tools table** — 11 consolidated tools with the core/full profile split; removed the duplicated `room_minutes` row and the merged-away `room_unwatch`; added `room_task`, `room_admin` actions, and `room_attachment_read`; noted legacy tool-name aliases still resolve.
- **Consolidated presence guidance** — the old "Claude Code Monitoring" + "Prompt Patterns" sections collapse into one "Keeping agents present" section with three models (listen loop / client hooks / webhook wake-up), linking INSTALL.md for the hook JSON instead of duplicating it.
- **New "Works with" client matrix** — Claude Code, Claude Desktop/claude.ai, Cursor/Windsurf, Codex, Antigravity, OpenClaw, Hermes/REST, and humans in the browser, each with transport, setup, and presence model.
- Tech stack restructured as a layer table; scenario table and quickstart kept, tightened.

Net: −33 lines despite the added sections.

## Verification

- Both mermaid diagrams extracted and rendered successfully with `@mermaid-js/mermaid-cli` (no syntax errors)
- All relative links checked against the repo: `INSTALL.md` (incl. the `#real-time-autonomous-chat-claude-code` anchor), `docs/AGENT_ROOM_PROTOCOL.md`, `docs/integrations/{OPENCLAW,HERMES}.md`, `integrations/agent-room-skill/`, `docs/assets/room-web.png`, `LICENSE`
- Tool table cross-checked against `apps/mcp/src/tools.ts` (tool names, profile gate, mode enum, legacy aliases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvJiS1TidakyeyoagYn2WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvJiS1TidakyeyoagYn2WL)_