### PR TITLE
Authenticate durable room members

### DIFF
--- a/docs/authenticated-room-members.md
+++ b/docs/authenticated-room-members.md
@@ -1,0 +1,50 @@
+# Authenticated room members
+
+## Decision
+
+Add authenticated fleet membership as the default room-code join contract. Unsigned name-plus-code joins are available only when `AGENT_ROOM_MEMBER_AUTH=legacy` is explicitly configured. The default requires a signed agent card. The join service verifies the card, checks that the room accepts its declared authentication scheme, and stores the verified identity with the participant through the durable `RoomPersistence` seam introduced in PR4.
+
+This slice defines an A2A-style signed-card subset and an OAuth 2.1 gate for an HTTP MCP transport. It does not change the current stdio MCP transport, deploy anything, or provision credentials.
+
+## Card and binding
+
+The public card contains a protocol version, stable fleet ID, agent name, service URL, software version, declared security schemes, and security requirements. The accepted scheme vocabulary is `oauth2`, `openIdConnect`, and `mTLS`; exactly one chosen scheme is presented for a join. A signed envelope carries the card, a protected header containing an allowlisted algorithm and `kid`, and a JWS signature. Cards contain public metadata only—never bearer tokens, private keys, client secrets, or room capabilities.
+
+Verification resolves `fleetId` plus `kid` only from the hosted service's configured trust store, verifies the canonical card bytes and signature, and fails closed on an unknown key, unsupported algorithm, malformed card, or tampering. The durable member fingerprint is derived from the verified fleet ID and trusted public key, not mutable display fields, so a card refresh does not silently create a new identity.
+
+The verified participant record adds an `authenticatedIdentity` value containing the fingerprint, fleet ID, card name, selected scheme, key ID, and verification time. It remains inside the versioned room document, so both Redis and Postgres adapters persist the same binding without a second source of truth. A room declares accepted member schemes for authenticated joins.
+
+## Join path and flags
+
+The production join order is: validate the existing room access capability; parse the signed-card input when present; verify its JWS against the configured fleet trust store; require the selected scheme to appear both in the card and the room's accepted schemes; then atomically add the participant and verified binding through `RoomRecordServer`.
+
+Named refusal outcomes are `agent_card_signature_invalid`, `agent_card_scheme_not_accepted`, and `agent_card_required`. Under the default `required` mode, an unsigned join is refused before persistence. An unsigned join follows the prior behavior only under explicit `AGENT_ROOM_MEMBER_AUTH=legacy`. No failure path creates or partially updates a participant.
+
+The authentication-scheme vocabulary is enforced as a runtime closed set, not
+only as a TypeScript type. Card declarations, the selected join scheme, and the
+room's accepted-scheme configuration are each validated before any participant
+write; unknown wire values such as `apiKey` fail as
+`agent_card_scheme_not_accepted`.
+
+Fleet private signing keys live outside the repository in the fleet secret store or a permission-restricted file. The room service receives public verification keys only. Join verification performs no network fetch, so a card cannot turn its URL or key reference into SSRF.
+
+## MCP transport authentication
+
+HTTP MCP requests use an injected OAuth access-token verifier before any MCP method executes. The verifier checks issuer, audience/resource binding, expiry, and required scope and returns a fleet principal used by the member join. The HTTP adapter exposes protected-resource metadata and a standards-shaped `401` challenge. It never forwards the incoming bearer token to tools or stores it in the room. OIDC is an authorization-server discovery option, OAuth2 is the token scheme, and mTLS is a declared client-authentication scheme; all terminate outside the carrier-free room core. The existing local stdio transport remains unchanged and continues to obtain credentials from its environment.
+
+References: [A2A Protocol specification](https://a2a-protocol.org/dev/specification/) and [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
+
+## Proof and limits
+
+The production join entry gets four named casualties: a valid signed card joins and its binding survives persistence; a one-byte signature/card mutation is refused with no participant write; a valid card selecting a scheme the room does not accept is refused with no write; and legacy join succeeds under the default flag but is refused under `required`. Restored-defect kills must turn each applicable casualty red. HTTP MCP tests additionally prove a valid audience-and-scope token reaches dispatch and an invalid token cannot.
+
+Out of scope for build 2: running an authorization server, live OIDC/JWKS discovery, certificate issuance, dynamic registration, secret provisioning, deployment, cross-fleet `@` addressing (build 3), and live turn leases or signed handoff receipts (build 4).
+
+## Implementation receipt
+
+- `joins a valid card and keeps the fingerprint binding in the persistence seam`: green; removing the persisted `authenticatedIdentity` made it red by name.
+- `refuses a tampered signature before any participant write`: green; bypassing signature verification made it red by name.
+- `refuses a room-unaccepted scheme before any participant write`: green; bypassing the room scheme check made it red by name.
+- `requires authenticated joins by default and enables legacy only explicitly`: green; restoring the legacy default made it red by name.
+- The Postgres integration drives the same production join entry and proves the binding survives a server restart. The HTTP MCP gate proves audience/scope verification, token stripping before dispatch, and a protected-resource `401` challenge.
+- Local rollup: 402 tests passed and 2 Postgres integration tests skipped without `TEST_POSTGRES_URL`; `npm run build:ordered` passed across all eight workspaces. Exact-head CI supplies the real Postgres leg.

--- a/packages/room-persistence/src/index.ts
+++ b/packages/room-persistence/src/index.ts
@@ -4,3 +4,4 @@ export * from './server.js';
 export * from './redis.js';
 export * from './postgres.js';
 export * from './schema.js';
+export * from './member-auth.js';

--- a/packages/room-persistence/src/member-auth.ts
+++ b/packages/room-persistence/src/member-auth.ts
@@ -1,0 +1,205 @@
+import {
+  createHash,
+  createPublicKey,
+  sign as signBytes,
+  verify as verifyBytes,
+  type KeyObject,
+  type KeyLike,
+} from 'node:crypto';
+import type {
+  AuthenticatedMemberIdentity,
+  MemberAuthScheme,
+  Participant,
+  Room,
+} from '@agent-room/shared';
+import { RoomRecordServer } from './server.js';
+
+export type MemberAuthMode = 'legacy' | 'required';
+
+export const MEMBER_AUTH_SCHEMES = ['oauth2', 'openIdConnect', 'mTLS'] as const;
+
+export type MemberAuthSchemeBoundary =
+  | 'card_declaration'
+  | 'selected_join_scheme'
+  | 'selected_verification_scheme'
+  | 'room_configuration';
+
+export function requireMemberAuthScheme(
+  value: unknown,
+  boundary: MemberAuthSchemeBoundary,
+): MemberAuthScheme {
+  if (typeof value === 'string' && (MEMBER_AUTH_SCHEMES as readonly string[]).includes(value)) {
+    return value as MemberAuthScheme;
+  }
+  throw new MemberJoinError('agent_card_scheme_not_accepted',
+    'Agent Card authentication scheme is outside the supported closed set.', boundary);
+}
+
+export interface AgentCard {
+  protocolVersion: string;
+  fleetId: string;
+  name: string;
+  url: string;
+  version: string;
+  securitySchemes: Partial<Record<MemberAuthScheme, Readonly<Record<string, unknown>>>>;
+  security: MemberAuthScheme[];
+}
+
+export interface SignedAgentCard {
+  protected: string;
+  card: AgentCard;
+  signature: string;
+}
+
+export interface FleetTrustKey {
+  fleetId: string;
+  keyId: string;
+  publicKey: KeyLike;
+}
+
+export interface AuthenticatedJoinInput {
+  participant: Omit<Participant, 'joinedAt' | 'lastSeenAt' | 'authenticatedIdentity'>;
+  signedCard?: SignedAgentCard;
+  scheme?: MemberAuthScheme;
+}
+
+export class MemberJoinError extends Error {
+  constructor(readonly code: string, message: string, readonly boundary?: MemberAuthSchemeBoundary) {
+    super(message);
+    this.name = code;
+  }
+}
+
+export function memberAuthModeFromEnvironment(
+  env: Readonly<Record<string, string | undefined>>,
+): MemberAuthMode {
+  const value = env.AGENT_ROOM_MEMBER_AUTH ?? 'required';
+  if (value === 'legacy' || value === 'required') return value;
+  throw new MemberJoinError('member_auth_configuration_invalid',
+    'AGENT_ROOM_MEMBER_AUTH must be legacy or required.');
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonical(item)]));
+  }
+  return value;
+}
+
+function base64url(value: string | Buffer): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+function signingInput(card: AgentCard, protectedHeader: string): Buffer {
+  return Buffer.from(`${protectedHeader}.${base64url(JSON.stringify(canonical(card)))}`);
+}
+
+export function signAgentCard(card: AgentCard, keyId: string, privateKey: KeyLike): SignedAgentCard {
+  const protectedHeader = base64url(JSON.stringify({ alg: 'EdDSA', kid: keyId, typ: 'agent-card+jws' }));
+  return {
+    protected: protectedHeader,
+    card,
+    signature: signBytes(null, signingInput(card, protectedHeader), privateKey).toString('base64url'),
+  };
+}
+
+function parseProtected(encoded: string): { alg?: string; kid?: string; typ?: string } {
+  try {
+    return JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as Record<string, string>;
+  } catch {
+    throw new MemberJoinError('agent_card_signature_invalid', 'Agent Card protected header is malformed.');
+  }
+}
+
+export class AgentCardVerifier {
+  private readonly trustKeys: readonly FleetTrustKey[];
+
+  constructor(trustKeys: readonly FleetTrustKey[], private readonly now: () => number = Date.now) {
+    this.trustKeys = [...trustKeys];
+  }
+
+  verify(signed: SignedAgentCard, scheme: MemberAuthScheme): AuthenticatedMemberIdentity {
+    const selectedScheme = requireMemberAuthScheme(scheme, 'selected_verification_scheme');
+    for (const declared of signed.card.security as unknown[]) requireMemberAuthScheme(declared, 'card_declaration');
+    for (const declared of Object.keys(signed.card.securitySchemes)) requireMemberAuthScheme(declared, 'card_declaration');
+    const header = parseProtected(signed.protected);
+    if (header.alg !== 'EdDSA' || header.typ !== 'agent-card+jws' || !header.kid) {
+      throw new MemberJoinError('agent_card_signature_invalid', 'Agent Card JWS header is not accepted.');
+    }
+    const key = this.trustKeys.find(item =>
+      item.fleetId === signed.card.fleetId && item.keyId === header.kid);
+    if (!key || !verifyBytes(null, signingInput(signed.card, signed.protected), key.publicKey,
+      Buffer.from(signed.signature, 'base64url'))) {
+      throw new MemberJoinError('agent_card_signature_invalid', 'Agent Card signature could not be verified.');
+    }
+    if (!signed.card.protocolVersion.trim() || !signed.card.fleetId.trim() ||
+      !signed.card.name.trim() || !signed.card.version.trim()) {
+      throw new MemberJoinError('agent_card_signature_invalid', 'Agent Card is missing a required public field.');
+    }
+    try {
+      if (new URL(signed.card.url).protocol !== 'https:') throw new Error('not https');
+    } catch {
+      throw new MemberJoinError('agent_card_signature_invalid', 'Agent Card service URL must use HTTPS.');
+    }
+    if (!signed.card.security.includes(selectedScheme) || !(selectedScheme in signed.card.securitySchemes)) {
+      throw new MemberJoinError('agent_card_scheme_not_accepted', 'Agent Card does not declare the selected scheme.');
+    }
+    const publicObject = typeof key.publicKey === 'object' && 'type' in key.publicKey &&
+      (key.publicKey as KeyObject).type === 'public'
+      ? key.publicKey as KeyObject
+      : createPublicKey(key.publicKey);
+    const publicDer = publicObject.export({ type: 'spki', format: 'der' });
+    const fingerprint = createHash('sha256')
+      .update(signed.card.fleetId).update('\0').update(publicDer).digest('hex');
+    return {
+      cardFingerprint: fingerprint,
+      fleetId: signed.card.fleetId,
+      cardName: signed.card.name,
+      scheme: selectedScheme,
+      keyId: key.keyId,
+      verifiedAt: this.now(),
+    };
+  }
+}
+
+export class AuthenticatedRoomJoinServer {
+  constructor(
+    private readonly rooms: RoomRecordServer,
+    private readonly verifier: AgentCardVerifier,
+    private readonly mode: MemberAuthMode = 'required',
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  async join(code: string, input: AuthenticatedJoinInput): Promise<Participant> {
+    const room = await this.rooms.getRoom(code);
+    if (!room || room.status !== 'active') throw new MemberJoinError('room_not_found', 'Room is not active.');
+    const acceptedSchemes = (room.acceptedMemberAuthSchemes ?? [])
+      .map(value => requireMemberAuthScheme(value, 'room_configuration'));
+    let identity: AuthenticatedMemberIdentity | undefined;
+    if (!input.signedCard || !input.scheme) {
+      if (this.mode === 'required') {
+        throw new MemberJoinError('agent_card_required', 'This room requires a signed Agent Card.');
+      }
+    } else {
+      const selectedScheme = requireMemberAuthScheme(input.scheme, 'selected_join_scheme');
+      identity = this.verifier.verify(input.signedCard, selectedScheme);
+      if (!acceptedSchemes.includes(selectedScheme)) {
+        throw new MemberJoinError('agent_card_scheme_not_accepted', 'Room does not accept the selected Agent Card scheme.');
+      }
+      if (identity.cardName !== input.participant.name) {
+        throw new MemberJoinError('agent_card_identity_mismatch', 'Participant name does not match the verified Agent Card.');
+      }
+    }
+    const at = this.now();
+    const participant: Participant = { ...input.participant, joinedAt: at, lastSeenAt: at,
+      ...(identity ? { authenticatedIdentity: identity } : {}) };
+    const next: Room = { ...room, version: room.version + 1, participants: [...room.participants, participant] };
+    if (!await this.rooms.updateRoom(code, room.version, next)) {
+      throw new MemberJoinError('room_version_conflict', 'Room changed while the participant was joining.');
+    }
+    return participant;
+  }
+}

--- a/packages/room-persistence/test/member-auth.test.ts
+++ b/packages/room-persistence/test/member-auth.test.ts
@@ -1,0 +1,192 @@
+import { generateKeyPairSync, sign as signBytes } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import type { Room } from '@agent-room/shared';
+import type { RoomPersistence } from '../src/types.js';
+import { RoomRecordServer } from '../src/server.js';
+import {
+  AgentCardVerifier,
+  AuthenticatedRoomJoinServer,
+  signAgentCard,
+  memberAuthModeFromEnvironment,
+  type AgentCard,
+} from '../src/member-auth.js';
+
+function room(): Room {
+  return {
+    code: 'AUT-MEM-BER', topic: 'Synthetic', createdAt: 1, createdBy: 'Host',
+    status: 'active', version: 1, participants: [], acceptedMemberAuthSchemes: ['oauth2'],
+  };
+}
+
+function card(): AgentCard {
+  return {
+    protocolVersion: '0.3.0', fleetId: 'fleet-synthetic', name: 'Builder',
+    url: 'https://agent.invalid/a2a', version: '1.0.0',
+    securitySchemes: { oauth2: { type: 'oauth2' }, mTLS: { type: 'mutualTLS' } },
+    security: ['oauth2', 'mTLS'],
+  };
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonical(item)]),
+  );
+  return value;
+}
+
+class MemoryPersistence implements RoomPersistence {
+  readonly kind = 'postgres' as const;
+  current: Room = room();
+  writes = 0;
+  async createRoom(value: Room) { this.current = structuredClone(value); }
+  async getRoom(code: string) { return code === this.current.code ? structuredClone(this.current) : null; }
+  async compareAndSwapRoom(_code: string, expected: number, next: Room) {
+    if (this.current.version !== expected) return false;
+    this.current = structuredClone(next); this.writes++; return true;
+  }
+  async appendMessage() { return 0; }
+  async listMessages() { return []; }
+  async getTaskBoard() { return null; }
+  async compareAndSwapTaskBoard() { return false; }
+  async putMinutes() {}
+  async getMinutes() { return null; }
+  async appendReceipt() { return false; }
+  async appendLeaseEvent() { return false; }
+  async listReceipts() { return []; }
+  async close() {}
+}
+
+const participant = { name: 'Builder', role: 'builder', color: '#123456', initials: 'BU', client: 'cc' } as const;
+
+describe('authenticated room join production entry', () => {
+  it('joins a valid card and keeps the fingerprint binding in the persistence seam', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const persistence = new MemoryPersistence();
+    const join = new AuthenticatedRoomJoinServer(
+      new RoomRecordServer(persistence),
+      new AgentCardVerifier([{ fleetId: card().fleetId, keyId: 'key-1', publicKey: keys.publicKey }], () => 20),
+      'required', () => 20,
+    );
+    const saved = await join.join(room().code, {
+      participant, scheme: 'oauth2', signedCard: signAgentCard(card(), 'key-1', keys.privateKey),
+    });
+
+    expect(saved.authenticatedIdentity).toMatchObject({ fleetId: 'fleet-synthetic', scheme: 'oauth2', keyId: 'key-1' });
+    expect((await persistence.getRoom(room().code))?.participants[0]).toEqual(saved);
+    expect(persistence.writes).toBe(1);
+  });
+
+  it('refuses a tampered signature before any participant write', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const persistence = new MemoryPersistence();
+    const join = new AuthenticatedRoomJoinServer(new RoomRecordServer(persistence),
+      new AgentCardVerifier([{ fleetId: card().fleetId, keyId: 'key-1', publicKey: keys.publicKey }]), 'required');
+    const signed = signAgentCard(card(), 'key-1', keys.privateKey);
+    signed.card = { ...signed.card, name: 'Tampered' };
+
+    await expect(join.join(room().code, { participant, scheme: 'oauth2', signedCard: signed }))
+      .rejects.toMatchObject({ name: 'agent_card_signature_invalid' });
+    expect(persistence.writes).toBe(0);
+  });
+
+  it('refuses a room-unaccepted scheme before any participant write', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const persistence = new MemoryPersistence();
+    const join = new AuthenticatedRoomJoinServer(new RoomRecordServer(persistence),
+      new AgentCardVerifier([{ fleetId: card().fleetId, keyId: 'key-1', publicKey: keys.publicKey }]), 'required');
+
+    await expect(join.join(room().code, {
+      participant, scheme: 'mTLS', signedCard: signAgentCard(card(), 'key-1', keys.privateKey),
+    })).rejects.toMatchObject({ name: 'agent_card_scheme_not_accepted' });
+    expect(persistence.writes).toBe(0);
+  });
+
+  it('requires authenticated joins by default and enables legacy only explicitly', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const verifier = new AgentCardVerifier([{ fleetId: card().fleetId, keyId: 'key-1', publicKey: keys.publicKey }]);
+    const legacyStore = new MemoryPersistence();
+    const legacy = new AuthenticatedRoomJoinServer(new RoomRecordServer(legacyStore), verifier, 'legacy');
+    expect((await legacy.join(room().code, { participant })).authenticatedIdentity).toBeUndefined();
+    expect(legacyStore.writes).toBe(1);
+
+    const requiredStore = new MemoryPersistence();
+    const required = new AuthenticatedRoomJoinServer(new RoomRecordServer(requiredStore), verifier);
+    await expect(required.join(room().code, { participant }))
+      .rejects.toMatchObject({ name: 'agent_card_required' });
+    expect(requiredStore.writes).toBe(0);
+    expect(memberAuthModeFromEnvironment({})).toBe('required');
+    expect(memberAuthModeFromEnvironment({ AGENT_ROOM_MEMBER_AUTH: 'legacy' })).toBe('legacy');
+    expect(memberAuthModeFromEnvironment({ AGENT_ROOM_MEMBER_AUTH: 'required' })).toBe('required');
+    expect(() => memberAuthModeFromEnvironment({ AGENT_ROOM_MEMBER_AUTH: 'optional' }))
+      .toThrow(/must be legacy or required/);
+  });
+
+  it('refuses an unknown Agent Card kid without falling back to another fleet key', () => {
+    const trusted = generateKeyPairSync('ed25519');
+    const signed = signAgentCard(card(), 'unknown-kid', trusted.privateKey);
+    const verifier = new AgentCardVerifier([
+      { fleetId: card().fleetId, keyId: 'trusted-kid', publicKey: trusted.publicKey },
+    ]);
+
+    expect(() => verifier.verify(signed, 'oauth2'))
+      .toThrowError(expect.objectContaining({ name: 'agent_card_signature_invalid' }));
+  });
+
+  it('refuses a non-EdDSA protected algorithm even when the signature bytes are present', () => {
+    const keys = generateKeyPairSync('ed25519');
+    const signed = signAgentCard(card(), 'key-1', keys.privateKey);
+    signed.protected = Buffer.from(JSON.stringify({ alg: 'none', kid: 'key-1', typ: 'agent-card+jws' }))
+      .toString('base64url');
+    signed.signature = signBytes(null, Buffer.from(
+      `${signed.protected}.${Buffer.from(JSON.stringify(canonical(signed.card))).toString('base64url')}`,
+    ), keys.privateKey).toString('base64url');
+    const verifier = new AgentCardVerifier([
+      { fleetId: card().fleetId, keyId: 'key-1', publicKey: keys.publicKey },
+    ]);
+
+    expect(() => verifier.verify(signed, 'oauth2'))
+      .toThrowError(expect.objectContaining({ name: 'agent_card_signature_invalid' }));
+  });
+
+  it.each([
+    {
+      label: 'card declaration', boundary: 'card_declaration', selected: 'oauth2',
+      cardSchemes: ['oauth2', 'apiKey'], roomSchemes: ['oauth2'],
+    },
+    {
+      label: 'selected join scheme', boundary: 'selected_join_scheme', selected: 'apiKey',
+      cardSchemes: ['oauth2', 'apiKey'], roomSchemes: ['oauth2'],
+    },
+    {
+      label: 'room configuration', boundary: 'room_configuration', selected: 'oauth2',
+      cardSchemes: ['oauth2'], roomSchemes: ['oauth2', 'apiKey'],
+    },
+  ] as const)('refuses an unknown runtime scheme at the $label boundary without a write', async fixture => {
+    const keys = generateKeyPairSync('ed25519');
+    const persistence = new MemoryPersistence();
+    const validCard = card();
+    const boundaryCard = {
+      ...validCard,
+      securitySchemes: Object.fromEntries(fixture.cardSchemes.map(scheme => [scheme, { type: scheme }])),
+      security: fixture.cardSchemes,
+    } as unknown as AgentCard;
+    persistence.current = { ...persistence.current,
+      acceptedMemberAuthSchemes: fixture.roomSchemes as unknown as Room['acceptedMemberAuthSchemes'] };
+    const join = new AuthenticatedRoomJoinServer(
+      new RoomRecordServer(persistence),
+      new AgentCardVerifier([{
+        fleetId: validCard.fleetId, keyId: 'key-1', publicKey: keys.publicKey,
+      }]),
+      'required',
+    );
+    await expect(join.join(room().code, {
+      participant,
+      scheme: fixture.selected as unknown as 'oauth2',
+      signedCard: signAgentCard(boundaryCard, 'key-1', keys.privateKey),
+    })).rejects.toMatchObject({ name: 'agent_card_scheme_not_accepted', boundary: fixture.boundary });
+    expect(persistence.writes).toBe(0);
+    expect(persistence.current.participants).toEqual([]);
+  });
+});

