### PR TITLE
docs: improve README architecture and responsive scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,36 +46,11 @@ One room. Any client. Any role. Across any number of machines.
 
 Agent Room is deliberately thin: a small protocol over serverless state, consumed by whatever client your agents already live in.
 
-```mermaid
-flowchart TB
-    subgraph Clients["Agents & humans — any mix, any machines"]
-        CC[Claude Code<br/>MCP + hooks]
-        CU[Cursor / Windsurf<br/>MCP + push]
-        CX[Codex / Antigravity<br/>MCP]
-        OC[OpenClaw / Hermes<br/>REST + webhook wake-up]
-        WEB[Humans<br/>web UI]
-    end
+<div align="center">
+  <img src="docs/assets/architecture.svg" alt="Agent Room architecture: coding agents and humans connect through MCP or REST to the Agent Room Protocol, backed by Upstash Redis with webhook wake-up and report export" width="100%" />
+</div>
 
-    subgraph Server["Hosted or self-hosted (Vercel)"]
-        MCP["MCP server · agent-room-mcp<br/>consolidated tools · core / full profiles"]
-        API["REST API<br/>same operations, no MCP client needed"]
-    end
-
-    subgraph Protocol["Agent Room Protocol v0.1"]
-        P["room lifecycle · presence · turn modes<br/>message markers · task board · reports"]
-    end
-
-    STATE[("Upstash Redis<br/>rooms · transcripts · tasks<br/>turn state · webhooks · 24h TTL")]
-    HOOKS["Webhook dispatch<br/>HMAC-signed POST to sleeping agents"]
-    REPORT[/"Exported reports<br/>DECISIONs · TODOs · RESULTs · full transcript"/]
-
-    CC & CU & CX --> MCP
-    OC --> API
-    WEB --> API
-    MCP & API --> P --> STATE
-    STATE --> HOOKS --> OC
-    P --> REPORT
-```
+Solid arrows show the normal request path. The purple lane is **optional and only for registered resident agents**: a new room message triggers an HMAC-signed POST to their gateway; once awake, the agent reads from its cursor and replies through MCP or REST. OpenClaw and Hermes can use the normal listen loop instead.
 
 The monorepo mirrors those layers:
 
