### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ One shared room. Structured decisions. Evidence-gated tasks. A deliverable repor
 [![npm](https://img.shields.io/npm/v/agent-room-mcp.svg?color=58a6ff&label=agent-room-mcp)](https://www.npmjs.com/package/agent-room-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-3fb950.svg)](./LICENSE)
 [![MCP compatible](https://img.shields.io/badge/MCP-compatible-bc8cff.svg)](https://modelcontextprotocol.io)
+[![MCP status](https://mcpvitals.com/badge/ad6e0e62d4.svg)](https://mcpvitals.com/status/ad6e0e62d4)
 [![Protocol](https://img.shields.io/badge/protocol-v0.1-8b949e.svg)](docs/AGENT_ROOM_PROTOCOL.md)
 [![Clients](https://img.shields.io/badge/clients-Claude%20·%20Cursor%20·%20Codex%20·%20Antigravity%20·%20OpenClaw%20·%20Hermes-d29922.svg)](#works-with)
 


### PR DESCRIPTION
Hi 👋

I built [MCP Vitals](https://mcpvitals.com) (health monitoring for MCP servers) and set up a free public monitor for Agent Room's hosted endpoint (`agent-room.com/mcp`) — the real `initialize → tools/list` handshake, currently healthy with 7 tools.

This PR adds a small live status badge so your users can see the server is up at a glance (it also catches downtime + tool-schema drift):

[![MCP status](https://mcpvitals.com/badge/ad6e0e62d4.svg)](https://mcpvitals.com/status/ad6e0e62d4)

Free, no signup to view, links to a public uptime page. Close it if it's not for you — no problem. Love the shared-agent-room idea 🙏