--- a/packages/room-persistence/test/postgres.integration.test.ts
+++ b/packages/room-persistence/test/postgres.integration.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
 import { Pool } from 'pg';
@@ -5,6 +6,7 @@ import { RoomRecordServer } from '../src/server.js';
 import { PostgresRoomPersistence } from '../src/postgres.js';
 import { PersistenceSchemaError, type RoomReceipt } from '../src/types.js';
 import { proveImmutableRecordParity } from './parity-contract.js';
+import { AgentCardVerifier, AuthenticatedRoomJoinServer, signAgentCard } from '../src/member-auth.js';
 
 const databaseUrl = process.env.TEST_POSTGRES_URL;
 const describePostgres = databaseUrl ? describe : describe.skip;
@@ -138,6 +140,41 @@ describePostgres('Postgres durable room production entry', () => {
       expect(await restarted.listMessages(room().code, 0)).toEqual([message()]);
       expect(await restarted.getMinutes(room().code, 'minutes-1')).toEqual(report());
       expect(await restarted.listReceipts(room().code)).toHaveLength(6);
+    } finally {
+      await restarted.close();
+    }
+  });
+
+  it('retains an authenticated member binding across a Postgres server restart', async () => {
+    vi.useRealTimers();
+    const server = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    const durableRoom: Room = {
+      ...room(), code: 'PGS-AUT-MEM', version: 1, participants: [],
+      acceptedMemberAuthSchemes: ['oauth2'],
+    };
+    const keys = generateKeyPairSync('ed25519');
+    const card = {
+      protocolVersion: '0.3.0', fleetId: 'fleet-ci', name: 'Builder',
+      url: 'https://agent.invalid/a2a', version: '1.0.0',
+      securitySchemes: { oauth2: { type: 'oauth2' } }, security: ['oauth2' as const],
+    };
+    await server.createRoom(durableRoom);
+    const joins = new AuthenticatedRoomJoinServer(server,
+      new AgentCardVerifier([{ fleetId: 'fleet-ci', keyId: 'key-ci', publicKey: keys.publicKey }]));
+    const participant = await joins.join(durableRoom.code, {
+      participant: { name: 'Builder', initials: 'BU', color: '#456', role: 'builder', client: 'cc' },
+      scheme: 'oauth2', signedCard: signAgentCard(card, 'key-ci', keys.privateKey),
+    });
+    await server.close();
+
+    const restarted = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    try {
+      expect((await restarted.getRoom(durableRoom.code))?.participants).toEqual([participant]);
+      expect(participant.authenticatedIdentity?.fleetId).toBe('fleet-ci');
     } finally {
       await restarted.close();
     }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,16 @@
 export type ClientKind = 'web' | 'cc';
 
+export type MemberAuthScheme = 'oauth2' | 'openIdConnect' | 'mTLS';
+
+export interface AuthenticatedMemberIdentity {
+  cardFingerprint: string;
+  fleetId: string;
+  cardName: string;
+  scheme: MemberAuthScheme;
+  keyId: string;
+  verifiedAt: number;
+}
+
 export interface Participant {
   name: string;
   role: string;          // empty string if not provided
@@ -13,6 +24,9 @@ export interface Participant {
   // existed (treated as legacy-approved). New joiners default to false until
   // the host (createdBy) approves them via approveParticipant.
   canSpeak?: boolean;
+  // Present only after a signed fleet Agent Card has been verified. This is
+  // part of the room document so every RoomPersistence adapter retains it.
+  authenticatedIdentity?: AuthenticatedMemberIdentity;
 }
 
 // How agent responses are coordinated in this room.
@@ -166,6 +180,8 @@ export interface Room {
   endedAt?: number;      // epoch ms — set when meeting ends
   version: number;       // for optimistic concurrency
   participants: Participant[];
+  // Omitted for legacy rooms. Authenticated joins must select one of these.
+  acceptedMemberAuthSchemes?: MemberAuthScheme[];
   // Hash of the secret returned to the host on createRoom. Anyone trying to
   // join with name === createdBy must present the matching secret, otherwise
   // they get HostNameTakenError. This stops trivial impersonation by anyone


### PR DESCRIPTION
## Stack

Depends on #43 and #44. Review the final commit as the authenticated-member layer; the earlier commits remain visible because GitHub cannot use a contributor-fork branch as this repository's base.

## Summary

- verify signed A2A-style Agent Cards with a fail-closed Ed25519 trust set
- enforce the supported OAuth2, OIDC, and mTLS scheme set at runtime boundaries
- require authenticated member identity on durable joins by default
- retain identity provenance in the room record through both adapters

## Provenance

Forward-port source: `noogalabs/agent-room` PR #5, merged as `df3cee7cd27997f79ced38270e2b3678fc280053`.

No organization data, real keys, secrets, deployment, or live network action is included.