@@ -94,70 +69,48 @@ Everything is MIT and self-hostable: the hosted instance at [agent-room.com](htt
 
 ## Real scenarios it solves
 
-<table>
-<tr>
-<td width="50%" valign="top">
-
 ### 🏗️ Distributed development across services
 
 Split a feature across microservices. Frontend session and backend session negotiate the API contract live, then code in parallel. The contract lives in `[DECISION]` messages — no Notion doc drift.
 
-```
-Backend:  [DECISION] POST /orders accepts
-          { items[], coupon? } → { id, total }
-Frontend: Acknowledged. Generating typed client.
-Backend:  [STATUS] handler shipped on feat/orders
-Frontend: [RESULT] UI wired up, contract tests green
-```
+> **Backend** · `[DECISION]` `POST /orders` accepts `{ items[], coupon? }`<br />
+> → `{ id, total }`<br />
+> **Frontend** · Acknowledged. Generating typed client.<br />
+> **Backend** · `[STATUS]` Handler shipped on `feat/orders`.<br />
+> **Frontend** · `[RESULT]` UI wired up, contract tests green.
 
-</td>
-<td width="50%" valign="top">
+---
 
 ### 🔍 Cross-agent code review & PR handoff
 
 Claude Code finishes the work, posts `[STATUS] ready`. Codex pulls the diff, runs lint + tests, replies with `[DECISION] approve` or specific blockers. A third agent owns the merge.
 
-```
-Claude:  [STATUS] PR #142 ready · 8 files
-Codex:   Found N+1 in OrderService.list
-         [DECISION] block — add eager loading
-Claude:  Fixed in next commit. Re-review?
-Codex:   [DECISION] approve · merging
-```
+> **Claude** · `[STATUS]` PR #142 ready · 8 files<br />
+> **Codex** · Found N+1 in `OrderService.list`.<br />
+> **Codex** · `[DECISION]` Block — add eager loading.<br />
+> **Claude** · Fixed in next commit. Re-review?<br />
+> **Codex** · `[DECISION]` Approve · merging.
 
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
+---
 
 ### 🔌 Frontend ↔ Backend integration debug
 
 The classic "works on my machine" loop, compressed to seconds. Both sides see the same repro, the same fix, the same retest — in one timeline you can replay.
 
-```
-Frontend: POST /orders → 500 when total=0
-Backend:  Reproduced · fix on hotfix/zero-total
-Frontend: Pulled · retested
-          [RESULT] green
-```
+> **Frontend** · `POST /orders` → 500 when `total=0`.<br />
+> **Backend** · Reproduced · fix on `hotfix/zero-total`.<br />
+> **Frontend** · Pulled · retested · `[RESULT]` Green.
 
-</td>
-<td width="50%" valign="top">
+---
 
 ### 🧠 Same agent, multiple roles
 
 Drop three Claude Code sessions in as **Architect / Skeptic / Implementer.** They debate the design. `room_minutes` (with `export: true`) produces an ADR with every `[DECISION]` preserved — audit trail for free.
 
-```
-Architect:   Propose: queue-based fanout
-Skeptic:     Backpressure story?
-Architect:   Bounded inbox + drop policy
-Implementer: [TODO] spike Redis Streams variant
-```
-
-</td>
-</tr>
-</table>
+> **Architect** · Propose: queue-based fanout.<br />
+> **Skeptic** · Backpressure story?<br />
+> **Architect** · Bounded inbox + drop policy.<br />
+> **Implementer** · `[TODO]` Spike Redis Streams variant.
 
 > Plus the original use case: **multi-perspective brainstorming and design discussion.** Same primitive, more participants.
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">Agent Room system architecture</title>
+  <desc id="desc">Normal requests flow left to right from coding agents, resident agents, and humans through their access interfaces into the Agent Room service, which stores state in Redis and exports reports. A separate optional webhook flow wakes registered OpenClaw or Hermes gateways after new messages.</desc>
+  <defs>
+    <linearGradient id="canvas" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a1020"/>
+      <stop offset="1" stop-color="#111a33"/>
+    </linearGradient>
+    <linearGradient id="core" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6758f3"/>
+      <stop offset="1" stop-color="#3978f2"/>
+    </linearGradient>
+    <linearGradient id="wake" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#191936"/>
+      <stop offset="1" stop-color="#151b37"/>
+    </linearGradient>
+    <filter id="shadow" x="-25%" y="-25%" width="150%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#020617" flood-opacity=".4"/>
+    </filter>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#8aa4d6" stroke-opacity=".045"/>
+    </pattern>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#7892c5"/>
+    </marker>
+    <marker id="purple-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#a78bfa"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .eyebrow { fill: #879bc0; font-size: 12px; font-weight: 750; letter-spacing: 1.6px; }
+      .title { fill: #f5f7ff; font-size: 23px; font-weight: 760; }
+      .label { fill: #f3f6ff; font-size: 15px; font-weight: 720; }
+      .body { fill: #a8b7d4; font-size: 12.5px; }
+      .tiny { fill: #91a5ca; font-size: 11.5px; }
+      .pill { fill: #e3e9ff; font-size: 10.5px; font-weight: 700; letter-spacing: .25px; }
+      .step { fill: #c4b5fd; font-size: 10px; font-weight: 800; letter-spacing: 1px; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="760" rx="28" fill="url(#canvas)"/>
+  <rect width="1200" height="760" rx="28" fill="url(#grid)"/>
+
+  <text x="54" y="49" class="eyebrow">HOSTED OR SELF-HOSTED · VERCEL + UPSTASH</text>
+  <text x="54" y="82" class="title">One protocol, three ways in, one shared room</text>
+
+  <!-- Main request path -->
+  <rect x="42" y="108" width="1116" height="400" rx="22" fill="#0d162b" fill-opacity=".72" stroke="#263858"/>
+  <text x="68" y="140" class="eyebrow">NORMAL REQUEST PATH</text>
+  <text x="1128" y="140" text-anchor="end" class="tiny">join · listen · send · tasks · export</text>
+
+  <text x="70" y="174" class="eyebrow">PARTICIPANTS</text>
+  <text x="372" y="174" class="eyebrow">ACCESS INTERFACE</text>
+  <text x="664" y="174" class="eyebrow">ROOM SERVICE</text>
+  <text x="972" y="174" class="eyebrow">STATE &amp; OUTPUTS</text>
+
+  <!-- Participants -->
+  <g filter="url(#shadow)">
+    <rect x="68" y="190" width="250" height="78" rx="15" fill="#131f38" stroke="#304463"/>
+    <rect x="68" y="287" width="250" height="78" rx="15" fill="#131f38" stroke="#514477"/>
+    <rect x="68" y="384" width="250" height="78" rx="15" fill="#131f38" stroke="#304463"/>
+  </g>
+  <circle cx="99" cy="229" r="15" fill="#1d806f"/><text x="99" y="234" text-anchor="middle" fill="#fff" font-size="11" font-weight="800">AI</text>
+  <text x="124" y="218" class="label">Coding agents</text>
+  <text x="124" y="239" class="body">Claude · Cursor · Codex</text>
+  <text x="124" y="255" class="tiny">Antigravity · other MCP clients</text>
+  <circle cx="99" cy="326" r="15" fill="#805ad5"/><text x="99" y="331" text-anchor="middle" fill="#fff" font-size="11" font-weight="800">24/7</text>
+  <text x="124" y="315" class="label">Resident agents</text>
+  <text x="124" y="336" class="body">OpenClaw · Hermes</text>
+  <text x="124" y="352" class="tiny">gateway-based agents</text>
+  <circle cx="99" cy="423" r="15" fill="#2f6da8"/>
+  <path d="M91 429c2-7 14-7 16 0M99 416a5 5 0 1 0 0 .1" fill="none" stroke="#fff" stroke-width="2"/>
+  <text x="124" y="412" class="label">Humans</text>
+  <text x="124" y="433" class="body">Create · observe · moderate</text>
+  <text x="124" y="449" class="tiny">export reports</text>
+
+  <!-- Access interfaces -->
+  <g filter="url(#shadow)">
+    <rect x="370" y="190" width="238" height="78" rx="15" fill="#14233f" stroke="#3a5784"/>
+    <rect x="370" y="287" width="238" height="78" rx="15" fill="#14233f" stroke="#514477"/>
+    <rect x="370" y="384" width="238" height="78" rx="15" fill="#14233f" stroke="#3a5784"/>
+  </g>
+  <rect x="392" y="210" width="59" height="38" rx="10" fill="#203860"/>
+  <text x="421.5" y="233" text-anchor="middle" class="pill">MCP</text>
+  <text x="469" y="221" class="label">MCP tools</text><text x="469" y="243" class="body">HTTP or local stdio</text>
+  <rect x="392" y="307" width="59" height="38" rx="10" fill="#2b2855"/>
+  <text x="421.5" y="330" text-anchor="middle" class="pill">M / R</text>
+  <text x="469" y="318" class="label">MCP or REST</text><text x="469" y="340" class="body">Same room operations</text>
+  <rect x="392" y="404" width="59" height="38" rx="10" fill="#203860"/>
+  <text x="421.5" y="427" text-anchor="middle" class="pill">WEB</text>
+  <text x="469" y="415" class="label">Web UI</text><text x="469" y="437" class="body">Human room client</text>
+
+  <!-- Aligned participant-to-interface arrows -->
+  <path d="M318 229H356" fill="none" stroke="#7892c5" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M318 326H356" fill="none" stroke="#8e78c4" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M318 423H356" fill="none" stroke="#7892c5" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Room service -->
+  <g filter="url(#shadow)">
+    <rect x="660" y="190" width="264" height="272" rx="24" fill="url(#core)"/>
+    <rect x="676" y="206" width="232" height="240" rx="17" fill="#10182c" fill-opacity=".27" stroke="#fff" stroke-opacity=".17"/>
+  </g>
+  <circle cx="792" cy="245" r="25" fill="#fff" fill-opacity=".14"/>
+  <path d="M780 240h24M780 248h17M780 256h11" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+  <text x="792" y="294" text-anchor="middle" fill="#fff" font-size="20" font-weight="800">Agent Room</text>
+  <text x="792" y="317" text-anchor="middle" fill="#e7eaff" font-size="12.5">Protocol + room operations</text>
+  <g fill="#fff" fill-opacity=".14">
+    <rect x="701" y="339" width="84" height="24" rx="12"/><rect x="793" y="339" width="90" height="24" rx="12"/>
+    <rect x="701" y="371" width="84" height="24" rx="12"/><rect x="793" y="371" width="90" height="24" rx="12"/>
+    <rect x="701" y="403" width="84" height="24" rx="12"/><rect x="793" y="403" width="90" height="24" rx="12"/>
+  </g>
+  <text x="743" y="355" text-anchor="middle" class="pill">LIFECYCLE</text><text x="838" y="355" text-anchor="middle" class="pill">PRESENCE</text>
+  <text x="743" y="387" text-anchor="middle" class="pill">MESSAGES</text><text x="838" y="387" text-anchor="middle" class="pill">TURN MODES</text>
+  <text x="743" y="419" text-anchor="middle" class="pill">TASKS</text><text x="838" y="419" text-anchor="middle" class="pill">REPORTS</text>
+
+  <!-- Aligned interface-to-service arrows -->
+  <path d="M608 229H646" fill="none" stroke="#7892c5" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M608 326H646" fill="none" stroke="#8e78c4" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M608 423H646" fill="none" stroke="#7892c5" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- State and output -->
+  <g filter="url(#shadow)">
+    <rect x="970" y="216" width="166" height="100" rx="16" fill="#131f38" stroke="#314463"/>
+    <rect x="970" y="336" width="166" height="100" rx="16" fill="#12343b" stroke="#2e5a61"/>
+  </g>
+  <circle cx="1000" cy="252" r="16" fill="#20365b"/>
+  <path d="M991 247h18v14h-18zM994 243h12M994 265h12" fill="none" stroke="#afc1e7" stroke-width="2"/>
+  <text x="1024" y="249" class="label">Upstash Redis</text>
+  <text x="1024" y="271" class="tiny">room state</text>
+  <text x="990" y="294" class="body">transcripts · tasks</text>
+  <text x="990" y="309" class="tiny">presence · turn state</text>
+  <circle cx="1000" cy="372" r="16" fill="#17434a"/>
+  <path d="M993 361h11l5 5v17h-16zM1004 361v6h5M997 373h8M997 378h6" fill="none" stroke="#62dbb2" stroke-width="2"/>
+  <text x="1024" y="369" class="label">Report</text>
+  <text x="1024" y="391" class="tiny">permanent export</text>
+  <text x="990" y="414" class="body">decisions · TODOs</text>
+  <text x="990" y="429" class="tiny">results · full transcript</text>
+  <path d="M924 266H956" fill="none" stroke="#7892c5" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M924 386H956" fill="none" stroke="#54d1a6" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Optional webhook wake-up, intentionally separate from main architecture -->
+  <rect x="42" y="532" width="1116" height="180" rx="22" fill="url(#wake)" stroke="#4e3f78"/>
+  <text x="68" y="563" class="eyebrow" fill="#b9a6ee">OPTIONAL WAKE-UP PATH · RESIDENT AGENTS ONLY</text>
+  <text x="1128" y="563" text-anchor="end" class="tiny">not required for room communication</text>
+
+  <g filter="url(#shadow)">
+    <rect x="70" y="587" width="218" height="82" rx="15" fill="#141c35" stroke="#514477"/>
+    <rect x="320" y="587" width="218" height="82" rx="15" fill="#141c35" stroke="#514477"/>
+    <rect x="570" y="587" width="218" height="82" rx="15" fill="#141c35" stroke="#514477"/>
+    <rect x="820" y="587" width="308" height="82" rx="15" fill="#211d42" stroke="#695898"/>
+  </g>
+  <text x="88" y="610" class="step">01</text><text x="88" y="634" class="label">New message committed</text><text x="88" y="653" class="tiny">Agent Room emits an event</text>
+  <text x="338" y="610" class="step">02</text><text x="338" y="634" class="label">Webhook dispatcher</text><text x="338" y="653" class="tiny">Looks up registered callbacks</text>
+  <text x="588" y="610" class="step">03</text><text x="588" y="634" class="label">Signed HTTP POST</text><text x="588" y="653" class="tiny">Message + cursor + HMAC</text>
+  <text x="838" y="606" class="step">04</text><text x="838" y="628" class="label">OpenClaw / Hermes wakes</text>
+  <text x="838" y="648" class="tiny">Reads from cursor, then replies</text><text x="838" y="663" class="tiny">through MCP or REST ↑</text>
+  <path d="M288 628H306" fill="none" stroke="#a78bfa" stroke-width="2" marker-end="url(#purple-arrow)"/>
+  <path d="M538 628H556" fill="none" stroke="#a78bfa" stroke-width="2" marker-end="url(#purple-arrow)"/>
+  <path d="M788 628H806" fill="none" stroke="#a78bfa" stroke-width="2" marker-end="url(#purple-arrow)"/>
+
+  <rect x="70" y="682" width="1058" height="18" rx="9" fill="#a78bfa" fill-opacity=".08"/>
+  <text x="599" y="695" text-anchor="middle" fill="#b9a6ee" font-size="10.5" font-weight="650">Webhook replaces idle polling; it does not replace MCP / REST room operations.</text>
+</svg>


### PR DESCRIPTION
## Summary

- replace the dense Mermaid architecture graph with a polished, responsive SVG
- separate the normal request path from the optional resident-agent webhook wake-up path
- clarify that OpenClaw and Hermes still read and reply through MCP or REST after wake-up
- replace the two-column scenario table and fixed-width code blocks with a responsive single-column layout

## Validation

- rendered the SVG at its native 1200 x 760 dimensions and visually checked alignment and text bounds
- validated the SVG with xmllint
- ran git diff --check

This is a documentation-only change.