### PR TITLE
Add durable room persistence seam

### DIFF
--- a/.github/workflows/room-persistence.yml
+++ b/.github/workflows/room-persistence.yml
@@ -1,0 +1,39 @@
+name: room-persistence
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ordered-build-and-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.10-alpine
+        env:
+          POSTGRES_USER: agent_room
+          POSTGRES_PASSWORD: agent_room_test
+          POSTGRES_DB: agent_room_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U agent_room -d agent_room_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      TEST_POSTGRES_URL: postgresql://agent_room:agent_room_test@127.0.0.1:5432/agent_room_test
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Ordered workspace build
+        run: npm run build:ordered
+      - name: Apply reviewed Postgres migration explicitly
+        run: npm run migrate:postgres -w packages/room-persistence
+      - name: Workspace rollup with Postgres integration
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The monorepo mirrors those layers:
 | `apps/mcp` | The MCP server, published as [`agent-room-mcp`](https://www.npmjs.com/package/agent-room-mcp). Consolidated tool surface, client detection, autonomous-chat hooks, attachment handling. |
 | `apps/web` | React web client — the human window into any room, plus the hosted landing. |
 | `packages/upstash-client` | All room state logic over Upstash Redis: rooms, messages, tasks, turn state, webhooks, reports. |
+| `packages/room-persistence` | Server-side persistence seam plus Redis-compatible and durable Postgres adapters. Redis remains the default; see [the storage design](docs/durable-room-storage.md). |
 | `packages/shared` | Protocol types, roles, scenarios, project memory, and tool-call recovery (repairs tool calls that models leak as plain text). |
 | `docs/` | [Protocol spec](docs/AGENT_ROOM_PROTOCOL.md), [integration guides](docs/integrations/), publishing notes. |
 | `integrations/agent-room-skill` | Portable SKILL.md + `room.sh` — the whole flow over plain REST for skill-based agents (Hermes, or anything that can run curl). |
@@ -230,7 +231,7 @@ room_listen again. Loop indefinitely until I tell you to stop.
 |-------|--------|
 | Protocol | [Agent Room Protocol v0.1](docs/AGENT_ROOM_PROTOCOL.md) — small by design |
 | MCP server | `@modelcontextprotocol/sdk`, published as [`agent-room-mcp`](https://www.npmjs.com/package/agent-room-mcp) |
-| State | Upstash Redis (serverless, 24h room TTL) |
+| State | Upstash Redis by default (serverless, 24h room TTL); optional durable Postgres through `AGENT_ROOM_PERSISTENCE=postgres` |
 | Web | React 18 · React Router · Tailwind CSS · Vite |
 | Hosting | Vercel — deploy your own with the same `vercel.json` |
 

--- a/apps/mcp/scripts/build-mcpb.mjs
+++ b/apps/mcp/scripts/build-mcpb.mjs
@@ -66,7 +66,7 @@ const manifest = {
     'Create a meeting room, share the 9-character code, and any MCP-capable agent (or a human in the browser at agent-room.com) can join, chat, and coordinate work in real time.',
   author: { name: 'Agent Room', url: 'https://www.agent-room.com' },
   homepage: 'https://www.agent-room.com',
-  documentation: 'https://github.com/agent-room-alkl/agent-room-commercial/blob/main/INSTALL.md',
+  documentation: 'https://github.com/noogalabs/agent-room/blob/main/INSTALL.md',
   server: {
     type: 'node',
     entry_point: 'server/index.js',

--- a/apps/mcp/src/credentials.ts
+++ b/apps/mcp/src/credentials.ts
@@ -1,0 +1,34 @@
+import { readRoomStateForCredentials, readState, type AgentRoomState } from './state.js';
+import { detectHarness } from './harness.js';
+import type { RoomCredentials } from './roomApi.js';
+
+/** Room capabilities recorded in a state snapshot (whichever scope produced it). */
+export function credentialsFromState(state: AgentRoomState, code: string): RoomCredentials | undefined {
+  const room = state.rooms[code];
+  if (!room || (!room.accessToken && !room.participantToken)) return undefined;
+  return {
+    ...(room.accessToken ? { accessToken: room.accessToken } : {}),
+    ...(room.participantToken ? { participantToken: room.participantToken } : {}),
+  };
+}
+
+/** Room capabilities persisted by earlier joins in this process's PPID-scoped state file. */
+export async function stateCredentialLoader(code: string): Promise<RoomCredentials | undefined> {
+  return credentialsFromState(await readState(), code);
+}
+
+/**
+ * Loader for the tool server. Cursor and Codex respawn the MCP server under a
+ * new wrapper PPID, so the PPID-scoped file is empty after a restart while
+ * the harness-scoped file still holds the joins; those harnesses read the
+ * stable harness state (same scope rule the Stop hook applies). Every other
+ * client keeps PPID-scoped state so parallel sessions stay isolated.
+ */
+export async function toolCredentialLoader(code: string, env: NodeJS.ProcessEnv = process.env): Promise<RoomCredentials | undefined> {
+  const kind = detectHarness(env).kind;
+  if (kind === 'cursor' || kind === 'codex') {
+    const room = await readRoomStateForCredentials(code);
+    return room ? credentialsFromState({ version: 1, rooms: { [code]: room } }, code) : undefined;
+  }
+  return credentialsFromState(await readState(), code);
+}

--- a/apps/mcp/src/hook.ts
+++ b/apps/mcp/src/hook.ts
@@ -1,4 +1,5 @@
-import { createRoomApiClient, getRoom, listMessages } from './roomApi.js';
+import { createRoomApiClient, getRoom, listMessages, RoomApiError, RoomNotFoundError } from './roomApi.js';
+import { credentialsFromState } from './credentials.js';
 import type { Message } from '@agent-room/shared';
 import {
   readState,
@@ -95,12 +96,67 @@ async function readHookState(scope: StateScope) {
   return scope === 'harness' ? readHarnessStateOrMerged() : readState();
 }
 
-async function fetchPending(scope: StateScope): Promise<PendingRoom[]> {
+export interface ActiveRoom { code: string; topic: string; selfName: string; cursor: number }
+
+/** Only a definitive "this room no longer exists" answer may evict a room from local state. */
+export function shouldDropRoomOnError(error: unknown, hasOwnCapability = false): boolean {
+  return error instanceof RoomNotFoundError ||
+    (hasOwnCapability && error instanceof RoomApiError && error.status === 403);
+}
+
+/**
+ * Best-effort cleanup at Stop: drop rooms from local state that are gone
+ * server-side (TTL expired), marked ended, or where this agent is no longer
+ * a participant, so a left-over entry cannot keep the Stop hook looping.
+ * Auth failures, DNS failures and timeouts are NOT evidence the room is gone:
+ * a brief room-API outage at Stop must not drop a live room and silence the
+ * agent, so those rows are retained and skipped this cycle.
+ */
+export async function pruneRoomsForStop(stateScope: StateScope): Promise<{ activeRooms: ActiveRoom[]; hadRetainedFailure: boolean }> {
+  const state = await readHookState(stateScope);
+  // Same snapshot rule as fetchPending: cleanup must never evaluate a room with missing capabilities.
+  const apiClient = createRoomApiClient({ loadCredentials: async (code) => credentialsFromState(state, code) });
+  const drop = async (code: string) => {
+    try {
+      if (stateScope === 'harness') await removeRoomEverywhere(code);
+      else await removeRoom(code);
+    } catch { /* non-essential */ }
+  };
+  const activeRooms: ActiveRoom[] = [];
+  let hadRetainedFailure = false;
+  for (const [code, r] of Object.entries(state.rooms)) {
+    try {
+      const room = await getRoom(apiClient, code);
+      const stillIn = room.participants.some(p => p.name === r.name && p.client === 'cc');
+      if (room.status !== 'active' || !stillIn) { await drop(code); continue; }
+      activeRooms.push({ code, topic: room.topic, selfName: r.name, cursor: r.cursor });
+    } catch (error) {
+      const hasOwnCapability = Boolean(r.accessToken && r.participantToken);
+      if (shouldDropRoomOnError(error, hasOwnCapability)) await drop(code);
+      else hadRetainedFailure = true;
+    }
+  }
+  return { activeRooms, hadRetainedFailure };
+}
+
+export async function pruneRooms(stateScope: StateScope): Promise<ActiveRoom[]> {
+  return (await pruneRoomsForStop(stateScope)).activeRooms;
+}
+
+export function shouldLongPollAfterPrune(result: { activeRooms: ActiveRoom[]; hadRetainedFailure: boolean }): boolean {
+  return result.activeRooms.length > 0 && !result.hadRetainedFailure;
+}
+
+export async function fetchPending(scope: StateScope): Promise<PendingRoom[]> {
   const state = await readHookState(scope);
   const codes = Object.keys(state.rooms);
   if (codes.length === 0) return [];
 
-  const client = createRoomApiClient();
+  // Credentials come from the SAME snapshot that enumerated the rooms. The
+  // hook process has its own PPID, so a PPID-scoped readState() can miss a
+  // room that only the harness-scoped file knows; the unauthenticated
+  // listMessages would then fail silently and cleanup could drop a live room.
+  const client = createRoomApiClient({ loadCredentials: async (code) => credentialsFromState(state, code) });
   const results: PendingRoom[] = [];
 
   for (const code of codes) {
@@ -157,7 +213,7 @@ function formatMessages(rooms: PendingRoom[]): string {
   return lines.join('\n');
 }
 
-async function commitCursors(rooms: PendingRoom[], scope: StateScope): Promise<void> {
+export async function commitCursors(rooms: PendingRoom[], scope: StateScope): Promise<void> {
   for (const r of rooms) {
     if (scope === 'harness') {
       await updateCursorEverywhere(r.code, r.newCursor);
@@ -187,8 +243,8 @@ async function readStdin(): Promise<HookInput> {
   });
 }
 
-export async function runHook(): Promise<void> {
-  const input = await readStdin();
+export async function runHook(inputOverride?: HookInput): Promise<void> {
+  const input = inputOverride ?? await readStdin();
   // Normalize the event name across clients. Cursor only fires the stop
   // hook (no UserPromptSubmit / SessionStart equivalent today). Older
   // Cursor hook docs/examples showed `{ status, loop_count }` without a
@@ -253,6 +309,7 @@ export async function runHook(): Promise<void> {
 
   let withMessages = pending.filter((r) => r.messages.length > 0);
   await commitCursors(pending, stateScope); // advance cursors even when only own-messages were skipped
+  let stopPrune: { activeRooms: ActiveRoom[]; hadRetainedFailure: boolean } | undefined;
 
   // Long-poll fallback (Fix A): on Stop, if there's any active room at all,
   // hold the turn open and watch for incoming messages. This used to fire
@@ -260,9 +317,9 @@ export async function runHook(): Promise<void> {
   // where a passively-listening agent would sleep instantly the moment its
   // turn ended — and any later web user reply would be missed.
   if (withMessages.length === 0 && event === 'Stop') {
-    const state = await readHookState(stateScope);
-    const hasActiveRoom = Object.keys(state.rooms).length > 0;
-    if (hasActiveRoom) {
+    try { stopPrune = await pruneRoomsForStop(stateScope); }
+    catch { stopPrune = { activeRooms: [], hadRetainedFailure: true }; }
+    if (shouldLongPollAfterPrune(stopPrune)) {
       const deadline = Date.now() + POLL_MAX_MS;
       // Ease 1.5s -> 5s across the window: the first replies usually land
       // fast; past ~10s of quiet, finer granularity is pure API load (this
@@ -308,36 +365,7 @@ export async function runHook(): Promise<void> {
   // cap up top (`stop_hook_active && streak >= MAX`), so reaching this
   // branch means we have budget for one more keep-alive nudge.
   if (withMessages.length === 0 && event === 'Stop') {
-    let activeRooms: Array<{ code: string; topic: string; selfName: string; cursor: number }> = [];
-    try {
-      const state = await readHookState(stateScope);
-      const apiClient = createRoomApiClient();
-      // Best-effort cleanup: drop rooms from local state that are gone
-      // server-side (TTL expired) or marked ended, or where this agent is
-      // no longer in the participants list. Without this, a left-over
-      // entry would keep the Stop hook looping "call room_listen" forever
-      // after the meeting closes — Codex caught this in 0.12.0 review.
-      for (const [code, r] of Object.entries(state.rooms)) {
-        try {
-          const room = await getRoom(apiClient, code);
-          const stillIn = room.participants.some(p => p.name === r.name && p.client === 'cc');
-          if (room.status !== 'active' || !stillIn) {
-            try {
-              if (stateScope === 'harness') await removeRoomEverywhere(code);
-              else await removeRoom(code);
-            } catch { /* non-essential */ }
-            continue;
-          }
-          activeRooms.push({ code, topic: room.topic, selfName: r.name, cursor: r.cursor });
-        } catch {
-          // Room not found / TTL expired — drop it from state too.
-          try {
-            if (stateScope === 'harness') await removeRoomEverywhere(code);
-            else await removeRoom(code);
-          } catch { /* non-essential */ }
-        }
-      }
-    } catch { /* fall through to plain exit */ }
+    const activeRooms = stopPrune?.activeRooms ?? [];
 
     if (activeRooms.length > 0) {
       try {

--- a/apps/mcp/src/httpAuth.ts
+++ b/apps/mcp/src/httpAuth.ts
@@ -1,0 +1,72 @@
+export interface McpFleetPrincipal {
+  subject: string;
+  fleetId: string;
+  issuer: string;
+  audience: string;
+  expiresAt: number;
+  scopes: readonly string[];
+}
+
+export interface McpAccessTokenVerifier {
+  verify(token: string, request: { resource: string; requiredScope: string }): Promise<McpFleetPrincipal>;
+}
+
+export interface McpHttpRequest {
+  headers: Readonly<Record<string, string | undefined>>;
+}
+
+export interface McpHttpResponse {
+  status: number;
+  headers?: Readonly<Record<string, string>>;
+  body: unknown;
+}
+
+export type AuthorizedMcpHandler = (
+  request: McpHttpRequest,
+  principal: McpFleetPrincipal,
+) => Promise<McpHttpResponse>;
+
+export function protectedResourceMetadata(resource: string, authorizationServers: readonly string[]) {
+  return {
+    resource,
+    authorization_servers: [...authorizationServers],
+    bearer_methods_supported: ['header'],
+    scopes_supported: ['agent-room:mcp'],
+  };
+}
+
+/**
+ * OAuth 2.1 gate for a future HTTP MCP transport. The existing stdio entry is
+ * deliberately separate and unchanged. Tokens stop here and are never passed
+ * to tool handlers.
+ */
+export function createAuthorizedMcpHttpHandler(options: {
+  resource: string;
+  metadataUrl: string;
+  verifier: McpAccessTokenVerifier;
+  dispatch: AuthorizedMcpHandler;
+  trustedIssuers: readonly string[];
+  now?: () => number;
+}): (request: McpHttpRequest) => Promise<McpHttpResponse> {
+  return async request => {
+    const header = request.headers.authorization;
+    const challenge = `Bearer resource_metadata="${options.metadataUrl}"`;
+    if (!header?.startsWith('Bearer ') || !header.slice(7).trim()) {
+      return { status: 401, headers: { 'www-authenticate': challenge }, body: { error: 'invalid_token' } };
+    }
+    let principal: McpFleetPrincipal;
+    try {
+      principal = await options.verifier.verify(header.slice(7), {
+        resource: options.resource,
+        requiredScope: 'agent-room:mcp',
+      });
+      if (!options.trustedIssuers.includes(principal.issuer) || principal.expiresAt <= (options.now?.() ?? Date.now()) ||
+        principal.audience !== options.resource || !principal.scopes.includes('agent-room:mcp')) {
+        throw new Error('resource or scope mismatch');
+      }
+    } catch {
+      return { status: 401, headers: { 'www-authenticate': challenge }, body: { error: 'invalid_token' } };
+    }
+    return options.dispatch({ ...request, headers: { ...request.headers, authorization: undefined } }, principal);
+  };
+}

--- a/apps/mcp/src/redact.ts
+++ b/apps/mcp/src/redact.ts
@@ -1,0 +1,19 @@
+/**
+ * A URL that reaches an error message or a log line must not carry a
+ * capability. Legacy self-hosted attachment URLs embed the room token as
+ * ?access=, and a base URL can carry userinfo, so every interpolated URL is
+ * reduced to origin + path first. The path and status stay, so the error
+ * still says what failed where.
+ */
+export function redactUrl(input: string): string {
+  try {
+    const url = new URL(input);
+    url.search = '';
+    url.hash = '';
+    url.username = '';
+    url.password = '';
+    return url.toString();
+  } catch {
+    return input.split(/[?#]/, 1)[0] ?? '';
+  }
+}

--- a/apps/mcp/src/roomApi.ts
+++ b/apps/mcp/src/roomApi.ts
@@ -1,3 +1,4 @@
+import { redactUrl } from './redact.js';
 // HTTP client for the agent-room server API (`POST /api/room`).
 //
 // The MCP server used to talk to Upstash Redis directly, which meant the
@@ -81,23 +82,63 @@ function apiEndpoint(): string {
 
 export interface RoomApiClient {
   post<T>(payload: Record<string, unknown>): Promise<T>;
+  setCredentials(code: string, credentials: { accessToken?: string; participantToken?: string }): void;
+  getCredentials(code: string): { accessToken?: string; participantToken?: string };
 }
 
-export function createRoomApiClient(): RoomApiClient {
+export type RoomCredentials = { accessToken?: string; participantToken?: string };
+
+export interface RoomApiClientOptions {
+  /**
+   * Rehydrates a room's capabilities when this process has none cached.
+   * The in-memory map dies with the process; a restarted MCP server that
+   * skips this loader sends unauthenticated requests to hardened rooms and
+   * every call fails 401/403 until the agent re-joins.
+   */
+  loadCredentials?: (code: string) => Promise<RoomCredentials | undefined>;
+}
+
+export function apiBaseUrl(): string {
+  return (process.env.AGENT_ROOM_BASE_URL ?? 'https://www.agent-room.com').replace(/\/$/, '');
+}
+
+export function createRoomApiClient(options: RoomApiClientOptions = {}): RoomApiClient {
   const endpoint = apiEndpoint();
+  const credentials = new Map<string, RoomCredentials>();
+  const resolveCredentials = async (code: string): Promise<RoomCredentials | undefined> => {
+    const cached = credentials.get(code);
+    if (cached?.accessToken || cached?.participantToken) return cached;
+    if (!options.loadCredentials) return cached;
+    const loaded = await options.loadCredentials(code).catch(() => undefined);
+    if (!loaded) return cached;
+    credentials.set(code, { ...loaded, ...cached });
+    return credentials.get(code);
+  };
   return {
+    setCredentials(code, next) {
+      credentials.set(code, { ...credentials.get(code), ...next });
+    },
+    getCredentials(code) {
+      return { ...credentials.get(code) };
+    },
     async post<T>(payload: Record<string, unknown>): Promise<T> {
+      const code = typeof payload.code === 'string' ? payload.code : undefined;
+      const auth = code ? await resolveCredentials(code) : undefined;
       let resp: Response;
       try {
         resp = await fetch(endpoint, {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: {
+            'content-type': 'application/json',
+            ...(auth?.accessToken ? { 'x-agent-room-access': auth.accessToken } : {}),
+            ...(auth?.participantToken ? { authorization: `Bearer ${auth.participantToken}` } : {}),
+          },
           body: JSON.stringify(payload),
           cache: 'no-store',
         });
       } catch (e) {
         const msg = e instanceof Error ? e.message : 'network failure';
-        throw new RoomApiError(`POST ${endpoint} failed: ${msg}`, 0);
+        throw new RoomApiError(`POST ${redactUrl(endpoint)} failed: ${msg}`, 0);
       }
       const body = (await resp.json().catch(() => ({}))) as {
         error?: string;
@@ -107,6 +148,16 @@ export function createRoomApiClient(): RoomApiClient {
       if (!resp.ok) {
         throw errorFromBody(body.error, body.message ?? `Room API failed (${resp.status})`, resp.status);
       }
+      if (typeof body.room === 'object' && body.room !== null) {
+        const responseCode = (body.room as { code?: unknown }).code;
+        if (typeof responseCode === 'string') {
+          credentials.set(responseCode, {
+            ...credentials.get(responseCode),
+            ...(typeof body.accessToken === 'string' ? { accessToken: body.accessToken } : {}),
+            ...(typeof body.participantToken === 'string' ? { participantToken: body.participantToken } : {}),
+          });
+        }
+      }
       return body as T;
     },
   };
@@ -115,15 +166,15 @@ export function createRoomApiClient(): RoomApiClient {
 export async function createRoom(
   client: RoomApiClient,
   input: { topic: string; createdBy: string; projectId?: string; projectKey?: string },
-): Promise<Room & { hostKey: string }> {
-  const body = await client.post<{ room: Room & { hostKey: string }; hostKey: string }>({
+): Promise<Room & { hostKey: string; accessToken?: string }> {
+  const body = await client.post<{ room: Room & { hostKey: string }; hostKey: string; accessToken?: string }>({
     action: 'create',
     topic: input.topic,
     createdBy: input.createdBy,
     // Optional durable-project attach (capability key proves authority).
     ...(input.projectId ? { projectId: input.projectId, projectKey: input.projectKey } : {}),
   });
-  return { ...body.room, hostKey: body.hostKey };
+  return { ...body.room, hostKey: body.hostKey, accessToken: body.accessToken };
 }
 
 export async function getRoom(client: RoomApiClient, code: string): Promise<Room> {
@@ -136,7 +187,7 @@ export async function joinRoom(
   code: string,
   participant: Participant,
   options: { hostKey?: string; priorIdentity?: { name: string; client: 'web' | 'cc' } } = {},
-): Promise<Room & { participant: Participant; agentContext?: string; roomPolicy?: string; policyVersion?: number }> {
+): Promise<Room & { participant: Participant; participantToken?: string; agentContext?: string; roomPolicy?: string; policyVersion?: number }> {
   const body = await client.post<{
     room: Room;
     participant: Participant;
@@ -146,6 +197,7 @@ export async function joinRoom(
     agentContext?: string;
     roomPolicy?: string;
     policyVersion?: number;
+    participantToken?: string;
   }>({
     action: 'join',
     code,
@@ -156,6 +208,7 @@ export async function joinRoom(
   return {
     ...body.room,
     participant: body.participant,
+    participantToken: body.participantToken,
     agentContext: body.agentContext,
     roomPolicy: body.roomPolicy,
     policyVersion: body.policyVersion,

--- a/apps/mcp/src/state.ts
+++ b/apps/mcp/src/state.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
+import { createHash, randomUUID } from 'crypto';
 import { homedir } from 'os';
-import { join, dirname } from 'path';
+import { basename, join, dirname } from 'path';
 import { detectHarness } from './harness.js';
 
 const STATE_DIR = process.env.AGENT_ROOM_STATE_DIR || join(homedir(), '.agent-room');
@@ -17,15 +18,32 @@ const STATE_FILE =
   process.env.AGENT_ROOM_STATE_FILE ||
   join(STATE_DIR, `state-${process.ppid ?? process.pid}.json`);
 
+// A detected harness without a stable session identifier must still stay out
+// of merged state. This nonce deliberately lasts only for this MCP process:
+// isolation is safer than guessing that another session's credentials belong
+// to the caller.
+const HARNESS_PROCESS_NONCE = randomUUID();
+
+function currentHarnessSessionId(kind: 'cursor' | 'codex'): string {
+  if (kind === 'codex') {
+    return process.env.CODEX_THREAD_ID || process.env.CODEX_RUN_ID || HARNESS_PROCESS_NONCE;
+  }
+  return process.env.CURSOR_TRACE_ID || HARNESS_PROCESS_NONCE;
+}
+
 function currentHarnessStateFile(): string | null {
   if (process.env.AGENT_ROOM_STATE_FILE) return null;
   const kind = detectHarness().kind;
   if (kind !== 'cursor' && kind !== 'codex') return null;
-  return join(STATE_DIR, `state-harness-${kind}.json`);
+  const sessionId = currentHarnessSessionId(kind);
+  const scope = createHash('sha256').update(sessionId).digest('hex').slice(0, 16);
+  return join(STATE_DIR, `state-harness-${kind}-${scope}.json`);
 }
 
 export interface RoomState {
   name: string;
+  /** Participant client is part of the immutable room identity tuple. */
+  client?: 'cc';
   cursor: number;
   joinedAt: number;
   lastSentAt?: number;
@@ -34,6 +52,11 @@ export interface RoomState {
   // it, joinRoom rejects with HostNameTakenError. Plain text on disk under
   // ~/.agent-room/ — same trust level as the MCP state itself.
   hostKey?: string;
+  // Local/self-hosted rooms require two independent capabilities: one to
+  // discover/read the room and one bound to this immutable participant.
+  // State files are mode 0600 and PPID-scoped.
+  accessToken?: string;
+  participantToken?: string;
 }
 
 export interface AgentRoomState {
@@ -90,6 +113,8 @@ export function mergeStates(states: AgentRoomState[]): AgentRoomState {
         joinedAt: newest.joinedAt,
         lastSentAt: Math.max(existing.lastSentAt ?? 0, room.lastSentAt ?? 0) || undefined,
         hostKey: newest.hostKey ?? existing.hostKey,
+        accessToken: newest.accessToken ?? existing.accessToken,
+        participantToken: newest.participantToken ?? existing.participantToken,
       };
     }
   }
@@ -104,7 +129,7 @@ async function listStateFiles(): Promise<string[]> {
   try {
     const entries = await fs.readdir(STATE_DIR);
     files = entries
-      .filter((name) => /^state-(?:\d+|harness-[a-z-]+)\.json$/.test(name))
+      .filter((name) => /^state-(?:\d+|harness-[a-z-]+-[a-f0-9]{16})\.json$/.test(name))
       .map((name) => join(STATE_DIR, name));
   } catch {
     files = [];
@@ -113,17 +138,81 @@ async function listStateFiles(): Promise<string[]> {
   return Array.from(new Set([...files, STATE_FILE, currentHarnessStateFile()].filter(Boolean) as string[]));
 }
 
+/** Files owned by this process and its current durable harness session only. */
+function activeStateFiles(): string[] {
+  return Array.from(new Set(
+    [STATE_FILE, currentHarnessStateFile()].filter(Boolean) as string[],
+  ));
+}
+
 export async function readMergedState(): Promise<AgentRoomState> {
-  const files = await listStateFiles();
+  const kind = detectHarness().kind;
+  const files = kind === 'cursor' || kind === 'codex'
+    ? activeStateFiles()
+    : await listStateFiles();
   const states = await Promise.all(files.map(readStateFile));
   return mergeStates(states);
+}
+
+function sameParticipant(a: RoomState, b: RoomState): boolean {
+  return a.name === b.name && (a.client ?? 'cc') === (b.client ?? 'cc');
+}
+
+/** Resolve capabilities without crossing participant identities. */
+export async function readRoomStateForCredentials(code: string): Promise<RoomState | undefined> {
+  const current = (await readStateFile(STATE_FILE)).rooms[code];
+  const harnessFile = currentHarnessStateFile();
+  const harness = harnessFile ? (await readStateFile(harnessFile)).rooms[code] : undefined;
+  const files = await listStateFiles();
+  const states = await Promise.all(files.map(readStateFile));
+  const candidates = states
+    .map((state) => state.rooms[code])
+    .filter((room): room is RoomState => Boolean(room));
+  // Cursor/Codex recovery is scoped to the actual run id. A globally unique
+  // participant in some other run is still foreign and must never become this
+  // session's host identity.
+  const identity = current ?? harness;
+  if (!identity) return undefined;
+
+  const matches = states
+    .map((state) => state.rooms[code])
+    .filter((room): room is RoomState => Boolean(room && sameParticipant(room, identity)))
+    .sort((a, b) => b.joinedAt - a.joinedAt);
+  const sources = [current, harness, ...matches].filter(
+    (room): room is RoomState => Boolean(room && sameParticipant(room, identity)),
+  );
+  const preferred = sources[0];
+  if (!preferred) return undefined;
+  return {
+    ...preferred,
+    cursor: Math.max(...sources.map((room) => room.cursor)),
+    lastSentAt: Math.max(...sources.map((room) => room.lastSentAt ?? 0)) || undefined,
+    hostKey: sources.find((room) => room.hostKey)?.hostKey,
+    accessToken: sources.find((room) => room.accessToken)?.accessToken,
+    participantToken: sources.find((room) => room.participantToken)?.participantToken,
+  };
+}
+
+/**
+ * Resolve interactive tool identity without crossing ordinary PPID sessions.
+ * Cursor and Codex need the durable harness recovery path because their MCP
+ * process identity changes across restarts; other harnesses share the current
+ * PPID state file and must never inherit a foreign session's host capability.
+ */
+export async function readRoomStateForSession(code: string): Promise<RoomState | undefined> {
+  const kind = detectHarness().kind;
+  if (kind === 'cursor' || kind === 'codex') return readRoomStateForCredentials(code);
+  return (await readState()).rooms[code];
 }
 
 export async function readRoomStateForJoin(code: string, desiredName: string): Promise<RoomState | undefined> {
   const current = (await readState()).rooms[code];
   if (current) return current;
 
-  const files = await listStateFiles();
+  const kind = detectHarness().kind;
+  const files = kind === 'cursor' || kind === 'codex'
+    ? activeStateFiles()
+    : await listStateFiles();
   const states = await Promise.all(files.map(readStateFile));
   return states
     .map((state) => state.rooms[code])
@@ -134,8 +223,7 @@ export async function readRoomStateForJoin(code: string, desiredName: string): P
 export async function readHarnessStateOrMerged(): Promise<AgentRoomState> {
   const harnessFile = currentHarnessStateFile();
   if (harnessFile) {
-    const harnessState = await readStateFile(harnessFile);
-    if (Object.keys(harnessState.rooms).length > 0) return harnessState;
+    return readStateFile(harnessFile);
   }
   return readMergedState();
 }
@@ -234,7 +322,7 @@ export async function updateCursor(code: string, cursor: number): Promise<void> 
 
 export async function updateCursorEverywhere(code: string, cursor: number): Promise<void> {
   await withStateLock(async () => {
-    const files = await listStateFiles();
+    const files = activeStateFiles();
     await Promise.all(files.map(async (file) => {
       const state = await readStateFile(file);
       const room = state.rooms[code];
@@ -266,8 +354,9 @@ export async function bumpBlockStreak(): Promise<number> {
 
 export async function bumpBlockStreakEverywhere(): Promise<number> {
   return withStateLock(async () => {
-    const next = ((await readMergedState()).blockStreak ?? 0) + 1;
-    const files = await listStateFiles();
+    const files = activeStateFiles();
+    const states = await Promise.all(files.map(readStateFile));
+    const next = Math.max(0, ...states.map((state) => state.blockStreak ?? 0)) + 1;
     await Promise.all(files.map(async (file) => {
       const state = await readStateFile(file);
       state.blockStreak = next;
@@ -288,7 +377,7 @@ export async function resetBlockStreak(): Promise<void> {
 
 export async function resetBlockStreakEverywhere(): Promise<void> {
   await withStateLock(async () => {
-    const files = await listStateFiles();
+    const files = activeStateFiles();
     await Promise.all(files.map(async (file) => {
       const state = await readStateFile(file);
       if (!state.blockStreak) return;
@@ -300,11 +389,18 @@ export async function resetBlockStreakEverywhere(): Promise<void> {
 
 export async function removeRoomEverywhere(code: string): Promise<void> {
   await withStateLock(async () => {
-    const files = await listStateFiles();
+    const files = activeStateFiles();
     await Promise.all(files.map(async (file) => {
       const state = await readStateFile(file);
       if (!(code in state.rooms)) return;
       delete state.rooms[code];
+      if (file !== STATE_FILE && basename(file).startsWith('state-harness-')
+          && Object.keys(state.rooms).length === 0) {
+        await fs.unlink(file).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== 'ENOENT') throw error;
+        });
+        return;
+      }
       await writeStateFile(file, state);
     }));
   });

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -33,7 +33,10 @@ import {
   InvalidModeConfigError,
   ModeNotSupportedError,
   type RoomApiClient,
+  apiBaseUrl,
 } from './roomApi.js';
+import { toolCredentialLoader } from './credentials.js';
+import { redactUrl } from './redact.js';
 import { AVATAR_PALETTE, roleBriefFor, normalizeEscapedWhitespace } from '@agent-room/shared';
 import type {
   Message,
@@ -45,7 +48,7 @@ import type {
   Room,
   TaskBoard,
 } from '@agent-room/shared';
-import { setRoom, removeRoom, updateCursor, markSent, readState, readRoomStateForJoin } from './state.js';
+import { setRoom, removeRoom, updateCursor, markSent, readRoomStateForJoin, readRoomStateForSession } from './state.js';
 import {
   detectHarness,
   defaultListenAfterJoin,
@@ -79,6 +82,37 @@ function colorForName(name: string): string {
   return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length]!;
 }
 
+/**
+ * Image and blob reads are emitted as real MCP content items (an image block a
+ * vision client can see, a resource block with the bytes), plus a text summary.
+ * Stringifying the base64 into the text item would hand a vision client a
+ * string, not pixels.
+ */
+export function attachmentReadResult(
+  attachment: MessageAttachment,
+  message: unknown,
+  read: { text?: string; image?: string; blob?: string; mime?: string; source: string; warning?: string },
+) {
+  const mimeType = read.mime || attachment.mime || 'application/octet-stream';
+  // Binary results echo the attachment without its url: the bytes are in the
+  // content item, and a protected relative path is useless to the caller.
+  const { url: _protectedUrl, ...meta } = attachment;
+  const summary = { ok: true, attachment: read.image !== undefined || read.blob !== undefined ? meta : attachment, message, source: read.source, text: read.text, warning: read.warning };
+  if (read.image !== undefined) {
+    return { content: [
+      { type: 'image' as const, data: read.image, mimeType },
+      { type: 'text' as const, text: JSON.stringify({ ...summary, mime: mimeType }, null, 2) },
+    ] };
+  }
+  if (read.blob !== undefined) {
+    return { content: [
+      { type: 'resource' as const, resource: { uri: `attachment://${attachment.id}/${encodeURIComponent(attachment.name)}`, mimeType, blob: read.blob } },
+      { type: 'text' as const, text: JSON.stringify({ ...summary, mime: mimeType, name: attachment.name, size: attachment.size }, null, 2) },
+    ] };
+  }
+  return ok(summary);
+}
+
 function ok(value: unknown) {
   return {
     content: [
@@ -100,6 +134,7 @@ export const CORE_PROFILE_TOOLS = new Set([
   'room_join',
   'room_send',
   'room_listen',
+  'room_attachment_read',
   'room_minutes',
   'room_leave',
   'room_end',
@@ -375,36 +410,96 @@ function canReadAsText(a: MessageAttachment): boolean {
     /\.(txt|md|markdown|csv|json|html?|svg|log)$/i.test(a.name);
 }
 
-async function fetchAttachmentBytes(url: string, maxBytes: number): Promise<Uint8Array> {
-  const resp = await fetch(url);
-  if (!resp.ok) throw new Error(`GET ${url} returned ${resp.status}.`);
-  const buf = new Uint8Array(await resp.arrayBuffer());
-  if (buf.byteLength > maxBytes) {
-    throw new Error(`Attachment is ${buf.byteLength} bytes; this reader caps downloads at ${maxBytes} bytes.`);
-  }
-  return buf;
+export interface AttachmentFetchAuth {
+  accessToken?: string;
 }
 
-async function readAttachmentText(a: MessageAttachment, maxChars: number): Promise<{ text?: string; source: string; warning?: string }> {
+/**
+ * Local/self-hosted rooms return attachment URLs relative to the room API
+ * base and no longer embed the room capability, so the reader resolves the
+ * URL against AGENT_ROOM_BASE_URL and presents the token as a header.
+ */
+export function resolveAttachmentUrl(url: string, base: string = apiBaseUrl()): string {
+  return new URL(url, `${base}/`).toString();
+}
+
+/** The room capability travels only to the room's own origin, never to a third-party attachment host. */
+export function attachmentAuthHeaders(target: string, auth: AttachmentFetchAuth, base: string = apiBaseUrl()): Record<string, string> {
+  if (!auth.accessToken) return {};
+  return new URL(target).origin === new URL(base).origin ? { 'x-agent-room-access': auth.accessToken } : {};
+}
+
+export async function fetchAttachmentBytes(url: string, maxBytes: number, auth: AttachmentFetchAuth = {}, fetchFn: typeof fetch = fetch): Promise<Uint8Array> {
+  let target = resolveAttachmentUrl(url);
+  let resp: Response | undefined;
+  for (let redirects = 0; redirects <= 5; redirects += 1) {
+    resp = await fetchFn(target, {
+      headers: attachmentAuthHeaders(target, auth),
+      redirect: 'manual',
+    });
+    if (![301, 302, 303, 307, 308].includes(resp.status)) break;
+    if (redirects === 5) throw new Error(`GET ${redactUrl(target)} exceeded 5 redirects.`);
+    const location = resp.headers.get('location');
+    if (!location) throw new Error(`GET ${redactUrl(target)} returned ${resp.status} without a Location header.`);
+    target = new URL(location, target).toString();
+  }
+  if (!resp) throw new Error(`GET ${redactUrl(target)} returned no response.`);
+  if (!resp.ok) throw new Error(`GET ${redactUrl(target)} returned ${resp.status}.`);
+
+  const contentLength = resp.headers.get('content-length')?.trim();
+  if (contentLength && /^\d+$/.test(contentLength) && BigInt(contentLength) > BigInt(maxBytes)) {
+    throw new Error(`Attachment is ${contentLength} bytes; this reader caps downloads at ${maxBytes} bytes.`);
+  }
+
+  if (!resp.body) throw new Error(`GET ${redactUrl(target)} returned no readable attachment body.`);
+  const reader = resp.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`Attachment exceeds ${maxBytes} bytes; this reader caps downloads at ${maxBytes} bytes.`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export async function readAttachmentText(a: MessageAttachment, maxChars: number, auth: AttachmentFetchAuth = {}): Promise<{ text?: string; image?: string; blob?: string; mime?: string; source: string; warning?: string }> {
   const existing = a.extractedText?.trim();
   if (existing) return { text: existing.slice(0, maxChars), source: 'stored_extractedText' };
 
-  if (a.type === 'image' || a.mime.toLowerCase().startsWith('image/')) {
-    return {
-      source: 'image_url',
-      warning: 'Image attachments are returned as URLs/metadata. Pass the URL to a vision-capable model or browser/image tool to inspect pixels.',
-    };
-  }
-
   const mime = a.mime.toLowerCase();
   const maxBytes = 10 * 1024 * 1024;
+  if (a.type === 'image' || mime.startsWith('image/')) {
+    // The URL may be a protected self-hosted path that a browser or vision
+    // tool cannot open (no origin, no capability), so the reader fetches the
+    // bytes with the room's credentials and hands back the image itself.
+    const bytes = await fetchAttachmentBytes(a.url, maxBytes, auth);
+    return { source: 'fetched_image', image: Buffer.from(bytes).toString('base64'), mime: a.mime || 'application/octet-stream' };
+  }
+
   if (canReadAsText(a)) {
-    const bytes = await fetchAttachmentBytes(a.url, maxBytes);
+    const bytes = await fetchAttachmentBytes(a.url, maxBytes, auth);
     return { text: Buffer.from(bytes).toString('utf8').trim().slice(0, maxChars), source: 'fetched_text' };
   }
 
   if (mime === 'application/pdf' || /\.pdf$/i.test(a.name)) {
-    const bytes = await fetchAttachmentBytes(a.url, maxBytes);
+    const bytes = await fetchAttachmentBytes(a.url, maxBytes, auth);
     const { extractText } = await import('unpdf');
     const extraction = await extractText(bytes, { mergePages: true });
     const merged = Array.isArray(extraction.text) ? extraction.text.join('\n\n') : String(extraction.text ?? '');
@@ -412,16 +507,18 @@ async function readAttachmentText(a: MessageAttachment, maxChars: number): Promi
   }
 
   if (mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || /\.docx$/i.test(a.name)) {
-    const bytes = await fetchAttachmentBytes(a.url, maxBytes);
+    const bytes = await fetchAttachmentBytes(a.url, maxBytes, auth);
     const mammoth = await import('mammoth');
     const result = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
     return { text: String(result.value ?? '').trim().slice(0, maxChars), source: 'fetched_docx' };
   }
 
-  return {
-    source: 'unsupported',
-    warning: `No MCP reader for ${a.mime}. Download/open the URL with a suitable local tool: ${a.url}`,
-  };
+  // Allowed but not text-extractable (zip, xls, ...): the URL may be a protected
+  // self-hosted path the caller cannot open, so hand back the bytes as a blob
+  // through the authenticated reader. Above the cap the size error surfaces as
+  // text (never a raw protected url).
+  const bytes = await fetchAttachmentBytes(a.url, maxBytes, auth);
+  return { source: 'fetched_blob', blob: Buffer.from(bytes).toString('base64'), mime: a.mime || 'application/octet-stream' };
 }
 
 /** Long-poll for new messages; shared by room_listen and post-join/create first listen. */
@@ -503,7 +600,7 @@ async function runRoomListenPoll(
       );
       const baseHint = `${msgs.length} new message(s). Reply with room_send if appropriate, then call room_listen again with since=${cursor} to keep listening. ${nextListenContract(code, cursor)}`;
       const attachmentHint = attachmentCount > 0
-        ? ` ATTACHMENTS: this batch carries ${attachmentCount} attachment URL(s) on message.attachments[]. To inspect their contents (read a screenshot, parse a PDF, etc.), fetch the .url with your environment's URL/file/vision tool. Image attachments work with vision-capable models — passing the URL to a multimodal step lets you actually see the image.`
+        ? ` ATTACHMENTS: this batch carries ${attachmentCount} attachment(s) on message.attachments[]. Call room_attachment_read with the attachment id, URL, or filename to read it through the room's authenticated path. Image attachments return an MCP image block for vision-capable clients.`
         : '';
       return {
         messages: msgs,
@@ -548,15 +645,14 @@ function resolvedListenTimeoutMs(raw: unknown, maxListenMs: number): number {
 // no hostKey and the server will reject the host action with NotHostError.
 async function readHostKey(code: string): Promise<string | undefined> {
   try {
-    const state = await readState();
-    return state.rooms[code]?.hostKey;
+    return (await readRoomStateForSession(code))?.hostKey;
   } catch {
     return undefined;
   }
 }
 
 export function registerTools(server: Server) {
-  const client = createRoomApiClient();
+  const client = createRoomApiClient({ loadCredentials: toolCredentialLoader });
   // Snapshot the host harness once at boot. This drives the persistence-setup
   // nudge in room_join / room_create — agents on harnesses that don't
   // auto-loop tool calls (Cursor without 1.7+ stop hook, Antigravity, etc.)
@@ -660,6 +756,7 @@ export function registerTools(server: Server) {
           required: ['code', 'name'],
           properties: {
             code: { type: 'string', description: '9-character dashed room code, e.g. ABC-DEF-GHJ' },
+            accessToken: { type: 'string', description: 'Private room-access token returned by room_create (required by hardened/self-hosted rooms).' },
             name: { type: 'string', description: 'Your display name' },
             role: { type: 'string', description: 'Your role (optional)' },
             listenAfterJoin: { type: 'boolean', description: 'Default true: run the first listen window in this call.' },
@@ -877,7 +974,7 @@ export function registerTools(server: Server) {
         joinedAt: Date.now(),
         lastSeenAt: Date.now(),
       };
-      await joinRoom(client, code, participant, {
+      const joined = await joinRoom(client, code, participant, {
         hostKey: created.hostKey,
         priorIdentity: { name: a.name, client: 'cc' },
       });
@@ -885,7 +982,12 @@ export function registerTools(server: Server) {
       // Save hostKey alongside cursor so a future room_join from this same
       // PPID can re-claim the host slot. State is PPID-scoped so two
       // parallel sessions don't share keys.
-      await setRoom(code, { name: a.name, cursor: msgs.length, joinedAt: Date.now(), hostKey: created.hostKey });
+      const credentials = client.getCredentials(code);
+      await setRoom(code, {
+        name: a.name, client: 'cc', cursor: msgs.length, joinedAt: Date.now(), hostKey: created.hostKey,
+        accessToken: created.accessToken ?? credentials.accessToken,
+        participantToken: joined.participantToken ?? credentials.participantToken,
+      });
 
       const listenAfterJoin = defaultListenAfterJoin(harness, a.listenAfterJoin);
       const listenMs = resolvedListenTimeoutMs(a.listenTimeoutMs, harness.maxListenMs);
@@ -902,6 +1004,7 @@ export function registerTools(server: Server) {
           messages: first.messages,
           ...(first.terminated ? { terminated: first.terminated } : {}),
           joinUrl: `https://www.agent-room.com/j/${code}`,
+          ...(created.accessToken ? { accessToken: created.accessToken } : {}),
           roleBrief: roleBriefFor(a.role ?? ''),
           ...(created.projectPrompt ? { projectPrompt: created.projectPrompt, projectPromptVersion: created.projectPromptVersion ?? 1 } : {}),
           ...(created.projectMemoryContext ? { projectMemoryContext: created.projectMemoryContext, projectId: created.projectId, projectName: created.projectName } : {}),
@@ -921,6 +1024,7 @@ export function registerTools(server: Server) {
         topic: created.topic,
         cursor: msgs.length,
         joinUrl: `https://www.agent-room.com/j/${code}`,
+        ...(created.accessToken ? { accessToken: created.accessToken } : {}),
         roleBrief: roleBriefFor(a.role ?? ''),
         ...(created.projectPrompt ? { projectPrompt: created.projectPrompt, projectPromptVersion: created.projectPromptVersion ?? 1 } : {}),
         ...(created.projectMemoryContext ? { projectMemoryContext: created.projectMemoryContext, projectId: created.projectId, projectName: created.projectName } : {}),
@@ -945,11 +1049,15 @@ export function registerTools(server: Server) {
       // Otherwise, joining as the host's display name is rejected server-side
       // by the join endpoint's verifyHostKey — clean error, no silent
       // impersonation.
-      const targetRoom = await getRoom(client, a.code);
-      let storedStateRoom: Awaited<ReturnType<typeof readState>>['rooms'][string] | undefined;
+      let storedStateRoom: Awaited<ReturnType<typeof readRoomStateForJoin>>;
       try {
         storedStateRoom = await readRoomStateForJoin(a.code, a.name);
       } catch { /* local state is optional; treat as fresh join */ }
+      client.setCredentials(a.code, {
+        accessToken: typeof a.accessToken === 'string' ? a.accessToken : storedStateRoom?.accessToken,
+        participantToken: storedStateRoom?.participantToken,
+      });
+      const targetRoom = await getRoom(client, a.code);
       const priorIdentity = storedStateRoom
         ? { name: storedStateRoom.name, client: 'cc' as const }
         : undefined;
@@ -995,7 +1103,12 @@ export function registerTools(server: Server) {
         } catch { /* greeting is nice-to-have; join/listen must still proceed */ }
       }
       const msgs = await listMessages(client, a.code, 0);
-      await setRoom(a.code, { name: finalName, cursor: msgs.length, joinedAt: Date.now() });
+      const credentials = client.getCredentials(a.code);
+      await setRoom(a.code, {
+        name: finalName, client: 'cc', cursor: msgs.length, joinedAt: Date.now(),
+        accessToken: credentials.accessToken,
+        participantToken: updated.participantToken ?? credentials.participantToken,
+      });
       const recentMessages = msgs.slice(-20).map((m: Message) => ({
         name: m.name,
         role: m.role,
@@ -1121,9 +1234,14 @@ export function registerTools(server: Server) {
       let attachments: MessageAttachment[] = [];
       if (Array.isArray(a.attachments) && a.attachments.length > 0) {
         try {
+          const credentials = await toolCredentialLoader(a.code);
           attachments = await uploadAgentAttachments(
             a.attachments as AgentAttachmentInput[],
             a.code,
+            {
+              accessToken: credentials?.accessToken,
+              participantToken: credentials?.participantToken,
+            },
           );
         } catch (e) {
           if (e instanceof AttachmentUploadError) {
@@ -1315,8 +1433,7 @@ export function registerTools(server: Server) {
       let selfName = a.name as string | undefined;
       if (!selfName) {
         try {
-          const state = await readState();
-          selfName = state.rooms[a.code]?.name;
+          selfName = (await readRoomStateForSession(a.code))?.name;
         } catch { /* state unavailable */ }
       }
       const timeoutMs = resolvedListenTimeoutMs(a.timeoutMs, harness.maxListenMs);
@@ -1373,7 +1490,7 @@ export function registerTools(server: Server) {
       let requesterName: string | undefined =
         typeof a.name === 'string' && a.name.trim() ? a.name.trim() : undefined;
       if (!requesterName) {
-        try { requesterName = (await readState()).rooms[a.code]?.name; } catch { /* state unavailable */ }
+        try { requesterName = (await readRoomStateForSession(a.code))?.name; } catch { /* state unavailable */ }
       }
       try {
         await endRoom(client, a.code, requesterName ?? '', await readHostKey(a.code));
@@ -1404,8 +1521,7 @@ export function registerTools(server: Server) {
         ? a.name.trim()
         : undefined;
       try {
-        const state = await readState();
-        selfName = selfName ?? state.rooms[a.code]?.name;
+        selfName = selfName ?? (await readRoomStateForSession(a.code))?.name;
       } catch { /* state unavailable */ }
       if (selfName) {
         try {
@@ -1427,7 +1543,7 @@ export function registerTools(server: Server) {
       let requesterName: string | undefined =
         typeof a.name === 'string' && a.name.trim() ? a.name.trim() : undefined;
       if (!requesterName) {
-        try { requesterName = (await readState()).rooms[a.code]?.name; } catch { /* state unavailable */ }
+        try { requesterName = (await readRoomStateForSession(a.code))?.name; } catch { /* state unavailable */ }
       }
       try {
         await reactivateRoom(client, a.code, requesterName ?? '', await readHostKey(a.code));
@@ -1485,15 +1601,9 @@ export function registerTools(server: Server) {
         ? Math.min(Math.max(1000, Math.floor(maxCharsRaw)), 30_000)
         : 12_000;
       try {
-        const read = await readAttachmentText(hit.attachment, maxChars);
-        return ok({
-          ok: true,
-          attachment: hit.attachment,
-          message: hit.message,
-          source: read.source,
-          text: read.text,
-          warning: read.warning,
-        });
+        // Same harness-aware scope as the room client: a PPID-scoped read misses after a Cursor/Codex restart.
+        const read = await readAttachmentText(hit.attachment, maxChars, { accessToken: (await toolCredentialLoader(a.code))?.accessToken });
+        return attachmentReadResult(hit.attachment, hit.message, read);
       } catch (e) {
         return ok({
           ok: false,

--- a/apps/mcp/src/uploadAttachment.ts
+++ b/apps/mcp/src/uploadAttachment.ts
@@ -1,3 +1,4 @@
+import { redactUrl } from './redact.js';
 // Server-side companion to apps/web/src/lib/upload.ts. Lets MCP agents
 // (Claude Code, Cursor, Codex, etc.) ship binary content into a room
 // via room_send's `attachments` arg without needing to touch R2 / Vercel
@@ -154,6 +155,8 @@ export async function uploadAgentAttachment(
     fetch?: typeof fetch;
     FormData?: typeof FormData;
     Blob?: typeof Blob;
+    accessToken?: string;
+    participantToken?: string;
   } = {},
 ): Promise<MessageAttachment> {
   if (!/^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{3}$/.test(roomCode)) {
@@ -175,10 +178,17 @@ export async function uploadAgentAttachment(
 
   let resp: Response;
   try {
-    resp = await fetchFn(uploadEndpoint(), { method: 'POST', body: fd as unknown as BodyInit });
+    resp = await fetchFn(uploadEndpoint(), {
+      method: 'POST',
+      headers: {
+        ...(deps.accessToken ? { 'x-agent-room-access': deps.accessToken } : {}),
+        ...(deps.participantToken ? { authorization: `Bearer ${deps.participantToken}` } : {}),
+      },
+      body: fd as unknown as BodyInit,
+    });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'network failure';
-    throw new AttachmentUploadError('network_error', `POST ${uploadEndpoint()} failed: ${msg}`);
+    throw new AttachmentUploadError('network_error', `POST ${redactUrl(uploadEndpoint())} failed: ${msg}`);
   }
 
   if (!resp.ok) {

--- a/apps/mcp/test/attachmentFetch.test.ts
+++ b/apps/mcp/test/attachmentFetch.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { attachmentAuthHeaders, fetchAttachmentBytes, readAttachmentText, resolveAttachmentUrl } from '../src/tools.js';
+
+afterEach(() => { delete process.env.AGENT_ROOM_BASE_URL; vi.unstubAllGlobals(); });
+
+describe('attachment reader against a self-hosted room', () => {
+  it('resolves a relative attachment url against the room base and presents the access header', async () => {
+    process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+    expect(resolveAttachmentUrl('/attachments/ABC-file.txt')).toBe('https://room.example/attachments/ABC-file.txt');
+    expect(resolveAttachmentUrl('https://cdn.example/x.txt')).toBe('https://cdn.example/x.txt');
+    const seen: Array<{ url: string; headers: Record<string, string> }> = [];
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, headers: { ...(init?.headers as Record<string, string>) } });
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as unknown as typeof fetch;
+    const bytes = await fetchAttachmentBytes('/attachments/ABC-file.txt', 1024, { accessToken: 'a'.repeat(43) }, fetchFn);
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    expect(seen).toEqual([{ url: 'https://room.example/attachments/ABC-file.txt', headers: { 'x-agent-room-access': 'a'.repeat(43) } }]);
+  });
+});
+
+describe('room capability never leaves the room origin', () => {
+  it('sends the access header to the room origin only, never to a third-party attachment host', async () => {
+    process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+    const auth = { accessToken: 'a'.repeat(43) };
+    expect(attachmentAuthHeaders('https://room.example/attachments/x.txt', auth)).toEqual({ 'x-agent-room-access': auth.accessToken });
+    expect(attachmentAuthHeaders('https://cdn.example/x.txt', auth)).toEqual({});
+    expect(attachmentAuthHeaders('https://room.example.evil.test/x.txt', auth)).toEqual({});
+    const seen: Array<{ url: string; headers: Record<string, string> }> = [];
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, headers: { ...(init?.headers as Record<string, string>) } });
+      return new Response(new Uint8Array([9]), { status: 200 });
+    }) as unknown as typeof fetch;
+    await fetchAttachmentBytes('https://cdn.example/public.txt', 1024, auth, fetchFn);
+    await fetchAttachmentBytes('/attachments/ABC-x.txt', 1024, auth, fetchFn);
+    expect(seen).toEqual([
+      { url: 'https://cdn.example/public.txt', headers: {} },
+      { url: 'https://room.example/attachments/ABC-x.txt', headers: { 'x-agent-room-access': auth.accessToken } },
+    ]);
+  });
+});
+
+describe('attachment download size boundary', () => {
+  it('drops room credentials when a same-origin attachment redirects cross-origin', async () => {
+    process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+    const seen: Array<{ url: string; headers: Record<string, string>; redirect?: RequestRedirect }> = [];
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, headers: { ...(init?.headers as Record<string, string>) }, redirect: init?.redirect });
+      if (url === 'https://room.example/attachments/x.txt') {
+        return new Response(null, { status: 302, headers: { location: 'https://cdn.example/x.txt' } });
+      }
+      return new Response(new Uint8Array([7]), { status: 200 });
+    }) as unknown as typeof fetch;
+    await fetchAttachmentBytes('/attachments/x.txt', 10, { accessToken: 'a'.repeat(43) }, fetchFn);
+    expect(seen).toEqual([
+      { url: 'https://room.example/attachments/x.txt', headers: { 'x-agent-room-access': 'a'.repeat(43) }, redirect: 'manual' },
+      { url: 'https://cdn.example/x.txt', headers: {}, redirect: 'manual' },
+    ]);
+  });
+
+  it('rejects an oversized Content-Length before reading the body', async () => {
+    const bodyRead = vi.fn();
+    const response = {
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-length': '1025' }),
+      get body() { bodyRead(); throw new Error('body must not be read'); },
+      arrayBuffer: vi.fn(() => { throw new Error('arrayBuffer must not be called'); }),
+    } as unknown as Response;
+    const fetchFn = vi.fn(async () => response) as unknown as typeof fetch;
+
+    await expect(fetchAttachmentBytes('/attachments/too-large.bin', 1024, {}, fetchFn))
+      .rejects.toThrow('Attachment is 1025 bytes');
+    expect(bodyRead).not.toHaveBeenCalled();
+    expect(response.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it('cancels a chunked stream as soon as its cumulative bytes exceed the cap', async () => {
+    const cancel = vi.fn(async () => undefined);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(6));
+        controller.enqueue(new Uint8Array(5));
+        controller.enqueue(new Uint8Array(99));
+      },
+      cancel,
+    });
+    const arrayBuffer = vi.fn(() => { throw new Error('arrayBuffer must not be called'); });
+    const response = {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body,
+      arrayBuffer,
+    } as unknown as Response;
+    const fetchFn = vi.fn(async () => response) as unknown as typeof fetch;
+
+    await expect(fetchAttachmentBytes('/attachments/chunked.bin', 10, {}, fetchFn))
+      .rejects.toThrow('Attachment exceeds 10 bytes');
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it('returns exact bytes from an under-cap streamed body without arrayBuffer', async () => {
+    const arrayBuffer = vi.fn(() => { throw new Error('arrayBuffer must not be called'); });
+    const response = new Response(new Uint8Array([1, 3, 5, 7]), { status: 200 });
+    Object.defineProperty(response, 'arrayBuffer', { value: arrayBuffer });
+    const fetchFn = vi.fn(async () => response) as unknown as typeof fetch;
+
+    await expect(fetchAttachmentBytes('/attachments/small.bin', 4, {}, fetchFn))
+      .resolves.toEqual(new Uint8Array([1, 3, 5, 7]));
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(response.body?.locked).toBe(false);
+  });
+});
+
+describe('self-hosted image attachments', () => {
+  it('returns the image bytes through the authenticated reader instead of a url the caller cannot open', async () => {
+    process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+    const seen: Array<{ url: string; headers: Record<string, string> }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, headers: { ...(init?.headers as Record<string, string>) } });
+      return new Response(new Uint8Array([137, 80, 78, 71]), { status: 200 });
+    }));
+    const read = await readAttachmentText(
+      { id: 'i1', type: 'image', url: '/attachments/ABC-pic.png', storageKey: 'k', name: 'pic.png', size: 4, mime: 'image/png', uploadedAt: 1 },
+      1000,
+      { accessToken: 'a'.repeat(43) },
+    );
+    expect(read.source).toBe('fetched_image');
+    expect(read.mime).toBe('image/png');
+    expect(Buffer.from(read.image ?? '', 'base64')).toEqual(Buffer.from([137, 80, 78, 71]));
+    expect(read.warning).toBeUndefined();
+    expect(seen).toEqual([{ url: 'https://room.example/attachments/ABC-pic.png', headers: { 'x-agent-room-access': 'a'.repeat(43) } }]);
+  });
+});

--- a/apps/mcp/test/attachmentTool.test.ts
+++ b/apps/mcp/test/attachmentTool.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+type Handler = (req: any) => Promise<any>;
+
+const savedClaude = { CLAUDECODE: process.env.CLAUDECODE, CLAUDE_CODE_ENTRYPOINT: process.env.CLAUDE_CODE_ENTRYPOINT };
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.AGENT_ROOM_STATE_DIR; delete process.env.CODEX_RUN_ID; delete process.env.CODEX_THREAD_ID; delete process.env.AGENT_ROOM_STATE_FILE; delete process.env.AGENT_ROOM_BASE_URL; delete process.env.AGENT_ROOM_PROFILE;
+  if (savedClaude.CLAUDECODE !== undefined) process.env.CLAUDECODE = savedClaude.CLAUDECODE;
+  if (savedClaude.CLAUDE_CODE_ENTRYPOINT !== undefined) process.env.CLAUDE_CODE_ENTRYPOINT = savedClaude.CLAUDE_CODE_ENTRYPOINT;
+});
+
+const CODE = 'ABC-DEF-GHJ';
+const ACCESS = 'a'.repeat(43); const PART = 'p'.repeat(43);
+
+/** Codex harness after a wrapper restart: joins live only in the harness-scoped state file. */
+function arrangeHarnessOnlyState() {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-room-tool-'));
+  process.env.AGENT_ROOM_STATE_DIR = dir;
+  process.env.CODEX_RUN_ID = 'run-1';
+  process.env.CODEX_THREAD_ID = '';
+  // The test itself may run under Claude Code; harness detection must see Codex.
+  delete process.env.CLAUDECODE; delete process.env.CLAUDE_CODE_ENTRYPOINT;
+  delete process.env.AGENT_ROOM_STATE_FILE;
+  process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+  const scope = createHash('sha256').update('run-1').digest('hex').slice(0, 16);
+  writeFileSync(join(dir, `state-harness-codex-${scope}.json`), JSON.stringify({
+    version: 1,
+    rooms: { [CODE]: { name: 'Me', cursor: 0, joinedAt: 1, accessToken: ACCESS, participantToken: PART } },
+  }));
+}
+
+function stubFetch(attachment: { name: string; mime: string; type: 'image' | 'file'; bytes: number[] }) {
+  const calls: Array<{ url: string; headers: Record<string, string>; body?: string }> = [];
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, headers: { ...(init?.headers as Record<string, string>) }, body: init?.body ? String(init.body) : undefined });
+    if (url.endsWith('/api/room')) {
+      const action = JSON.parse(String(init?.body)).action;
+      if (action === 'messages') {
+        return new Response(JSON.stringify({ messages: [{ id: 1, type: 'msg', name: 'Peer', initials: 'PE', color: '#000', role: 'Dev', text: 'see attached', client: 'cc', time: 1,
+          attachments: [{ id: 'att-1', type: attachment.type, url: `/attachments/${CODE}-att-1-${attachment.name}`, storageKey: 'k', name: attachment.name, size: attachment.bytes.length, mime: attachment.mime, uploadedAt: 1 }] }] }),
+          { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ result: { cursor: 1 } }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(new Uint8Array(attachment.bytes), { status: 200 });
+  }));
+  return calls;
+}
+
+async function tools() {
+  vi.resetModules();
+  const { registerTools } = await import('../src/tools.js');
+  const handlers = new Map<unknown, Handler>();
+  const server = { setRequestHandler(schema: unknown, handler: Handler) { handlers.set(schema, handler); } } as unknown as Server;
+  registerTools(server);
+  return (name: string, args: Record<string, unknown>) => handlers.get(CallToolRequestSchema)!({ params: { name, arguments: args } });
+}
+
+describe('tool client after a harness restart', () => {
+  it('room_send carries both capabilities from the harness-scoped state on its first call', async () => {
+    arrangeHarnessOnlyState();
+    const calls = stubFetch({ name: 'x.txt', mime: 'text/plain', type: 'file', bytes: [] });
+    const call = await tools();
+    await call('room_send', { code: CODE, name: 'Me', text: 'hello' });
+    const first = calls.find((c) => c.url.endsWith('/api/room') && c.body?.includes('"action":"send"'));
+    expect(first, 'send request').toBeDefined();
+    expect(first!.headers['x-agent-room-access']).toBe(ACCESS);
+    expect(first!.headers.authorization).toBe(`Bearer ${PART}`);
+  });
+});
+
+describe('room_attachment_read on a self-hosted room', () => {
+  it('is readable through the authenticated core profile', async () => {
+    arrangeHarnessOnlyState();
+    process.env.AGENT_ROOM_PROFILE = 'core';
+    const calls = stubFetch({ name: 'proof.txt', mime: 'text/plain', type: 'file', bytes: [112, 114, 111, 111, 102] });
+    const call = await tools();
+    const res = await call('room_attachment_read', { code: CODE, id: 'att-1' });
+    expect(res.content.map((part: any) => part.text ?? '').join('\n')).toContain('proof');
+    const get = calls.find((c) => c.url.includes('/attachments/'));
+    expect(get!.headers['x-agent-room-access']).toBe(ACCESS);
+  });
+
+  it('returns an MCP image block for an image attachment', async () => {
+    arrangeHarnessOnlyState();
+    const calls = stubFetch({ name: 'pic.png', mime: 'image/png', type: 'image', bytes: [137, 80, 78, 71] });
+    const call = await tools();
+    const res = await call('room_attachment_read', { code: CODE, id: 'att-1' });
+    const image = res.content.find((c: any) => c.type === 'image');
+    expect(image).toBeDefined();
+    expect(image.mimeType).toBe('image/png');
+    expect(Buffer.from(image.data, 'base64')).toEqual(Buffer.from([137, 80, 78, 71]));
+    const get = calls.find((c) => c.url.includes('/attachments/'));
+    expect(get!.url).toBe(`https://room.example/attachments/${CODE}-att-1-pic.png`);
+    expect(get!.headers['x-agent-room-access']).toBe(ACCESS);
+  });
+
+  it('returns a resource blob for an allowed but unsupported format and never a raw protected url', async () => {
+    arrangeHarnessOnlyState();
+    const calls = stubFetch({ name: 'bundle.zip', mime: 'application/zip', type: 'file', bytes: [80, 75, 3, 4] });
+    const call = await tools();
+    const res = await call('room_attachment_read', { code: CODE, id: 'att-1' });
+    const blob = res.content.find((c: any) => c.type === 'resource');
+    expect(blob).toBeDefined();
+    expect(blob.resource.mimeType).toBe('application/zip');
+    expect(Buffer.from(blob.resource.blob, 'base64')).toEqual(Buffer.from([80, 75, 3, 4]));
+    const texts = res.content.filter((c: any) => c.type === 'text').map((c: any) => c.text).join('\n');
+    expect(texts).not.toContain('/attachments/');
+    const get = calls.find((c) => c.url.includes('/attachments/'));
+    expect(get!.headers['x-agent-room-access']).toBe(ACCESS);
+  });
+});

--- a/apps/mcp/test/credentialRehydrate.test.ts
+++ b/apps/mcp/test/credentialRehydrate.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoomApiClient } from '../src/roomApi.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.AGENT_ROOM_STATE_FILE;
+  delete process.env.AGENT_ROOM_STATE_DIR;
+  delete process.env.CODEX_RUN_ID;
+});
+
+function captureFetch() {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, headers: { ...(init.headers as Record<string, string>) } });
+    return new Response(JSON.stringify({ result: { cursor: 1 } }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }));
+  return calls;
+}
+
+function harnessFile(dir: string, sessionId: string) {
+  const scope = createHash('sha256').update(sessionId).digest('hex').slice(0, 16);
+  return join(dir, `state-harness-codex-${scope}.json`);
+}
+
+describe('room credential rehydration after restart', () => {
+  it('a fresh client sends the persisted capabilities on its first authenticated call', async () => {
+    const calls = captureFetch();
+    const client = createRoomApiClient({
+      loadCredentials: async (code) => (code === 'ABC-DEF-GHJ' ? { accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } : undefined),
+    });
+    await client.post({ action: 'send', code: 'ABC-DEF-GHJ', message: { text: 'hi' } });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.headers['x-agent-room-access']).toBe('a'.repeat(43));
+    expect(calls[0]!.headers.authorization).toBe(`Bearer ${'p'.repeat(43)}`);
+    client.setCredentials('ABC-DEF-GHJ', { accessToken: 'b'.repeat(43) });
+    await client.post({ action: 'messages', code: 'ABC-DEF-GHJ', cursor: 0 });
+    expect(calls[1]!.headers['x-agent-room-access']).toBe('b'.repeat(43));
+    expect(calls[1]!.headers.authorization).toBe(`Bearer ${'p'.repeat(43)}`);
+  });
+
+  it('the state-file loader returns the capabilities an earlier join persisted', async () => {
+    // STATE_FILE is bound when the state module loads, so point the env at a
+    // temp file and load the loader fresh.
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-cred-'));
+    process.env.AGENT_ROOM_STATE_FILE = join(dir, 'state.json');
+    vi.resetModules();
+    const { toolCredentialLoader: stateCredentialLoader } = await import('../src/credentials.js');
+    await writeFile(process.env.AGENT_ROOM_STATE_FILE, JSON.stringify({
+      version: 1,
+      rooms: { 'ABC-DEF-GHJ': { code: 'ABC-DEF-GHJ', name: 'Me', role: 'Dev', cursor: 0, joinedAt: 1, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    expect(await stateCredentialLoader('ABC-DEF-GHJ')).toEqual({ accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) });
+    expect(await stateCredentialLoader('NOP-QRS-TUV')).toBeUndefined();
+  });
+
+  it('does not recover a room from a foreign scoped state', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-cred-merged-'));
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'test-run';
+    await writeFile(harnessFile(dir, 'test-run'), JSON.stringify({
+      version: 1, rooms: { 'HAR-NES-SON': { name: 'Other', cursor: 0, joinedAt: 2, accessToken: 'h'.repeat(43) } },
+    }));
+    await writeFile(join(dir, 'state-111.json'), JSON.stringify({
+      version: 1, rooms: { 'SCO-PED-ONE': { name: 'Me', cursor: 0, joinedAt: 3, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    vi.resetModules();
+    const { toolCredentialLoader } = await import('../src/credentials.js');
+    expect(await toolCredentialLoader('SCO-PED-ONE')).toBeUndefined();
+  });
+
+  it('keeps the current participant token when a newer foreign participant shares the room', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-cred-identity-'));
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'test-run';
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    const code = 'SHR-RUM-ONE';
+    await writeFile(join(dir, `state-${process.ppid}.json`), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session A', client: 'cc', cursor: 0, joinedAt: 1, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    await writeFile(join(dir, 'state-999999.json'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session B', client: 'cc', cursor: 0, joinedAt: 99, accessToken: 'b'.repeat(43), participantToken: 'q'.repeat(43) } },
+    }));
+    vi.resetModules();
+    const calls = captureFetch();
+    const { toolCredentialLoader } = await import('../src/credentials.js');
+    const client = createRoomApiClient({ loadCredentials: toolCredentialLoader });
+    await client.post({ action: 'send', code, message: { text: 'from A' } });
+    expect(calls[0]!.headers['x-agent-room-access']).toBe('a'.repeat(43));
+    expect(calls[0]!.headers.authorization).toBe(`Bearer ${'p'.repeat(43)}`);
+  });
+
+  it('returns no credentials when only a foreign participant has capabilities', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-cred-foreign-'));
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'test-run';
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    const code = 'SHR-RUM-TWO';
+    await writeFile(join(dir, `state-${process.ppid}.json`), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session A', client: 'cc', cursor: 0, joinedAt: 1 } },
+    }));
+    await writeFile(join(dir, 'state-999998.json'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session B', client: 'cc', cursor: 0, joinedAt: 99, accessToken: 'b'.repeat(43), participantToken: 'q'.repeat(43) } },
+    }));
+    vi.resetModules();
+    const { toolCredentialLoader } = await import('../src/credentials.js');
+    expect(await toolCredentialLoader(code)).toBeUndefined();
+  });
+});

--- a/apps/mcp/test/hookRehydrate.test.ts
+++ b/apps/mcp/test/hookRehydrate.test.ts
@@ -1,0 +1,177 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  process.env.CODEX_THREAD_ID = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.AGENT_ROOM_STATE_DIR; delete process.env.CODEX_RUN_ID; delete process.env.CODEX_THREAD_ID; delete process.env.AGENT_ROOM_STATE_FILE;
+});
+
+function harnessFile(dir: string, sessionId = 'run-1') {
+  const scope = createHash('sha256').update(sessionId).digest('hex').slice(0, 16);
+  return join(dir, `state-harness-codex-${scope}.json`);
+}
+
+describe('hook credential rehydration across process scopes', () => {
+  it('a room known only to the harness-scoped state file is listed with both capabilities from that same snapshot', async () => {
+    // Codex harness: the hook reads its run-scoped harness file; this hook process's
+    // own PPID-scoped file does not exist, so a PPID-scoped loader would miss.
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-hook-'));
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'run-1';
+    process.env.CODEX_THREAD_ID = '';
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    writeFileSync(harnessFile(dir), JSON.stringify({
+      version: 1,
+      rooms: { 'ABC-DEF-GHJ': { name: 'Me', cursor: 0, joinedAt: 1, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    const calls: Array<{ headers: Record<string, string>; body: string }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      calls.push({ headers: { ...(init.headers as Record<string, string>) }, body: String(init.body) });
+      return new Response(JSON.stringify({ messages: [] }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    vi.resetModules();
+    const { fetchPending } = await import('../src/hook.js');
+    await fetchPending('harness');
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0]!.body).toContain('"code":"ABC-DEF-GHJ"');
+    expect(calls[0]!.headers['x-agent-room-access']).toBe('a'.repeat(43));
+    expect(calls[0]!.headers.authorization).toBe(`Bearer ${'p'.repeat(43)}`);
+  });
+});
+
+describe('Stop cleanup keeps live rooms through outages', () => {
+  async function arrange(responder: () => Promise<Response>) {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-prune-'));
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'run-1';
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    const file = harnessFile(dir);
+    writeFileSync(file, JSON.stringify({
+      version: 1,
+      rooms: { 'ABC-DEF-GHJ': { name: 'Me', cursor: 3, joinedAt: 1, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    vi.stubGlobal('fetch', vi.fn(responder));
+    vi.resetModules();
+    const { pruneRooms } = await import('../src/hook.js');
+    const active = await pruneRooms('harness');
+    const rooms = existsSync(file)
+      ? Object.keys(JSON.parse(readFileSync(file, 'utf8')).rooms)
+      : [];
+    return { active, rooms };
+  }
+
+  it('retains the room when the room API is unreachable', async () => {
+    const { active, rooms } = await arrange(async () => { throw new Error('getaddrinfo ENOTFOUND room.example'); });
+    expect(rooms).toEqual(['ABC-DEF-GHJ']);
+    expect(active).toEqual([]);
+  });
+
+  it('retains the room on an auth failure', async () => {
+    const { rooms } = await arrange(async () => new Response(JSON.stringify({ error: 'room_access_required', message: 'Room access token required.' }), { status: 401, headers: { 'content-type': 'application/json' } }));
+    expect(rooms).toEqual(['ABC-DEF-GHJ']);
+  });
+
+  it('removes a stale room when both owned capabilities receive 403', async () => {
+    const { rooms } = await arrange(async () => new Response(JSON.stringify({ error: 'room_access_denied', message: 'Room access denied.' }), { status: 403, headers: { 'content-type': 'application/json' } }));
+    expect(rooms).toEqual([]);
+  });
+
+  it('marks retained transport failures so the same Stop skips long polling', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-prune-failure-'));
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'run-1';
+    writeFileSync(harnessFile(dir), JSON.stringify({
+      version: 1,
+      rooms: { 'ABC-DEF-GHJ': { name: 'Me', cursor: 3, joinedAt: 1, accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43) } },
+    }));
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND room.example'); }));
+    vi.resetModules();
+    const { pruneRoomsForStop, shouldLongPollAfterPrune } = await import('../src/hook.js');
+    const result = await pruneRoomsForStop('harness');
+    expect(result).toEqual({ activeRooms: [], hadRetainedFailure: true });
+    expect(shouldLongPollAfterPrune(result)).toBe(false);
+  });
+
+  it('removes the room only on a definitive not-found answer', async () => {
+    const { rooms } = await arrange(async () => new Response(JSON.stringify({ error: 'RoomNotFoundError', message: 'Room not found: ABC-DEF-GHJ' }), { status: 404, headers: { 'content-type': 'application/json' } }));
+    expect(rooms).toEqual([]);
+  });
+});
+
+describe('harness hook mutations stay in the active session', () => {
+  it('cursor commit and room removal leave a second Codex session byte-identical', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-hook-session-scope-'));
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'run-a';
+    process.env.CODEX_THREAD_ID = '';
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    const code = 'ABC-DEF-GHJ';
+    const runA = harnessFile(dir, 'run-a');
+    const runB = harnessFile(dir, 'run-b');
+    const room = (name: string, cursor: number) => ({
+      version: 1,
+      blockStreak: 0,
+      rooms: { [code]: {
+        name, cursor, joinedAt: 1,
+        accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43),
+      } },
+    });
+    writeFileSync(runA, JSON.stringify(room('Session A', 2), null, 2));
+    writeFileSync(runB, JSON.stringify(room('Session B', 9), null, 2));
+    const runBBefore = readFileSync(runB, 'utf8');
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: 'room_access_denied', message: 'Room access denied.',
+    }), { status: 403, headers: { 'content-type': 'application/json' } })));
+    vi.resetModules();
+    const { commitCursors, pruneRoomsForStop } = await import('../src/hook.js');
+
+    await commitCursors([{
+      code, topic: 'Synthetic', selfName: 'Session A', newCursor: 7, messages: [],
+    }], 'harness');
+    expect(JSON.parse(readFileSync(runA, 'utf8')).rooms[code].cursor).toBe(7);
+    expect(readFileSync(runB, 'utf8')).toBe(runBBefore);
+
+    await pruneRoomsForStop('harness');
+    expect(existsSync(runA)).toBe(false);
+    expect(readFileSync(runB, 'utf8')).toBe(runBBefore);
+  });
+
+  it('block-streak bump and production prompt reset leave a second Codex session byte-identical', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-room-hook-streak-scope-'));
+    process.env.AGENT_ROOM_STATE_DIR = dir;
+    process.env.CODEX_RUN_ID = 'run-a';
+    process.env.CODEX_THREAD_ID = '';
+    delete process.env.AGENT_ROOM_STATE_FILE;
+    const runA = harnessFile(dir, 'run-a');
+    const runB = harnessFile(dir, 'run-b');
+    writeFileSync(runA, JSON.stringify({ version: 1, blockStreak: 0, rooms: {} }, null, 2));
+    writeFileSync(runB, JSON.stringify({ version: 1, blockStreak: 17, rooms: {} }, null, 2));
+    const runBBefore = readFileSync(runB, 'utf8');
+
+    vi.resetModules();
+    const state = await import('../src/state.js');
+    for (let index = 0; index < 60; index += 1) {
+      await state.bumpBlockStreakEverywhere();
+    }
+    expect(JSON.parse(readFileSync(runA, 'utf8')).blockStreak).toBe(60);
+    expect(readFileSync(runB, 'utf8')).toBe(runBBefore);
+
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('synthetic offline'); }));
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('synthetic exit');
+    }) as never);
+    const { runHook } = await import('../src/hook.js');
+    await expect(runHook({ hook_event_name: 'UserPromptSubmit' })).rejects.toThrow('synthetic exit');
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(JSON.parse(readFileSync(runA, 'utf8')).blockStreak).toBe(0);
+    expect(readFileSync(runB, 'utf8')).toBe(runBBefore);
+  });
+});

--- a/apps/mcp/test/httpAuth.test.ts
+++ b/apps/mcp/test/httpAuth.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAuthorizedMcpHttpHandler, protectedResourceMetadata } from '../src/httpAuth.js';
+
+describe('HTTP MCP OAuth 2.1 gate', () => {
+  it('dispatches an audience-and-scope-bound principal without forwarding its bearer token', async () => {
+    const dispatch = vi.fn(async (request, principal) => ({ status: 200, body: { request, principal } }));
+    const verifier = { verify: vi.fn(async () => ({
+      subject: 'agent-1', fleetId: 'fleet-1', issuer: 'https://issuer.invalid',
+      audience: 'https://room.invalid/mcp', expiresAt: 2_000,
+      scopes: ['agent-room:mcp'],
+    })) };
+    const handler = createAuthorizedMcpHttpHandler({
+      resource: 'https://room.invalid/mcp',
+      metadataUrl: 'https://room.invalid/.well-known/oauth-protected-resource',
+      verifier, dispatch, trustedIssuers: ['https://issuer.invalid'], now: () => 1_000,
+    });
+
+    const response = await handler({ headers: { authorization: 'Bearer secret-token', 'x-request-id': 'r-1' } });
+
+    expect(response.status).toBe(200);
+    expect(verifier.verify).toHaveBeenCalledWith('secret-token', {
+      resource: 'https://room.invalid/mcp', requiredScope: 'agent-room:mcp',
+    });
+    expect(dispatch.mock.calls[0]?.[0].headers.authorization).toBeUndefined();
+  });
+
+  it('refuses an invalid token before MCP dispatch with protected-resource metadata', async () => {
+    const dispatch = vi.fn();
+    const handler = createAuthorizedMcpHttpHandler({
+      resource: 'https://room.invalid/mcp',
+      metadataUrl: 'https://room.invalid/.well-known/oauth-protected-resource',
+      verifier: { verify: async () => { throw new Error('bad token'); } }, dispatch,
+      trustedIssuers: ['https://issuer.invalid'],
+    });
+
+    expect(await handler({ headers: { authorization: 'Bearer bad' } })).toEqual({
+      status: 401,
+      headers: { 'www-authenticate': 'Bearer resource_metadata="https://room.invalid/.well-known/oauth-protected-resource"' },
+      body: { error: 'invalid_token' },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(protectedResourceMetadata('https://room.invalid/mcp', ['https://issuer.invalid']))
+      .toMatchObject({ resource: 'https://room.invalid/mcp', authorization_servers: ['https://issuer.invalid'] });
+  });
+
+  it.each([
+    ['wrong audience', { audience: 'https://other.invalid/mcp' }],
+    ['missing issuer', { issuer: '' }],
+    ['expired token', { expiresAt: 999 }],
+  ] as const)('refuses a principal with %s before dispatch', async (_label, override) => {
+    const dispatch = vi.fn();
+    const principal = { subject: 'agent-1', fleetId: 'fleet-1', issuer: 'https://issuer.invalid',
+      audience: 'https://room.invalid/mcp', expiresAt: 2_000, scopes: ['agent-room:mcp'], ...override };
+    const handler = createAuthorizedMcpHttpHandler({
+      resource: 'https://room.invalid/mcp',
+      metadataUrl: 'https://room.invalid/.well-known/oauth-protected-resource',
+      verifier: { verify: async () => principal }, dispatch,
+      trustedIssuers: ['https://issuer.invalid'], now: () => 1_000,
+    });
+
+    expect((await handler({ headers: { authorization: 'Bearer token' } })).status).toBe(401);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/test/profile.test.ts
+++ b/apps/mcp/test/profile.test.ts
@@ -1,5 +1,5 @@
-// The consolidated tool surface: 7 core tools + 4 extras (task board, host
-// admin, watch, attachment reader) — with every pre-consolidation name still
+// The consolidated tool surface: 8 core tools + 3 extras (task board, host
+// admin, watch) — with every pre-consolidation name still
 // dispatching as a hidden alias, and AGENT_ROOM_PROFILE=core gating on the
 // canonical (listed) name so legacy core calls like room_status keep working.
 
@@ -42,14 +42,15 @@ describe('consolidated tool surface', () => {
     expect(names).not.toContain('room_list_messages');
   });
 
-  it('core profile lists exactly the 7 core tools', async () => {
+  it('core profile includes the authenticated attachment reader', async () => {
     process.env.AGENT_ROOM_PROFILE = 'core';
     const { server, handlers } = captureHandlers();
     registerTools(server);
     const { tools } = await handlers.get(ListToolsRequestSchema)!({});
     const names = tools.map((t: { name: string }) => t.name).sort();
     expect(names).toEqual([...CORE_PROFILE_TOOLS].sort());
-    expect(names).toHaveLength(7);
+    expect(names).toHaveLength(8);
+    expect(names).toContain('room_attachment_read');
   });
 
   it('core profile refuses full-only tools (and their aliases) with a hint', async () => {

--- a/apps/mcp/test/redact.test.ts
+++ b/apps/mcp/test/redact.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { redactUrl } from '../src/redact.js';
+import { fetchAttachmentBytes, readAttachmentText } from '../src/tools.js';
+
+afterEach(() => { delete process.env.AGENT_ROOM_BASE_URL; vi.unstubAllGlobals(); });
+
+describe('urls in errors and logs carry no capability', () => {
+  it('strips query, fragment and userinfo but keeps origin and path', () => {
+    expect(redactUrl('https://room.example/attachments/ABC-x.txt?access=legacy-secret-capability')).toBe('https://room.example/attachments/ABC-x.txt');
+    expect(redactUrl('https://user:pw@room.example/api/room#frag')).toBe('https://room.example/api/room');
+    expect(redactUrl('/attachments/ABC-x.txt?access=legacy-secret-capability')).toBe('/attachments/ABC-x.txt');
+  });
+
+  it('a failed legacy attachment fetch names the status and the path, never the token', async () => {
+    process.env.AGENT_ROOM_BASE_URL = 'https://room.example';
+    const fetchFn = vi.fn(async () => new Response('denied', { status: 403 })) as unknown as typeof fetch;
+    const url = '/attachments/ABC-x.txt?access=legacy-secret-capability';
+    let message = '';
+    try { await fetchAttachmentBytes(url, 1024, {}, fetchFn); } catch (error) { message = (error as Error).message; }
+    expect(message).toContain('403');
+    expect(message).toContain('/attachments/ABC-x.txt');
+    expect(message).not.toContain('legacy-secret-capability');
+    expect(message).not.toContain('access=');
+    // A blob-read failure surfaces the same redacted message.
+    vi.stubGlobal('fetch', fetchFn);
+    let blobMessage = '';
+    try { await readAttachmentText({ id: 'u', type: 'file', url, storageKey: 'k', name: 'x.bin', size: 1, mime: 'application/x-unknown', uploadedAt: 1 }, 100); }
+    catch (error) { blobMessage = (error as Error).message; }
+    expect(blobMessage).toContain('/attachments/ABC-x.txt');
+    expect(blobMessage).not.toContain('legacy-secret-capability');
+  });
+});

--- a/apps/mcp/test/state.test.ts
+++ b/apps/mcp/test/state.test.ts
@@ -1,11 +1,33 @@
 import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { mergeStates, type AgentRoomState } from '../src/state.js';
 
 async function makeStateDir(prefix: string) {
   return fs.mkdtemp(join(tmpdir(), prefix));
+}
+
+function harnessFile(dir: string, kind: string, sessionId: string) {
+  const scope = createHash('sha256').update(sessionId).digest('hex').slice(0, 16);
+  return join(dir, `state-harness-${kind}-${scope}.json`);
+}
+
+async function invokeRoomEnd(code: string) {
+  const handlers = new Map<unknown, (request: any) => Promise<any>>();
+  const server = {
+    setRequestHandler(schema: unknown, handler: (request: any) => Promise<any>) {
+      handlers.set(schema, handler);
+    },
+  } as unknown as Server;
+  const { registerTools } = await import('../src/tools.js');
+  registerTools(server);
+  return handlers.get(CallToolRequestSchema)!({
+    params: { name: 'room_end', arguments: { code } },
+  });
 }
 
 afterEach(() => {
@@ -86,6 +108,7 @@ describe('state harness files', () => {
     // clear them so the tests pass when the suite runs inside Claude Code.
     vi.stubEnv('CLAUDECODE', '');
     vi.stubEnv('CLAUDE_CODE_ENTRYPOINT', '');
+    vi.stubEnv('CODEX_THREAD_ID', '');
   });
 
   it('writes stable Codex harness state alongside the PPID-scoped state', async () => {
@@ -101,13 +124,134 @@ describe('state harness files', () => {
     });
 
     const files = await fs.readdir(dir);
-    expect(files).toContain('state-harness-codex.json');
+    const filename = harnessFile(dir, 'codex', 'test-run');
+    expect(files).toContain(filename.split('/').at(-1));
 
-    const harnessRaw = await fs.readFile(join(dir, 'state-harness-codex.json'), 'utf8');
+    const harnessRaw = await fs.readFile(filename, 'utf8');
     expect(JSON.parse(harnessRaw).rooms['ABC-DEF-GHJ']).toMatchObject({
       name: 'Codex',
       cursor: 2,
     });
+  });
+
+  it('prunes empty per-session harness files after sessions leave', async () => {
+    const dir = await makeStateDir('agent-room-state-prune-harness-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+
+    for (const sessionId of ['run-a', 'run-b', 'run-c']) {
+      vi.stubEnv('CODEX_RUN_ID', sessionId);
+      vi.resetModules();
+      const stateModule = await import('../src/state.js');
+      await stateModule.setRoom('ABC-DEF-GHJ', {
+        name: sessionId, cursor: 0, joinedAt: 1,
+      });
+      await stateModule.removeRoomEverywhere('ABC-DEF-GHJ');
+    }
+
+    const files = await fs.readdir(dir);
+    expect(files.filter((name) => name.startsWith('state-harness-'))).toEqual([]);
+    expect(files.filter((name) => name.startsWith('state-'))).toEqual([
+      `state-${process.ppid}.json`,
+    ]);
+  });
+
+  it('recovers Codex state by thread id and isolates a foreign thread', async () => {
+    const dir = await makeStateDir('agent-room-state-codex-thread-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_HOME', '/synthetic/codex-home');
+    vi.stubEnv('CODEX_THREAD_ID', 'thread-a');
+    vi.stubEnv('CODEX_RUN_ID', '');
+
+    let stateModule = await import('../src/state.js');
+    await stateModule.setRoom('ABC-DEF-GHJ', {
+      name: 'Thread A Host', cursor: 4, joinedAt: 123, hostKey: 'thread-a-host-key',
+    });
+    expect(await fs.readFile(harnessFile(dir, 'codex', 'thread-a'), 'utf8')).toContain('thread-a-host-key');
+
+    vi.resetModules();
+    stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForSession('ABC-DEF-GHJ')).toMatchObject({
+      name: 'Thread A Host', hostKey: 'thread-a-host-key',
+    });
+
+    await fs.rm(join(dir, `state-${process.ppid}.json`));
+    vi.stubEnv('CODEX_THREAD_ID', 'thread-b');
+    vi.resetModules();
+    stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForSession('ABC-DEF-GHJ')).toBeUndefined();
+  });
+
+  it('does not recover join state from a foreign Codex session with the same name', async () => {
+    const dir = await makeStateDir('agent-room-state-join-session-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', 'run-a');
+    await fs.writeFile(harnessFile(dir, 'codex', 'run-a'), JSON.stringify({
+      version: 1,
+      rooms: { 'ABC-DEF-GHJ': {
+        name: 'Same Name', cursor: 8, joinedAt: 123, hostKey: 'foreign-host-key',
+      } },
+    }));
+
+    vi.stubEnv('CODEX_RUN_ID', 'run-b');
+    vi.resetModules();
+    const stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForJoin('ABC-DEF-GHJ', 'Same Name')).toBeUndefined();
+  });
+
+  it('does not treat the Cursor harness marker as a session identity', async () => {
+    const dir = await makeStateDir('agent-room-state-cursor-marker-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_HOME', '');
+    vi.stubEnv('CODEX_RUN_ID', '');
+    vi.stubEnv('CURSOR_TRACE_ID', '');
+    vi.stubEnv('CURSOR_AGENT', '1');
+
+    let stateModule = await import('../src/state.js');
+    await stateModule.setRoom('AAA-BBB-CCC', {
+      name: 'Cursor A Host', cursor: 5, joinedAt: 234, hostKey: 'cursor-a-host-key',
+    });
+    // Model a distinct Cursor process: it has its own PPID file, but presents
+    // the same boolean CURSOR_AGENT marker and no trace identifier.
+    await fs.rm(join(dir, `state-${process.ppid}.json`));
+
+    vi.resetModules();
+    stateModule = await import('../src/state.js');
+    await stateModule.setRoom('DDD-EEE-FFF', {
+      name: 'Cursor B Host', cursor: 6, joinedAt: 345, hostKey: 'cursor-b-host-key',
+    });
+
+    const harnessFiles = (await fs.readdir(dir)).filter((name) =>
+      name.startsWith('state-harness-cursor-'),
+    );
+    expect(harnessFiles).toHaveLength(2);
+
+    // A later restart without a real session identifier gets a fresh scope.
+    // It may recover neither process's host capability from merged state.
+    await fs.rm(join(dir, `state-${process.ppid}.json`));
+    vi.resetModules();
+    stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForSession('AAA-BBB-CCC')).toBeUndefined();
+    expect(await stateModule.readRoomStateForSession('DDD-EEE-FFF')).toBeUndefined();
+  });
+
+  it('never falls back to merged state for a detected harness without an id', async () => {
+    const dir = await makeStateDir('agent-room-state-cursor-nonce-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_HOME', '');
+    vi.stubEnv('CODEX_RUN_ID', '');
+    vi.stubEnv('CURSOR_TRACE_ID', '');
+    vi.stubEnv('CURSOR_AGENT', '');
+    vi.stubEnv('TERM_PROGRAM', 'Cursor');
+    await fs.writeFile(join(dir, 'state-111.json'), JSON.stringify({
+      version: 1, rooms: { 'ABC-DEF-GHJ': {
+        name: 'Foreign Host', cursor: 9, joinedAt: 999, hostKey: 'foreign-host-key',
+      } },
+    }));
+
+    vi.resetModules();
+    const stateModule = await import('../src/state.js');
+    expect((await stateModule.readHarnessStateOrMerged()).rooms).toEqual({});
+    expect(await stateModule.readRoomStateForSession('ABC-DEF-GHJ')).toBeUndefined();
   });
 
   it('reads Codex harness state when the hook PPID state is empty', async () => {
@@ -116,7 +260,7 @@ describe('state harness files', () => {
     vi.stubEnv('CODEX_RUN_ID', 'test-run');
 
     await fs.writeFile(
-      join(dir, 'state-harness-codex.json'),
+      harnessFile(dir, 'codex', 'test-run'),
       JSON.stringify({
         version: 1,
         blockStreak: 0,
@@ -142,6 +286,11 @@ describe('state harness files', () => {
   it('finds a same-name prior room state after the PPID state changes', async () => {
     const dir = await makeStateDir('agent-room-state-rejoin-');
     vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_HOME', '');
+    vi.stubEnv('CODEX_RUN_ID', '');
+    vi.stubEnv('CURSOR_TRACE_ID', '');
+    vi.stubEnv('CURSOR_AGENT', '');
+    vi.stubEnv('TERM_PROGRAM', '');
 
     await fs.writeFile(
       join(dir, 'state-111.json'),
@@ -180,6 +329,158 @@ describe('state harness files', () => {
       name: 'Claude',
       cursor: 7,
     });
+  });
+
+  it('resolves room identity fields from scoped state without crossing participants', async () => {
+    const dir = await makeStateDir('agent-room-state-identity-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', 'test-run');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(join(dir, `state-${process.ppid}.json`), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session A', client: 'cc', cursor: 3, joinedAt: 10 } },
+    }));
+    await fs.writeFile(join(dir, 'state-111.json'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session A', client: 'cc', cursor: 9, joinedAt: 9, hostKey: 'host-a' } },
+    }));
+    await fs.writeFile(join(dir, 'state-222.json'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Session B', client: 'cc', cursor: 99, joinedAt: 99, hostKey: 'host-b' } },
+    }));
+
+    vi.resetModules();
+    const { readRoomStateForCredentials } = await import('../src/state.js');
+    expect(await readRoomStateForCredentials(code)).toMatchObject({
+      name: 'Session A', cursor: 9, hostKey: 'host-a',
+    });
+  });
+
+  it('tools resolve room names and host keys through the identity-scoped reader', async () => {
+    const source = await fs.readFile(join(import.meta.dirname, '../src/tools.ts'), 'utf8');
+    expect(source).not.toMatch(/\breadState\s*\(/);
+    expect(source.match(/readRoomStateForSession\s*\(/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('does not recover a foreign PPID host key for an ordinary harness session', async () => {
+    const dir = await makeStateDir('agent-room-state-foreign-host-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', '');
+    vi.stubEnv('CLAUDECODE', '1');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(join(dir, 'state-111.json'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Foreign Host', client: 'cc', cursor: 7, joinedAt: 10, hostKey: 'foreign-host-key' } },
+    }));
+
+    vi.resetModules();
+    const { readRoomStateForSession } = await import('../src/state.js');
+    expect(await readRoomStateForSession(code)).toBeUndefined();
+  });
+
+  it('recovers the current Codex participant after its PPID changes', async () => {
+    const dir = await makeStateDir('agent-room-state-codex-host-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CODEX_RUN_ID', 'test-run');
+    vi.stubEnv('CLAUDECODE', '');
+    vi.stubEnv('CLAUDE_CODE_ENTRYPOINT', '');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(harnessFile(dir, 'codex', 'test-run'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Codex Host', client: 'cc', cursor: 7, joinedAt: 10, hostKey: 'codex-host-key' } },
+    }));
+
+    vi.resetModules();
+    const { readRoomStateForSession } = await import('../src/state.js');
+    expect(await readRoomStateForSession(code)).toMatchObject({ name: 'Codex Host', hostKey: 'codex-host-key' });
+  });
+
+  it('scopes Codex host recovery to the actual run id', async () => {
+    const dir = await makeStateDir('agent-room-state-codex-run-scope-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('CLAUDECODE', '');
+    vi.stubEnv('CLAUDE_CODE_ENTRYPOINT', '');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(harnessFile(dir, 'codex', 'run-a'), JSON.stringify({
+      version: 1, rooms: { [code]: { name: 'Run A Host', client: 'cc', cursor: 2, joinedAt: 10, hostKey: 'run-a-host-key' } },
+    }));
+
+    vi.stubEnv('CODEX_RUN_ID', 'run-b');
+    vi.resetModules();
+    let stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForSession(code)).toBeUndefined();
+
+    vi.stubEnv('CODEX_RUN_ID', 'run-a');
+    vi.resetModules();
+    stateModule = await import('../src/state.js');
+    expect(await stateModule.readRoomStateForSession(code)).toMatchObject({
+      name: 'Run A Host', hostKey: 'run-a-host-key',
+    });
+  });
+
+  it('production room_end never uses a foreign Codex run host identity', async () => {
+    const dir = await makeStateDir('agent-room-tool-codex-run-scope-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('AGENT_ROOM_BASE_URL', 'https://room.example');
+    vi.stubEnv('CLAUDECODE', '');
+    vi.stubEnv('CLAUDE_CODE_ENTRYPOINT', '');
+    vi.stubEnv('CODEX_RUN_ID', 'run-b');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(harnessFile(dir, 'codex', 'run-a'), JSON.stringify({
+      version: 1, rooms: { [code]: {
+        name: 'Run A Host', client: 'cc', cursor: 2, joinedAt: 10,
+        hostKey: 'run-a-host-key', accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43),
+      } },
+    }));
+    const calls: Array<{ headers: Record<string, string>; body: Record<string, unknown> }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      calls.push({
+        headers: { ...(init.headers as Record<string, string>) },
+        body: JSON.parse(String(init.body)),
+      });
+      return new Response(JSON.stringify({ error: 'NotHostError', message: 'not host' }), {
+        status: 403, headers: { 'content-type': 'application/json' },
+      });
+    }));
+
+    vi.resetModules();
+    const response = await invokeRoomEnd(code);
+
+    expect(JSON.parse(response.content[0].text)).toMatchObject({ ok: false, error: 'not_host' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toMatchObject({ action: 'end', code, requesterName: '' });
+    expect(calls[0]!.body).not.toHaveProperty('hostKey');
+    expect(calls[0]!.headers).not.toHaveProperty('x-agent-room-access');
+    expect(calls[0]!.headers).not.toHaveProperty('authorization');
+  });
+
+  it.each([
+    { label: 'same Codex run after restart', codexRun: 'run-a', claude: '', file: (dir: string) => harnessFile(dir, 'codex', 'run-a') },
+    { label: 'ordinary local session', codexRun: '', claude: '1', file: (dir: string) => join(dir, `state-${process.ppid}.json`) },
+  ])('production room_end recovers host identity for $label', async ({ codexRun, claude, file }) => {
+    const dir = await makeStateDir('agent-room-tool-legitimate-host-');
+    vi.stubEnv('AGENT_ROOM_STATE_DIR', dir);
+    vi.stubEnv('AGENT_ROOM_BASE_URL', 'https://room.example');
+    vi.stubEnv('CODEX_RUN_ID', codexRun);
+    vi.stubEnv('CLAUDECODE', claude);
+    vi.stubEnv('CLAUDE_CODE_ENTRYPOINT', '');
+    const code = 'ABC-DEF-GHJ';
+    await fs.writeFile(file(dir), JSON.stringify({
+      version: 1, rooms: { [code]: {
+        name: 'Current Host', client: 'cc', cursor: 2, joinedAt: 10,
+        hostKey: 'current-host-key', accessToken: 'a'.repeat(43), participantToken: 'p'.repeat(43),
+      } },
+    }));
+    const calls: Array<{ headers: Record<string, string>; body: Record<string, unknown> }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      calls.push({ headers: { ...(init.headers as Record<string, string>) }, body: JSON.parse(String(init.body)) });
+      return new Response(JSON.stringify({ room: { code, status: 'ended' } }), {
+        status: 200, headers: { 'content-type': 'application/json' },
+      });
+    }));
+
+    vi.resetModules();
+    const response = await invokeRoomEnd(code);
+
+    expect(JSON.parse(response.content[0].text)).toMatchObject({ ended: true, code });
+    expect(calls[0]!.body).toMatchObject({ action: 'end', code, requesterName: 'Current Host', hostKey: 'current-host-key' });
+    expect(calls[0]!.headers['x-agent-room-access']).toBe('a'.repeat(43));
+    expect(calls[0]!.headers.authorization).toBe(`Bearer ${'p'.repeat(43)}`);
   });
 });
 

--- a/docs/durable-room-storage.md
+++ b/docs/durable-room-storage.md
@@ -1,0 +1,113 @@
+# Durable room storage
+
+Status: design checkpoint for UC2 build 1. This change adds a storage seam and a
+Postgres implementation without changing the running default. Deployment,
+database provisioning, credentials, and backfill execution are separate hosting
+decisions.
+
+## Seam
+
+The room server depends on a `RoomPersistence` interface rather than issuing
+vendor commands. The interface owns the durable record families and their
+ordering/concurrency contracts:
+
+- rooms: create, read, compare-and-swap update, and explicit end;
+- participants: the participant collection stored with the room version;
+- messages: append in room order and list from an absolute cursor;
+- task boards: read and compare-and-swap write by board version;
+- minutes/reports: create and read the immutable room snapshot;
+- receipts: append and deduplicate by a caller-supplied receipt id.
+
+The live turn lease remains an ephemeral Redis coordination primitive, but each
+lease transition is also appended through `appendLeaseEvent` as a receipt-class
+durable record. The closed event vocabulary is `granted`, `renewed`, `released`,
+`expired`, and `handoff_requested`. Build 3 and signed handoff receipts therefore
+read the one-pen-at-a-time history after the live lease itself has expired.
+
+The seam uses the shared domain types. It does not expose Redis commands, SQL,
+connection objects, or credentials. `createRoomPersistence(config)` is the only
+adapter-selection point. `AGENT_ROOM_PERSISTENCE=redis` is the default and uses
+the existing Redis environment and 24-hour behavior. `postgres` requires a
+server-side database URL and fails closed when it is absent. Browser code never
+receives that URL.
+
+This first slice preserves the current exported Redis operations through a
+`RedisRoomPersistence` adapter and adds a `PostgresRoomPersistence` adapter. The
+production entry chooses once at startup and passes the interface into room
+handlers. Presence, listen cursors, turn leases, rate-limit counters, and other
+ephemeral coordination remain in Redis; later UC2 builds may give turn leasing
+its own seam.
+
+## Durability contract
+
+| Record | Redis default | Postgres durable mode |
+| --- | --- | --- |
+| Room | Hard expiry 24 hours after creation | Retained until an explicit retention/deletion action |
+| Participants | Stored in the room JSON and expires with it | Versioned room state; survives restart and elapsed wall time |
+| Messages/transcript | Ordered list, trimmed to the current Redis cap, expires with room | Append-only ordered rows; no TTL and no destructive trim |
+| Tasks | Versioned board with room TTL | Versioned current board plus durable update timestamp |
+| Minutes/report | Redis snapshot with 24-hour TTL | Immutable snapshot retained with its room |
+| Receipts | Existing message/artifact representation and room TTL | Idempotent append keyed by `(room_id, receipt_id)` |
+
+Immutable minutes and receipt replays use one recursive canonical JSON encoding
+in both adapters, so top-level or nested object-key order cannot change whether
+the same payload is accepted as an idempotent retry.
+
+“Durable” means a committed record is visible after server-process restart and
+after a clock advance beyond 25 hours. It does not mean undeletable: explicit
+retention/deletion remains possible, auditable work outside this PR. Failed
+transactions publish no partial room record. Per-room message sequence and
+receipt uniqueness are database constraints rather than process memory.
+
+## Postgres schema sketch
+
+- `rooms(code primary key, topic, created_at, created_by, status, version,
+  room_json, updated_at)`; compare-and-swap is `UPDATE ... WHERE version = ?`.
+- `room_messages(room_code references rooms, sequence bigint, message_id,
+  message_json, created_at, primary key(room_code, sequence), unique(room_code,
+  message_id))`.
+- `room_task_boards(room_code primary key references rooms, version,
+  board_json, updated_at)`.
+- `room_minutes(room_code, report_id, report_json, created_at,
+  primary key(room_code, report_id))`.
+- `room_receipts(room_code, receipt_id, receipt_json, created_at,
+  primary key(room_code, receipt_id))`.
+
+Participant state stays in the versioned room document in this slice so current
+room compare-and-swap semantics remain one atomic write. JSON columns retain the
+shared wire schema while relational keys enforce ownership, ordering, and
+idempotency. Schema migrations are numbered SQL files and run explicitly; the
+application does not auto-mutate production schema at request time.
+
+## Migration and backfill
+
+1. Deploy the seam with `redis` as the default; behavior and TTL stay unchanged.
+2. Provision Postgres and explicitly run the reviewed schema migration with
+   `npm run migrate:postgres -w packages/room-persistence`; application startup
+   verifies the schema version and fails closed without mutating it.
+3. Run a dry-run backfill that reads live Redis rooms and related keys, validates
+   shared types, and reports counts/conflicts without writing.
+4. Run an idempotent one-way backfill. Existing Postgres keys win only when the
+   canonical payload matches; mismatches stop and surface a conflict.
+5. Shadow-read and compare both adapters for a bounded window, without returning
+   shadow data to callers.
+6. Change the flag only after governance and hosting approval. Keep Redis for
+   presence, rate limits, and turn coordination.
+
+Rollback changes the selection flag back to Redis. It does not delete Postgres
+records. There is no automatic dual-write in this slice because an uncoordinated
+two-store write would create an ambiguous source of truth.
+
+## Proof bar
+
+- The existing Redis suite passes unchanged through the adapter and proves the
+  24-hour expiry remains the default.
+- A production-entry test selects Redis when the flag is absent.
+- CI starts a local Postgres service, applies the numbered migration, creates a
+  room through the production entry, restarts the server/store object, advances
+  the clock 25 hours, and reads the same room, transcript, tasks, minutes, and
+  receipt.
+- Restored-defect kills cover adapter selection, restart persistence, 25-hour
+  retention, message ordering, task CAS, and receipt idempotency.
+- Tests use synthetic records. No hosted database, deployment, Railway setting,
+  or secret is part of this PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,10 @@
         "vitest": "^1.5.0"
       }
     },
+    "node_modules/@agent-room/room-persistence": {
+      "resolved": "packages/room-persistence",
+      "link": true
+    },
     "node_modules/@agent-room/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -3301,6 +3305,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -6686,6 +6702,95 @@
         "node": "*"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6916,6 +7021,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
@@ -7527,6 +7671,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -9258,6 +9411,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9276,6 +9438,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/room-persistence": {
+      "name": "@agent-room/room-persistence",
+      "version": "0.0.0",
+      "dependencies": {
+        "@agent-room/shared": "*",
+        "@agent-room/upstash-client": "*",
+        "pg": "8.16.3"
+      },
+      "devDependencies": {
+        "@types/pg": "8.15.5",
+        "typescript": "^5.4.0",
+        "vitest": "^1.5.0"
       }
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "npm -ws run test --if-present",
     "build": "npm -ws run build --if-present",
+    "build:ordered": "npm run build -w packages/shared && npm run build -w packages/upstash-client && npm run build -w packages/room-persistence && npm run build -w apps/mcp && npm run build -w apps/web",
     "dev:web": "npm -w apps/web run dev"
   },
   "devDependencies": {

--- a/packages/room-persistence/migrations/001_durable_room_record.sql
+++ b/packages/room-persistence/migrations/001_durable_room_record.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS agent_room_schema_migrations (
+  version integer PRIMARY KEY,
+  applied_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_rooms (
+  code text PRIMARY KEY,
+  topic text NOT NULL,
+  created_at bigint NOT NULL,
+  created_by text NOT NULL,
+  status text NOT NULL CHECK (status IN ('active', 'ended')),
+  version integer NOT NULL CHECK (version >= 1),
+  room_json jsonb NOT NULL,
+  updated_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_messages (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  sequence bigint NOT NULL,
+  message_id bigint NOT NULL,
+  message_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, sequence),
+  UNIQUE (room_code, message_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_task_boards (
+  room_code text PRIMARY KEY REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  version integer NOT NULL CHECK (version >= 1),
+  board_json jsonb NOT NULL,
+  updated_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_minutes (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  report_id text NOT NULL,
+  report_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, report_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_receipts (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  receipt_id text NOT NULL,
+  receipt_kind text NOT NULL CHECK (receipt_kind IN ('receipt', 'lease_event')),
+  lease_event text CHECK (lease_event IS NULL OR lease_event IN
+    ('granted', 'renewed', 'released', 'expired', 'handoff_requested')),
+  receipt_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, receipt_id)
+);
+
+CREATE INDEX IF NOT EXISTS agent_room_messages_room_created_idx
+  ON agent_room_messages(room_code, created_at);
+CREATE INDEX IF NOT EXISTS agent_room_receipts_room_created_idx
+  ON agent_room_receipts(room_code, created_at);
+
+INSERT INTO agent_room_schema_migrations (version, applied_at)
+VALUES (1, (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint)
+ON CONFLICT (version) DO NOTHING;

--- a/packages/room-persistence/package.json
+++ b/packages/room-persistence/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@agent-room/room-persistence",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.json",
+    "migrate:postgres": "node dist/migrate.js"
+  },
+  "dependencies": {
+    "@agent-room/shared": "*",
+    "@agent-room/upstash-client": "*",
+    "pg": "8.16.3"
+  },
+  "devDependencies": {
+    "@types/pg": "8.15.5",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/packages/room-persistence/src/factory.ts
+++ b/packages/room-persistence/src/factory.ts
@@ -1,0 +1,63 @@
+import { createClient, type UpstashClient } from '@agent-room/upstash-client';
+import type { Pool } from 'pg';
+import { PostgresRoomPersistence } from './postgres.js';
+import { RedisRoomPersistence } from './redis.js';
+import {
+  PersistenceConfigurationError,
+  type PersistenceKind,
+  type RoomPersistence,
+} from './types.js';
+
+export interface PersistenceEnvironment {
+  AGENT_ROOM_PERSISTENCE?: string;
+  DATABASE_URL?: string;
+  UPSTASH_REDIS_REST_URL?: string;
+  UPSTASH_REDIS_REST_TOKEN?: string;
+}
+
+export interface PersistenceDependencies {
+  redisClient?: UpstashClient;
+  postgresPool?: Pool;
+}
+
+export function persistenceKind(env: PersistenceEnvironment): PersistenceKind {
+  const selected = env.AGENT_ROOM_PERSISTENCE?.trim().toLowerCase() || 'redis';
+  if (selected !== 'redis' && selected !== 'postgres') {
+    throw new PersistenceConfigurationError(
+      `AGENT_ROOM_PERSISTENCE must be redis or postgres, got ${JSON.stringify(selected)}`,
+    );
+  }
+  return selected;
+}
+
+export async function createRoomPersistence(
+  env: PersistenceEnvironment,
+  dependencies: PersistenceDependencies = {},
+): Promise<RoomPersistence> {
+  const kind = persistenceKind(env);
+  if (kind === 'redis') {
+    const client = dependencies.redisClient ?? redisClientFromEnvironment(env);
+    return new RedisRoomPersistence(client);
+  }
+
+  if (dependencies.postgresPool) {
+    return PostgresRoomPersistence.fromPool(dependencies.postgresPool);
+  }
+  if (!env.DATABASE_URL?.trim()) {
+    throw new PersistenceConfigurationError(
+      'DATABASE_URL is required when AGENT_ROOM_PERSISTENCE=postgres',
+    );
+  }
+  return PostgresRoomPersistence.connect({ connectionString: env.DATABASE_URL });
+}
+
+function redisClientFromEnvironment(env: PersistenceEnvironment): UpstashClient {
+  const url = env.UPSTASH_REDIS_REST_URL?.trim();
+  const token = env.UPSTASH_REDIS_REST_TOKEN?.trim();
+  if (!url || !token) {
+    throw new PersistenceConfigurationError(
+      'UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are required for Redis persistence',
+    );
+  }
+  return createClient({ url, token });
+}

--- a/packages/room-persistence/src/index.ts
+++ b/packages/room-persistence/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types.js';
+export * from './factory.js';
+export * from './server.js';
+export * from './redis.js';
+export * from './postgres.js';
+export * from './schema.js';

--- a/packages/room-persistence/src/json.ts
+++ b/packages/room-persistence/src/json.ts
@@ -1,0 +1,19 @@
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonical(item)]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonical(value));
+}
+
+export function sameJson(left: unknown, right: unknown): boolean {
+  return canonicalJson(left) === canonicalJson(right);
+}

--- a/packages/room-persistence/src/migrate.ts
+++ b/packages/room-persistence/src/migrate.ts
@@ -1,0 +1,9 @@
+import { applyPostgresMigrations } from './postgres.js';
+
+const connectionString = process.env.DATABASE_URL ?? process.env.TEST_POSTGRES_URL;
+if (!connectionString?.trim()) {
+  throw new Error('DATABASE_URL or TEST_POSTGRES_URL is required for the explicit Postgres migration command.');
+}
+
+await applyPostgresMigrations({ connectionString });
+process.stdout.write('agent-room Postgres schema migrated to version 1\n');

--- a/packages/room-persistence/src/postgres.ts
+++ b/packages/room-persistence/src/postgres.ts
@@ -1,0 +1,264 @@
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+import { Pool, type PoolClient, type PoolConfig, type QueryResult } from 'pg';
+import { POSTGRES_SCHEMA_SQL } from './schema.js';
+import { PersistenceSchemaError, type LeaseEventInput, type RoomPersistence, type RoomReceipt } from './types.js';
+import { sameJson } from './json.js';
+
+const REQUIRED_SCHEMA_VERSION = 1;
+
+function value<T>(raw: unknown): T {
+  return (typeof raw === 'string' ? JSON.parse(raw) : raw) as T;
+}
+
+function count(result: QueryResult): number {
+  return result.rowCount ?? 0;
+}
+
+export class PostgresRoomPersistence implements RoomPersistence {
+  readonly kind = 'postgres' as const;
+  private closed = false;
+
+  private constructor(
+    private readonly pool: Pool,
+    private readonly ownsPool: boolean,
+  ) {}
+
+  static async connect(config: PoolConfig): Promise<PostgresRoomPersistence> {
+    const store = new PostgresRoomPersistence(new Pool(config), true);
+    try {
+      await store.verifySchema();
+      return store;
+    } catch (error) {
+      await store.close();
+      throw error;
+    }
+  }
+
+  static async fromPool(pool: Pool, verify = true): Promise<PostgresRoomPersistence> {
+    const store = new PostgresRoomPersistence(pool, false);
+    if (verify) await store.verifySchema();
+    return store;
+  }
+
+  private async verifySchema(): Promise<void> {
+    try {
+      const result = await this.pool.query<{ version: number }>(
+        'SELECT COALESCE(MAX(version), 0)::int AS version FROM agent_room_schema_migrations',
+      );
+      const version = Number(result.rows[0]?.version ?? 0);
+      if (version < REQUIRED_SCHEMA_VERSION) {
+        throw new PersistenceSchemaError(
+          `Postgres persistence schema is behind: expected ${REQUIRED_SCHEMA_VERSION}, found ${version}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof PersistenceSchemaError) throw error;
+      throw new PersistenceSchemaError(
+        `Postgres persistence schema is not migrated; run the explicit migration command (${String(error)})`,
+      );
+    }
+  }
+
+  async createRoom(room: Room): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO agent_room_rooms
+        (code, topic, created_at, created_by, status, version, room_json, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)`,
+      [room.code, room.topic, room.createdAt, room.createdBy, room.status,
+        room.version, JSON.stringify(room), room.createdAt],
+    );
+  }
+
+  async getRoom(code: string): Promise<Room | null> {
+    const result = await this.pool.query<{ room_json: unknown }>(
+      'SELECT room_json FROM agent_room_rooms WHERE code = $1',
+      [code],
+    );
+    const row = result.rows[0];
+    return row ? value<Room>(row.room_json) : null;
+  }
+
+  async compareAndSwapRoom(code: string, expectedVersion: number, next: Room): Promise<boolean> {
+    const result = await this.pool.query(
+      `UPDATE agent_room_rooms
+          SET topic = $3, status = $4, version = $5, room_json = $6::jsonb, updated_at = $7
+        WHERE code = $1 AND version = $2`,
+      [code, expectedVersion, next.topic, next.status, next.version,
+        JSON.stringify(next), Date.now()],
+    );
+    return count(result) === 1;
+  }
+
+  async appendMessage(code: string, message: Message): Promise<number> {
+    return this.transaction(async client => {
+      const room = await client.query('SELECT code FROM agent_room_rooms WHERE code = $1 FOR UPDATE', [code]);
+      if (!room.rows[0]) throw new Error(`Room ${code} not found`);
+      const next = await client.query<{ sequence: string }>(
+        `SELECT COALESCE(MAX(sequence) + 1, 0)::text AS sequence
+           FROM agent_room_messages WHERE room_code = $1`,
+        [code],
+      );
+      const sequence = Number(next.rows[0]?.sequence ?? 0);
+      const result = await client.query(
+        `INSERT INTO agent_room_messages
+          (room_code, sequence, message_id, message_json, created_at)
+         VALUES ($1, $2, $3, $4::jsonb, $5)
+         ON CONFLICT (room_code, message_id) DO NOTHING`,
+        [code, sequence, message.id, JSON.stringify(message), message.time],
+      );
+      if (count(result) === 0) {
+        const existing = await client.query<{ sequence: string; message_json: unknown }>(
+          `SELECT sequence::text, message_json FROM agent_room_messages
+            WHERE room_code = $1 AND message_id = $2`,
+          [code, message.id],
+        );
+        const row = existing.rows[0];
+        if (!row || !sameJson(value<Message>(row.message_json), message)) {
+          throw new Error(`Message id collision: ${message.id}`);
+        }
+        return Number(row.sequence) + 1;
+      }
+      return sequence + 1;
+    });
+  }
+
+  async listMessages(code: string, fromSequence: number): Promise<Message[]> {
+    const result = await this.pool.query<{ message_json: unknown }>(
+      `SELECT message_json FROM agent_room_messages
+        WHERE room_code = $1 AND sequence >= $2
+        ORDER BY sequence ASC`,
+      [code, fromSequence],
+    );
+    return result.rows.map(row => value<Message>(row.message_json));
+  }
+
+  async getTaskBoard(code: string): Promise<TaskBoard | null> {
+    const result = await this.pool.query<{ board_json: unknown }>(
+      'SELECT board_json FROM agent_room_task_boards WHERE room_code = $1',
+      [code],
+    );
+    const row = result.rows[0];
+    return row ? value<TaskBoard>(row.board_json) : null;
+  }
+
+  async compareAndSwapTaskBoard(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+  ): Promise<boolean> {
+    if (expectedVersion === null) {
+      const inserted = await this.pool.query(
+        `INSERT INTO agent_room_task_boards (room_code, version, board_json, updated_at)
+         VALUES ($1, $2, $3::jsonb, $4)
+         ON CONFLICT (room_code) DO NOTHING`,
+        [code, next.version, JSON.stringify(next), Date.now()],
+      );
+      return count(inserted) === 1;
+    }
+    const updated = await this.pool.query(
+      `UPDATE agent_room_task_boards
+          SET version = $3, board_json = $4::jsonb, updated_at = $5
+        WHERE room_code = $1 AND version = $2`,
+      [code, expectedVersion, next.version, JSON.stringify(next), Date.now()],
+    );
+    return count(updated) === 1;
+  }
+
+  async putMinutes(code: string, reportId: string, report: RoomReport): Promise<void> {
+    const inserted = await this.pool.query(
+      `INSERT INTO agent_room_minutes (room_code, report_id, report_json, created_at)
+       VALUES ($1, $2, $3::jsonb, $4)
+       ON CONFLICT (room_code, report_id) DO NOTHING`,
+      [code, reportId, JSON.stringify(report), report.exportedAt],
+    );
+    if (count(inserted) === 0) {
+      const existing = await this.getMinutes(code, reportId);
+      if (!existing || !sameJson(existing, report)) {
+        throw new Error(`Minutes id collision: ${reportId}`);
+      }
+    }
+  }
+
+  async getMinutes(code: string, reportId: string): Promise<RoomReport | null> {
+    const result = await this.pool.query<{ report_json: unknown }>(
+      `SELECT report_json FROM agent_room_minutes
+        WHERE room_code = $1 AND report_id = $2`,
+      [code, reportId],
+    );
+    const row = result.rows[0];
+    return row ? value<RoomReport>(row.report_json) : null;
+  }
+
+  async appendReceipt(receipt: RoomReceipt): Promise<boolean> {
+    const result = await this.pool.query(
+      `INSERT INTO agent_room_receipts
+        (room_code, receipt_id, receipt_kind, lease_event, receipt_json, created_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+       ON CONFLICT (room_code, receipt_id) DO NOTHING`,
+      [receipt.roomCode, receipt.id, receipt.kind, receipt.leaseEvent ?? null,
+        JSON.stringify(receipt), receipt.createdAt],
+    );
+    if (count(result) === 1) return true;
+    const existing = await this.pool.query<{ receipt_json: unknown }>(
+      `SELECT receipt_json FROM agent_room_receipts
+        WHERE room_code = $1 AND receipt_id = $2`,
+      [receipt.roomCode, receipt.id],
+    );
+    const row = existing.rows[0];
+    if (!row || !sameJson(value<RoomReceipt>(row.receipt_json), receipt)) {
+      throw new Error(`Receipt id collision: ${receipt.id}`);
+    }
+    return false;
+  }
+
+  appendLeaseEvent(event: LeaseEventInput): Promise<boolean> {
+    return this.appendReceipt({
+      id: event.id,
+      roomCode: event.roomCode,
+      kind: 'lease_event',
+      createdAt: event.at,
+      leaseEvent: event.event,
+      payload: { actor: event.actor, leaseId: event.leaseId, ...(event.details ?? {}) },
+    });
+  }
+
+  async listReceipts(code: string): Promise<RoomReceipt[]> {
+    const result = await this.pool.query<{ receipt_json: unknown }>(
+      `SELECT receipt_json FROM agent_room_receipts
+        WHERE room_code = $1 ORDER BY created_at ASC, receipt_id ASC`,
+      [code],
+    );
+    return result.rows.map(row => value<RoomReceipt>(row.receipt_json));
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsPool && !this.closed) {
+      this.closed = true;
+      await this.pool.end();
+    }
+  }
+
+  private async transaction<T>(work: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await work(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+export async function applyPostgresMigrations(config: PoolConfig): Promise<void> {
+  const pool = new Pool(config);
+  try {
+    await pool.query(POSTGRES_SCHEMA_SQL);
+  } finally {
+    await pool.end();
+  }
+}

--- a/packages/room-persistence/src/redis.ts
+++ b/packages/room-persistence/src/redis.ts
@@ -1,0 +1,181 @@
+import { MAX_MESSAGES_PER_ROOM, ROOM_TTL_SECONDS } from '@agent-room/shared';
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+import type { UpstashClient } from '@agent-room/upstash-client';
+import type { LeaseEventInput, RoomPersistence, RoomReceipt } from './types.js';
+import { canonicalJson } from './json.js';
+
+const roomKey = (code: string): string => `room:${code}`;
+const messagesKey = (code: string): string => `room-msgs:${code}`;
+const messageCountKey = (code: string): string => `room-msg-count:${code}`;
+const taskBoardKey = (code: string): string => `task-board:${code}`;
+const minutesKey = (code: string, reportId: string): string => `room-minutes:${code}:${reportId}`;
+const receiptIdsKey = (code: string): string => `room-receipt-ids:${code}`;
+const receiptsKey = (code: string): string => `room-receipts:${code}`;
+
+const ROOM_CAS_SCRIPT = [
+  "local raw = redis.call('GET', KEYS[1])",
+  'if not raw then return 0 end',
+  'local current = cjson.decode(raw)',
+  'if tonumber(current.version) ~= tonumber(ARGV[1]) then return 0 end',
+  "redis.call('SET', KEYS[1], ARGV[2], 'KEEPTTL')",
+  'return 1',
+].join('\n');
+
+const BOARD_CAS_SCRIPT = [
+  "local raw = redis.call('GET', KEYS[1])",
+  "if ARGV[1] == 'absent' then",
+  '  if raw then return 0 end',
+  'else',
+  '  if not raw then return 0 end',
+  '  local current = cjson.decode(raw)',
+  '  if tonumber(current.version) ~= tonumber(ARGV[2]) then return 0 end',
+  'end',
+  "redis.call('SET', KEYS[1], ARGV[3], 'EX', tonumber(ARGV[4]))",
+  'return 1',
+].join('\n');
+
+const RECEIPT_SCRIPT = [
+  "if redis.call('SISMEMBER', KEYS[1], ARGV[1]) == 1 then",
+  "  local rows = redis.call('LRANGE', KEYS[2], 0, -1)",
+  '  for _, row in ipairs(rows) do',
+  '    local decoded = cjson.decode(row)',
+  '    if decoded.id == ARGV[1] then',
+  "      if row == ARGV[2] then return 0 end",
+  "      return redis.error_reply('Receipt id collision: ' .. ARGV[1])",
+  '    end',
+  '  end',
+  "  return redis.error_reply('Receipt id collision with missing payload: ' .. ARGV[1])",
+  'end',
+  "redis.call('SADD', KEYS[1], ARGV[1])",
+  "redis.call('RPUSH', KEYS[2], ARGV[2])",
+  "redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[3]))",
+  "redis.call('EXPIREAT', KEYS[2], tonumber(ARGV[3]))",
+  'return 1',
+].join('\n');
+
+const MINUTES_SCRIPT = [
+  "local raw = redis.call('GET', KEYS[1])",
+  'if raw then',
+  '  if raw == ARGV[1] then return 0 end',
+  "  return redis.error_reply('Minutes id collision: ' .. ARGV[2])",
+  'end',
+  "redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[3]))",
+  'return 1',
+].join('\n');
+
+function parseJson<T>(raw: unknown): T | null {
+  if (raw === null || raw === undefined) return null;
+  return JSON.parse(String(raw)) as T;
+}
+
+export class RedisRoomPersistence implements RoomPersistence {
+  readonly kind = 'redis' as const;
+
+  constructor(private readonly client: UpstashClient) {}
+
+  async createRoom(room: Room): Promise<void> {
+    await this.client.command(['SET', roomKey(room.code), JSON.stringify(room), 'EX', ROOM_TTL_SECONDS]);
+  }
+
+  async getRoom(code: string): Promise<Room | null> {
+    return parseJson<Room>(await this.client.command(['GET', roomKey(code)]));
+  }
+
+  async compareAndSwapRoom(code: string, expectedVersion: number, next: Room): Promise<boolean> {
+    const result = await this.client.command<number>([
+      'EVAL', ROOM_CAS_SCRIPT, '1', roomKey(code), String(expectedVersion), JSON.stringify(next),
+    ]);
+    return Number(result) === 1;
+  }
+
+  async appendMessage(code: string, message: Message): Promise<number> {
+    const room = await this.getRoom(code);
+    if (!room) throw new Error(`Room ${code} not found`);
+    const expiresAt = Math.floor(room.createdAt / 1000) + ROOM_TTL_SECONDS;
+    const safe = typeof message.text === 'string' ? message : { ...message, text: '' };
+    const result = await this.client.pipeline<unknown>([
+      ['RPUSH', messagesKey(code), JSON.stringify(safe)],
+      ['INCR', messageCountKey(code)],
+      ['LTRIM', messagesKey(code), -MAX_MESSAGES_PER_ROOM, -1],
+      ['EXPIREAT', messagesKey(code), expiresAt],
+      ['EXPIREAT', messageCountKey(code), expiresAt],
+    ]);
+    return Number(result[1]);
+  }
+
+  async listMessages(code: string, fromSequence: number): Promise<Message[]> {
+    const metadata = await this.client.pipeline<unknown>([
+      ['GET', messageCountKey(code)],
+      ['LLEN', messagesKey(code)],
+    ]);
+    const total = metadata[0] === null || metadata[0] === undefined ? null : Number(metadata[0]);
+    const length = Number(metadata[1] ?? 0);
+    if (length === 0) return [];
+    const trimmed = total === null ? 0 : total - length;
+    const start = Math.max(0, fromSequence - trimmed);
+    if (start >= length) return [];
+    const rows = await this.client.command<string[]>(['LRANGE', messagesKey(code), start, -1]);
+    return rows.map(row => {
+      const message = JSON.parse(row) as Message;
+      return typeof message.text === 'string' ? message : { ...message, text: '' };
+    });
+  }
+
+  async getTaskBoard(code: string): Promise<TaskBoard | null> {
+    return parseJson<TaskBoard>(await this.client.command(['GET', taskBoardKey(code)]));
+  }
+
+  async compareAndSwapTaskBoard(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+  ): Promise<boolean> {
+    const result = await this.client.command<number>([
+      'EVAL', BOARD_CAS_SCRIPT, '1', taskBoardKey(code),
+      expectedVersion === null ? 'absent' : 'present',
+      expectedVersion === null ? '' : String(expectedVersion),
+      JSON.stringify(next), String(ROOM_TTL_SECONDS),
+    ]);
+    return Number(result) === 1;
+  }
+
+  async putMinutes(code: string, reportId: string, report: RoomReport): Promise<void> {
+    await this.client.command([
+      'EVAL', MINUTES_SCRIPT, '1', minutesKey(code, reportId), canonicalJson(report),
+      reportId, String(ROOM_TTL_SECONDS),
+    ]);
+  }
+
+  async getMinutes(code: string, reportId: string): Promise<RoomReport | null> {
+    return parseJson<RoomReport>(await this.client.command(['GET', minutesKey(code, reportId)]));
+  }
+
+  async appendReceipt(receipt: RoomReceipt): Promise<boolean> {
+    const room = await this.getRoom(receipt.roomCode);
+    if (!room) throw new Error(`Room ${receipt.roomCode} not found`);
+    const expiresAt = Math.floor(room.createdAt / 1000) + ROOM_TTL_SECONDS;
+    const result = await this.client.command<number>([
+      'EVAL', RECEIPT_SCRIPT, '2', receiptIdsKey(receipt.roomCode), receiptsKey(receipt.roomCode),
+      receipt.id, canonicalJson(receipt), String(expiresAt),
+    ]);
+    return Number(result) === 1;
+  }
+
+  appendLeaseEvent(event: LeaseEventInput): Promise<boolean> {
+    return this.appendReceipt({
+      id: event.id,
+      roomCode: event.roomCode,
+      kind: 'lease_event',
+      createdAt: event.at,
+      leaseEvent: event.event,
+      payload: { actor: event.actor, leaseId: event.leaseId, ...(event.details ?? {}) },
+    });
+  }
+
+  async listReceipts(code: string): Promise<RoomReceipt[]> {
+    const rows = await this.client.command<string[] | null>(['LRANGE', receiptsKey(code), 0, -1]);
+    return (rows ?? []).map(row => JSON.parse(row) as RoomReceipt);
+  }
+
+  async close(): Promise<void> {}
+}

--- a/packages/room-persistence/src/schema.ts
+++ b/packages/room-persistence/src/schema.ts
@@ -1,0 +1,62 @@
+export const POSTGRES_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS agent_room_schema_migrations (
+  version integer PRIMARY KEY,
+  applied_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_rooms (
+  code text PRIMARY KEY,
+  topic text NOT NULL,
+  created_at bigint NOT NULL,
+  created_by text NOT NULL,
+  status text NOT NULL CHECK (status IN ('active', 'ended')),
+  version integer NOT NULL CHECK (version >= 1),
+  room_json jsonb NOT NULL,
+  updated_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_messages (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  sequence bigint NOT NULL,
+  message_id bigint NOT NULL,
+  message_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, sequence),
+  UNIQUE (room_code, message_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_task_boards (
+  room_code text PRIMARY KEY REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  version integer NOT NULL CHECK (version >= 1),
+  board_json jsonb NOT NULL,
+  updated_at bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_minutes (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  report_id text NOT NULL,
+  report_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, report_id)
+);
+
+CREATE TABLE IF NOT EXISTS agent_room_receipts (
+  room_code text NOT NULL REFERENCES agent_room_rooms(code) ON DELETE CASCADE,
+  receipt_id text NOT NULL,
+  receipt_kind text NOT NULL CHECK (receipt_kind IN ('receipt', 'lease_event')),
+  lease_event text CHECK (lease_event IS NULL OR lease_event IN
+    ('granted', 'renewed', 'released', 'expired', 'handoff_requested')),
+  receipt_json jsonb NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (room_code, receipt_id)
+);
+
+CREATE INDEX IF NOT EXISTS agent_room_messages_room_created_idx
+  ON agent_room_messages(room_code, created_at);
+CREATE INDEX IF NOT EXISTS agent_room_receipts_room_created_idx
+  ON agent_room_receipts(room_code, created_at);
+
+INSERT INTO agent_room_schema_migrations (version, applied_at)
+VALUES (1, (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint)
+ON CONFLICT (version) DO NOTHING;
+`;

--- a/packages/room-persistence/src/server.ts
+++ b/packages/room-persistence/src/server.ts
@@ -1,0 +1,52 @@
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+import { createRoomPersistence, type PersistenceDependencies, type PersistenceEnvironment } from './factory.js';
+import type { LeaseEventInput, RoomPersistence, RoomReceipt } from './types.js';
+
+/**
+ * Server-side production entry for durable room records. Business-rule layers
+ * call this object; only the selected adapter knows Redis or Postgres.
+ */
+export class RoomRecordServer {
+  constructor(readonly persistence: RoomPersistence) {}
+
+  static async fromEnvironment(
+    env: PersistenceEnvironment,
+    dependencies: PersistenceDependencies = {},
+  ): Promise<RoomRecordServer> {
+    return new RoomRecordServer(await createRoomPersistence(env, dependencies));
+  }
+
+  createRoom(room: Room): Promise<void> { return this.persistence.createRoom(room); }
+  getRoom(code: string): Promise<Room | null> { return this.persistence.getRoom(code); }
+  updateRoom(code: string, expectedVersion: number, next: Room): Promise<boolean> {
+    return this.persistence.compareAndSwapRoom(code, expectedVersion, next);
+  }
+  appendMessage(code: string, message: Message): Promise<number> {
+    return this.persistence.appendMessage(code, message);
+  }
+  listMessages(code: string, fromSequence: number): Promise<Message[]> {
+    return this.persistence.listMessages(code, fromSequence);
+  }
+  getTaskBoard(code: string): Promise<TaskBoard | null> {
+    return this.persistence.getTaskBoard(code);
+  }
+  updateTaskBoard(code: string, expectedVersion: number | null, next: TaskBoard): Promise<boolean> {
+    return this.persistence.compareAndSwapTaskBoard(code, expectedVersion, next);
+  }
+  putMinutes(code: string, reportId: string, report: RoomReport): Promise<void> {
+    return this.persistence.putMinutes(code, reportId, report);
+  }
+  getMinutes(code: string, reportId: string): Promise<RoomReport | null> {
+    return this.persistence.getMinutes(code, reportId);
+  }
+  appendReceipt(receipt: RoomReceipt): Promise<boolean> {
+    return this.persistence.appendReceipt(receipt);
+  }
+  appendLeaseEvent(event: LeaseEventInput): Promise<boolean> {
+    return this.persistence.appendLeaseEvent(event);
+  }
+  listReceipts(code: string): Promise<RoomReceipt[]> {
+    return this.persistence.listReceipts(code);
+  }
+  close(): Promise<void> { return this.persistence.close(); }
+}

--- a/packages/room-persistence/src/types.ts
+++ b/packages/room-persistence/src/types.ts
@@ -1,0 +1,70 @@
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+
+export type PersistenceKind = 'redis' | 'postgres';
+
+export type LeaseEventName =
+  | 'granted'
+  | 'renewed'
+  | 'released'
+  | 'expired'
+  | 'handoff_requested';
+
+export interface RoomReceipt {
+  id: string;
+  roomCode: string;
+  kind: 'receipt' | 'lease_event';
+  createdAt: number;
+  payload: Readonly<Record<string, unknown>>;
+  leaseEvent?: LeaseEventName;
+}
+
+export interface LeaseEventInput {
+  id: string;
+  roomCode: string;
+  event: LeaseEventName;
+  actor: string;
+  leaseId: string;
+  at: number;
+  details?: Readonly<Record<string, unknown>>;
+}
+
+export interface RoomPersistence {
+  readonly kind: PersistenceKind;
+
+  createRoom(room: Room): Promise<void>;
+  getRoom(code: string): Promise<Room | null>;
+  compareAndSwapRoom(code: string, expectedVersion: number, next: Room): Promise<boolean>;
+
+  appendMessage(code: string, message: Message): Promise<number>;
+  listMessages(code: string, fromSequence: number): Promise<Message[]>;
+
+  getTaskBoard(code: string): Promise<TaskBoard | null>;
+  compareAndSwapTaskBoard(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+  ): Promise<boolean>;
+
+  putMinutes(code: string, reportId: string, report: RoomReport): Promise<void>;
+  getMinutes(code: string, reportId: string): Promise<RoomReport | null>;
+
+  appendReceipt(receipt: RoomReceipt): Promise<boolean>;
+  appendLeaseEvent(event: LeaseEventInput): Promise<boolean>;
+  listReceipts(code: string): Promise<RoomReceipt[]>;
+
+  close(): Promise<void>;
+}
+
+export class PersistenceConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PersistenceConfigurationError';
+  }
+}
+
+export class PersistenceSchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PersistenceSchemaError';
+  }
+}

--- a/packages/room-persistence/test/parity-contract.ts
+++ b/packages/room-persistence/test/parity-contract.ts
@@ -1,0 +1,43 @@
+import { expect } from 'vitest';
+import type { Room, RoomReport } from '@agent-room/shared';
+import type { RoomPersistence, RoomReceipt } from '../src/types.js';
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reverseObjectKeys);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).reverse()
+        .map(([key, item]) => [key, reverseObjectKeys(item)]),
+    );
+  }
+  return value;
+}
+
+export async function proveImmutableRecordParity(
+  store: RoomPersistence,
+  room: Room,
+  report: RoomReport,
+  receipt: RoomReceipt,
+): Promise<void> {
+  await store.createRoom(room);
+
+  await store.putMinutes(room.code, 'parity-minutes', report);
+  await store.putMinutes(room.code, 'parity-minutes', report);
+  await store.putMinutes(
+    room.code,
+    'parity-minutes',
+    reverseObjectKeys(report) as RoomReport,
+  );
+  await expect(store.putMinutes(room.code, 'parity-minutes', {
+    ...report, summary: 'conflicting minutes',
+  })).rejects.toThrow('Minutes id collision');
+  expect(await store.getMinutes(room.code, 'parity-minutes')).toEqual(report);
+
+  expect(await store.appendReceipt(receipt)).toBe(true);
+  expect(await store.appendReceipt(receipt)).toBe(false);
+  expect(await store.appendReceipt(reverseObjectKeys(receipt) as RoomReceipt)).toBe(false);
+  await expect(store.appendReceipt({
+    ...receipt, payload: { disposition: 'conflicting' },
+  })).rejects.toThrow('Receipt id collision');
+  expect(await store.listReceipts(room.code)).toEqual([receipt]);
+}

--- a/packages/room-persistence/test/postgres.integration.test.ts
+++ b/packages/room-persistence/test/postgres.integration.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+import { Pool } from 'pg';
+import { RoomRecordServer } from '../src/server.js';
+import { PostgresRoomPersistence } from '../src/postgres.js';
+import { PersistenceSchemaError, type RoomReceipt } from '../src/types.js';
+import { proveImmutableRecordParity } from './parity-contract.js';
+
+const databaseUrl = process.env.TEST_POSTGRES_URL;
+const describePostgres = databaseUrl ? describe : describe.skip;
+
+function room(): Room {
+  return {
+    code: 'PGS-TST-234', topic: 'Synthetic durable room', createdAt: 1_700_000_000_000,
+    createdBy: 'Host', status: 'active', version: 1,
+    participants: [{ name: 'Host', initials: 'HO', color: '#123', role: 'host', client: 'web', lastSeen: 1_700_000_000_000 }],
+  };
+}
+
+function message(): Message {
+  return {
+    id: 1_700_000_000_100, type: 'msg', name: 'Agent', initials: 'AG', color: '#456',
+    role: 'builder', text: 'durable synthetic message', client: 'cc', time: 1_700_000_000_100,
+  };
+}
+
+function board(): TaskBoard {
+  return { code: room().code, tasks: [], version: 1, lastProgressAt: 1_700_000_000_200 };
+}
+
+function report(): RoomReport {
+  return {
+    code: room().code,
+    topic: room().topic,
+    createdAt: room().createdAt,
+    exportedAt: 1_700_000_000_300,
+    participants: [],
+    messageCount: 1,
+    summary: 'Synthetic minutes',
+    highlights: [], decisions: [], actionItems: [], artifacts: [], transcript: [message()],
+  };
+}
+
+describePostgres('Postgres durable room production entry', () => {
+  let first: RoomRecordServer;
+  let admin: Pool;
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: databaseUrl });
+    first = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    // Synthetic CI database dedicated to this job; clearing it makes retries deterministic.
+    await admin.query(`TRUNCATE agent_room_receipts, agent_room_minutes, agent_room_task_boards,
+      agent_room_messages, agent_room_rooms CASCADE`);
+  });
+
+  afterAll(async () => {
+    vi.useRealTimers();
+    await first?.close();
+    await admin?.end();
+  });
+
+  it('refuses an unmigrated schema without mutating it at connect time', async () => {
+    const schema = `unmigrated_${process.pid}_${Date.now()}`;
+    await admin.query(`CREATE SCHEMA ${schema}`);
+    try {
+      await expect(PostgresRoomPersistence.connect({
+        connectionString: databaseUrl,
+        options: `-c search_path=${schema}`,
+      })).rejects.toBeInstanceOf(PersistenceSchemaError);
+      const result = await admin.query<{ relation: string | null }>(
+        'SELECT to_regclass($1) AS relation',
+        [`${schema}.agent_room_rooms`],
+      );
+      expect(result.rows[0]?.relation).toBeNull();
+    } finally {
+      await admin.query(`DROP SCHEMA ${schema} CASCADE`);
+    }
+  });
+
+  it('matches the Redis immutable minutes and receipt collision contract', async () => {
+    const parityRoom = { ...room(), code: 'PGS-PTY-234', topic: 'Synthetic parity room' };
+    const parityReport = { ...report(), code: parityRoom.code, topic: parityRoom.topic };
+    const parityReceipt: RoomReceipt = {
+      id: 'parity-receipt', roomCode: parityRoom.code, kind: 'receipt',
+      createdAt: 1_700_000_000_450, payload: { disposition: 'accepted' },
+    };
+    await proveImmutableRecordParity(first.persistence, parityRoom, parityReport, parityReceipt);
+  });
+
+  it('survives a server restart and a 25-hour clock skip with every durable record family', async () => {
+    await first.createRoom(room());
+    expect(await first.appendMessage(room().code, message())).toBe(1);
+    expect(await first.updateTaskBoard(room().code, null, board())).toBe(true);
+    await first.putMinutes(room().code, 'minutes-1', report());
+    expect(await first.appendReceipt({
+      id: 'receipt-1', roomCode: room().code, kind: 'receipt',
+      createdAt: 1_700_000_000_400, payload: { disposition: 'accepted' },
+    })).toBe(true);
+
+    const leaseEvents = ['granted', 'renewed', 'released', 'expired', 'handoff_requested'] as const;
+    for (const [index, event] of leaseEvents.entries()) {
+      expect(await first.appendLeaseEvent({
+        id: `lease-${index}`, roomCode: room().code, event, actor: 'Agent',
+        leaseId: 'lease-synthetic', at: 1_700_000_000_500 + index,
+      })).toBe(true);
+    }
+    await first.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(room().createdAt + 25 * 60 * 60 * 1000);
+    const restarted = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    try {
+      expect(await restarted.getRoom(room().code)).toEqual(room());
+      expect(await restarted.listMessages(room().code, 0)).toEqual([message()]);
+      expect(await restarted.getTaskBoard(room().code)).toEqual(board());
+      expect(await restarted.getMinutes(room().code, 'minutes-1')).toEqual(report());
+      const receipts = await restarted.listReceipts(room().code);
+      expect(receipts).toHaveLength(6);
+      expect(receipts.filter(item => item.kind === 'lease_event').map(item => item.leaseEvent)).toEqual(leaseEvents);
+      // Receipt retries are idempotent, not duplicate ledger rows.
+      expect(await restarted.appendReceipt(receipts[0]!)).toBe(false);
+      expect(await restarted.listReceipts(room().code)).toHaveLength(6);
+
+      await expect(restarted.appendMessage(room().code, {
+        ...message(), text: 'different payload reusing an id',
+      })).rejects.toThrow('Message id collision');
+      await expect(restarted.putMinutes(room().code, 'minutes-1', {
+        ...report(), summary: 'different minutes reusing an id',
+      })).rejects.toThrow('Minutes id collision');
+      await expect(restarted.appendReceipt({
+        ...receipts[0]!, payload: { disposition: 'different' },
+      })).rejects.toThrow('Receipt id collision');
+
+      expect(await restarted.listMessages(room().code, 0)).toEqual([message()]);
+      expect(await restarted.getMinutes(room().code, 'minutes-1')).toEqual(report());
+      expect(await restarted.listReceipts(room().code)).toHaveLength(6);
+    } finally {
+      await restarted.close();
+    }
+  });
+});

--- a/packages/room-persistence/test/redis.test.ts
+++ b/packages/room-persistence/test/redis.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import { ROOM_TTL_SECONDS, type Message, type Room, type RoomReport } from '@agent-room/shared';
+import type { UpstashClient } from '@agent-room/upstash-client';
+import { RoomRecordServer } from '../src/server.js';
+import { RedisRoomPersistence } from '../src/redis.js';
+import type { RoomReceipt } from '../src/types.js';
+import { proveImmutableRecordParity } from './parity-contract.js';
+
+class RecordingRedis implements UpstashClient {
+  readonly commands: Array<readonly (string | number)[]> = [];
+  readonly pipelines: Array<readonly (readonly (string | number)[])[]> = [];
+  private readonly values = new Map<string, string>();
+
+  async command<T>(command: readonly (string | number)[]): Promise<T> {
+    this.commands.push(command);
+    const [name, key, value] = command;
+    if (name === 'SET') {
+      this.values.set(String(key), String(value));
+      return 'OK' as T;
+    }
+    if (name === 'GET') return (this.values.get(String(key)) ?? null) as T;
+    if (name === 'LRANGE') return [] as T;
+    throw new Error(`Unsupported fake command ${String(name)}`);
+  }
+
+  async pipeline<T>(commands: readonly (readonly (string | number)[])[]): Promise<T[]> {
+    this.pipelines.push(commands);
+    return commands.map((command, index) => {
+      if (command[0] === 'INCR') return 1 as T;
+      if (command[0] === 'LLEN') return 0 as T;
+      if (command[0] === 'GET') return null as T;
+      return (index + 1) as T;
+    });
+  }
+}
+
+class ExpiringRedis implements UpstashClient {
+  private nowSeconds = 1_700_000_000;
+  private readonly values = new Map<string, string>();
+  private readonly expiries = new Map<string, number>();
+
+  advance(seconds: number): void { this.nowSeconds += seconds; }
+
+  async command<T>(command: readonly (string | number)[]): Promise<T> {
+    const [name, rawKey, rawValue] = command;
+    const key = String(rawKey);
+    if (name === 'SET') {
+      this.values.set(key, String(rawValue));
+      const exIndex = command.indexOf('EX');
+      if (exIndex >= 0) this.expiries.set(key, this.nowSeconds + Number(command[exIndex + 1]));
+      return 'OK' as T;
+    }
+    if (name === 'GET') {
+      if ((this.expiries.get(key) ?? Infinity) <= this.nowSeconds) {
+        this.values.delete(key);
+        this.expiries.delete(key);
+      }
+      return (this.values.get(key) ?? null) as T;
+    }
+    throw new Error(`Unsupported fake command ${String(name)}`);
+  }
+
+  async pipeline<T>(_commands: readonly (readonly (string | number)[])[]): Promise<T[]> {
+    return [];
+  }
+}
+
+class StatefulRedis implements UpstashClient {
+  private readonly values = new Map<string, string>();
+  private readonly receiptIds = new Set<string>();
+  private readonly lists = new Map<string, string[]>();
+
+  async command<T>(command: readonly (string | number)[]): Promise<T> {
+    const [name, rawKey] = command;
+    const key = String(rawKey);
+    if (name === 'SET') {
+      this.values.set(key, String(command[2]));
+      return 'OK' as T;
+    }
+    if (name === 'GET') return (this.values.get(key) ?? null) as T;
+    if (name === 'LRANGE') return (this.lists.get(key) ?? []) as T;
+    if (name === 'EVAL') {
+      const script = String(command[1]);
+      if (script.includes('Minutes id collision')) {
+        const minutesKey = String(command[3]);
+        const payload = String(command[4]);
+        const reportId = String(command[5]);
+        const existing = this.values.get(minutesKey);
+        if (existing === payload) return 0 as T;
+        if (existing !== undefined) throw new Error(`Minutes id collision: ${reportId}`);
+        this.values.set(minutesKey, payload);
+        return 1 as T;
+      }
+      if (script.includes('Receipt id collision')) {
+        const idsKey = String(command[3]);
+        const listKey = String(command[4]);
+        const id = String(command[5]);
+        const payload = String(command[6]);
+        const compositeId = `${idsKey}:${id}`;
+        if (this.receiptIds.has(compositeId)) {
+          const existing = (this.lists.get(listKey) ?? []).find(row => JSON.parse(row).id === id);
+          if (existing === payload) return 0 as T;
+          throw new Error(`Receipt id collision: ${id}`);
+        }
+        this.receiptIds.add(compositeId);
+        this.lists.set(listKey, [...(this.lists.get(listKey) ?? []), payload]);
+        return 1 as T;
+      }
+    }
+    throw new Error(`Unsupported fake command ${String(name)}`);
+  }
+
+  async pipeline<T>(_commands: readonly (readonly (string | number)[])[]): Promise<T[]> {
+    return [];
+  }
+}
+
+function room(): Room {
+  return {
+    code: 'ABC-DEF-GHJ', topic: 'Synthetic room', createdAt: 1_700_000_000_000,
+    createdBy: 'Host', status: 'active', version: 1, participants: [],
+  };
+}
+
+function message(): Message {
+  return {
+    id: 1_700_000_000_100, type: 'msg', name: 'Agent', initials: 'AG', color: '#000',
+    role: 'builder', text: 'synthetic message', client: 'cc', time: 1_700_000_000_100,
+  };
+}
+
+function report(): RoomReport {
+  return {
+    code: room().code, topic: room().topic, createdAt: room().createdAt,
+    exportedAt: 1_700_000_000_300, participants: [], messageCount: 0,
+    summary: 'Synthetic minutes', highlights: [], decisions: [], actionItems: [], artifacts: [], transcript: [],
+  };
+}
+
+function receipt(): RoomReceipt {
+  return {
+    id: 'receipt-1', roomCode: room().code, kind: 'receipt',
+    createdAt: 1_700_000_000_400, payload: { disposition: 'accepted' },
+  };
+}
+
+describe('RedisRoomPersistence compatibility', () => {
+  it('keeps Redis as the production default and the existing hard room TTL', async () => {
+    const redis = new RecordingRedis();
+    const server = await RoomRecordServer.fromEnvironment({}, { redisClient: redis });
+
+    expect(server.persistence.kind).toBe('redis');
+    await server.createRoom(room());
+
+    expect(redis.commands[0]).toEqual([
+      'SET', 'room:ABC-DEF-GHJ', JSON.stringify(room()), 'EX', ROOM_TTL_SECONDS,
+    ]);
+  });
+
+  it('expires a production-entry Redis room after a 25-hour clock skip', async () => {
+    const redis = new ExpiringRedis();
+    const server = await RoomRecordServer.fromEnvironment({}, { redisClient: redis });
+    await server.createRoom(room());
+    expect(await server.getRoom(room().code)).toEqual(room());
+
+    redis.advance(25 * 60 * 60);
+
+    expect(await server.getRoom(room().code)).toBeNull();
+  });
+
+  it('uses the existing message keys, trim cap, count, and creation-anchored expiry', async () => {
+    const redis = new RecordingRedis();
+    const store = new RedisRoomPersistence(redis);
+    await store.createRoom(room());
+    await store.appendMessage(room().code, message());
+
+    expect(redis.pipelines[0]).toEqual([
+      ['RPUSH', 'room-msgs:ABC-DEF-GHJ', JSON.stringify(message())],
+      ['INCR', 'room-msg-count:ABC-DEF-GHJ'],
+      ['LTRIM', 'room-msgs:ABC-DEF-GHJ', -500, -1],
+      ['EXPIREAT', 'room-msgs:ABC-DEF-GHJ', Math.floor(room().createdAt / 1000) + ROOM_TTL_SECONDS],
+      ['EXPIREAT', 'room-msg-count:ABC-DEF-GHJ', Math.floor(room().createdAt / 1000) + ROOM_TTL_SECONDS],
+    ]);
+  });
+
+  it('fails closed on an unknown adapter instead of silently changing storage', async () => {
+    await expect(RoomRecordServer.fromEnvironment(
+      { AGENT_ROOM_PERSISTENCE: 'mystery' },
+      { redisClient: new RecordingRedis() },
+    )).rejects.toThrow(/must be redis or postgres/);
+  });
+
+  it('matches the durable adapter collision contract for minutes and receipts', async () => {
+    const store = new RedisRoomPersistence(new StatefulRedis());
+    await proveImmutableRecordParity(store, room(), report(), receipt());
+  });
+});

--- a/packages/room-persistence/test/schema.test.ts
+++ b/packages/room-persistence/test/schema.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { POSTGRES_SCHEMA_SQL } from '../src/schema.js';
+
+describe('migration custody', () => {
+  it('keeps the shipped migration byte-equivalent to the schema applied by the adapter', () => {
+    const path = fileURLToPath(new URL('../migrations/001_durable_room_record.sql', import.meta.url));
+    expect(readFileSync(path, 'utf8').trim()).toBe(POSTGRES_SCHEMA_SQL.trim());
+  });
+});

--- a/packages/room-persistence/tsconfig.json
+++ b/packages/room-persistence/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Stack

Depends on #43. Review this commit as the durable-storage layer after that MCP forward port; GitHub shows the dependency commit because cross-fork contributor branches cannot be selected as a base branch in this repository.

## Summary

- add a `RoomPersistence` seam with Redis as the unchanged default
- add a durable Postgres adapter and an explicit, reviewed migration command
- retain messages, task boards, minutes, receipts, and lease-event records with adapter parity
- run adapter contract tests and CI-local Postgres 16 integration tests

## Provenance

Forward-port source: `noogalabs/agent-room` PR #4, merged as `9abf3d938d04ed9e4987c472afaea9a710db860c`.

No organization data, deployment configuration, credentials, or live database action is included.
