### PR TITLE
Enforce durable task turn leases

### DIFF
--- a/docs/task-turn-lease.md
+++ b/docs/task-turn-lease.md
@@ -1,0 +1,41 @@
+# Task turn lease
+
+## Source contract
+
+This ports the lease mechanics from Bothread commit `cf2d8f8a9647636d438223fbbda51233752eea9a`, specifically [`packages/shared/src/index.ts`](https://github.com/AdamACE9/bothread/blob/cf2d8f8a9647636d438223fbbda51233752eea9a/packages/shared/src/index.ts#L48-L61) for the 15-minute default and lease shape, and [`packages/server/src/engine/engine.ts`](https://github.com/AdamACE9/bothread/blob/cf2d8f8a9647636d438223fbbda51233752eea9a/packages/server/src/engine/engine.ts#L1129-L1341) for sweep-before-claim, atomic conflict-check plus grant, holder-only renew/release, TTL expiry, and routed handoff behavior. Agent Room applies those semantics to one board task rather than a file glob and makes the lease a server-enforced write guard, not an advisory prompt.
+
+## Record and actors
+
+An optional `lease` on a task contains `id`, `holderId`, `holderName`, `holderClient`, `status`, `grantedAt`, `expiresAt`, and optional renewal/release and pending-handoff fields. `holderId` is the authenticated Agent Card fingerprint from PR5. Only an active authenticated room participant may claim or receive a lease. Existing unleased task behavior remains unchanged; a legacy participant may use unleased tasks but cannot create an identity-bearing lease.
+
+The default TTL is 15 minutes, matching Bothread, with a positive caller override capped at 24 hours. Time comparisons are server-side. Every mutating entry first sweeps an active lease whose `expiresAt <= now` to `expired` and records that transition before evaluating the requested action.
+
+## Atomic state and ledger
+
+The task board is the current-state authority and PR4's receipt ledger is the immutable history. The persistence seam gains one compare-and-swap operation that updates the task board and appends its lease events in the same Redis script or Postgres transaction. A failed compare-and-swap appends no receipt; a retry uses deterministic receipt IDs so it cannot duplicate history.
+
+Two concurrent claims read the same board version, but only one compare-and-swap may commit. The loser reloads and receives `task_lease_held`; it never overwrites the winner. Grant, renew, release, expiry, and handoff request each append the corresponding PR4 `lease_event` (`granted`, `renewed`, `released`, `expired`, `handoff_requested`) with room, task, lease, actor, holder, sequence time, and transfer context.
+
+## Commands and push guard
+
+- `claim`: grants an unleased or expired task to the authenticated caller.
+- `renew`: holder-only; replaces `expiresAt` with `now + ttl`, rather than extending stale time.
+- `release`: holder-only; closes the lease and makes the task claimable.
+- `requestHandoff`: a non-holder records one pending request addressed to the current holder. It does not steal or release the lease.
+- `grantHandoff`: holder-only; re-validates the named requester as an active authenticated participant at grant time, then atomically replaces the holder, clears the request, resets the TTL, and records the new `granted` event with transfer context. A departed or unauthenticated recipient is refused by name, leaves the board unchanged, and writes a refusal receipt to the durable ledger.
+- `submit`: if a task has an active lease, the production task submission entry compares the caller's authenticated fingerprint to `holderId`. A mismatch fails by name as `task_lease_holder_required` before evidence or board state can change. Expiry is swept first, so an expired lease no longer authorizes its former holder.
+
+## Proof and scope
+
+Production-entry casualties bind the contract: two authenticated participants race and exactly one claim commits; a non-holder submission is refused with the board unchanged; renew extends while release frees; expiry frees and emits `expired`; a handoff reaches the holder and holder grant transfers atomically; a departed handoff recipient is refused with a durable receipt; and renew, release, handoff request, and submit each persist lazy expiry before reporting their own rejected precondition. The combined receipt assertions require every emitted event in exact ledger order, including all five event kinds. Each restored defect must turn its named casualty red, then green at the frozen head. The ordered eight-workspace build, full rollup, and real-Postgres CI leg are required.
+
+Out of scope: file-glob overlap, git branch automation, cross-fleet `@` addressing, decision pins and signed handoff receipts (build 4), deployment, and secrets.
+
+## Implementation receipt
+
+- `atomically grants exactly one of two concurrent claims`: green; removing the held-lease conflict check made both contenders succeed and turned it red. The real-Postgres restart test repeats the race through the production persistence transaction.
+- `refuses a non-holder submission by name without changing the board`: green with holder-submit control; bypassing the holder comparison made it red.
+- `lets only the holder renew and release, extending from server time and freeing the task`: green; restoring a non-extending renewal made it red.
+- `sweeps expiry before claim and records expiry before the replacement grant`: green; disabling the expiry sweep made it red.
+- `routes a handoff to the holder and transfers its grant atomically with ordered ledger events`: green; retaining the old holder during grant made it red.
+- Redis uses one script for board CAS plus ordered ledger appends; Postgres uses one transaction. Local rollup: 408 passed and 3 Postgres tests skipped without `TEST_POSTGRES_URL`; `npm run build:ordered` passed across all eight workspaces. Exact-head CI supplies the real Postgres leg.

--- a/packages/room-persistence/src/index.ts
+++ b/packages/room-persistence/src/index.ts
@@ -5,3 +5,4 @@ export * from './redis.js';
 export * from './postgres.js';
 export * from './schema.js';
 export * from './member-auth.js';
+export * from './task-leases.js';

--- a/packages/room-persistence/src/postgres.ts
+++ b/packages/room-persistence/src/postgres.ts
@@ -1,7 +1,7 @@
 import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
 import { Pool, type PoolClient, type PoolConfig, type QueryResult } from 'pg';
 import { POSTGRES_SCHEMA_SQL } from './schema.js';
-import { PersistenceSchemaError, type LeaseEventInput, type RoomPersistence, type RoomReceipt } from './types.js';
+import { PersistenceSchemaError, type LeaseEventInput, type LeaseMembershipPrecondition, type RoomPersistence, type RoomReceipt } from './types.js';
 import { sameJson } from './json.js';
 
 const REQUIRED_SCHEMA_VERSION = 1;
@@ -162,6 +162,60 @@ export class PostgresRoomPersistence implements RoomPersistence {
       [code, expectedVersion, next.version, JSON.stringify(next), Date.now()],
     );
     return count(updated) === 1;
+  }
+
+  async compareAndSwapTaskBoardWithLeaseEvents(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+    events: readonly LeaseEventInput[],
+    membership?: LeaseMembershipPrecondition,
+  ): Promise<boolean> {
+    return this.transaction(async client => {
+      if (membership) {
+        const locked = await client.query<{ version: number; status: string; room_json: unknown }>(
+          'SELECT version, status, room_json FROM agent_room_rooms WHERE code = $1 FOR UPDATE', [code],
+        );
+        const row = locked.rows[0];
+        const room = row ? value<Room>(row.room_json) : null;
+        const membersPresent = room?.status === 'active' && Number(row?.version) === membership.roomVersion &&
+          membership.members.every(required => room.participants.some(participant =>
+            participant.authenticatedIdentity?.cardFingerprint === required.memberId &&
+            participant.name === required.name && participant.client === required.client));
+        if (!membersPresent) return false;
+      }
+      let changed: QueryResult;
+      if (expectedVersion === null) {
+        changed = await client.query(
+          `INSERT INTO agent_room_task_boards (room_code, version, board_json, updated_at)
+           VALUES ($1, $2, $3::jsonb, $4)
+           ON CONFLICT (room_code) DO NOTHING`,
+          [code, next.version, JSON.stringify(next), Date.now()],
+        );
+      } else {
+        changed = await client.query(
+          `UPDATE agent_room_task_boards
+              SET version = $3, board_json = $4::jsonb, updated_at = $5
+            WHERE room_code = $1 AND version = $2`,
+          [code, expectedVersion, next.version, JSON.stringify(next), Date.now()],
+        );
+      }
+      if (count(changed) !== 1) return false;
+      for (const event of events) {
+        const receipt: RoomReceipt = {
+          id: event.id, roomCode: event.roomCode, kind: 'lease_event', createdAt: event.at,
+          leaseEvent: event.event,
+          payload: { actor: event.actor, leaseId: event.leaseId, ...(event.details ?? {}) },
+        };
+        await client.query(
+          `INSERT INTO agent_room_receipts
+            (room_code, receipt_id, receipt_kind, lease_event, receipt_json, created_at)
+           VALUES ($1, $2, 'lease_event', $3, $4::jsonb, $5)`,
+          [code, receipt.id, event.event, JSON.stringify(receipt), event.at],
+        );
+      }
+      return true;
+    });
   }
 
   async putMinutes(code: string, reportId: string, report: RoomReport): Promise<void> {

--- a/packages/room-persistence/src/redis.ts
+++ b/packages/room-persistence/src/redis.ts
@@ -1,7 +1,7 @@
 import { MAX_MESSAGES_PER_ROOM, ROOM_TTL_SECONDS } from '@agent-room/shared';
 import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
 import type { UpstashClient } from '@agent-room/upstash-client';
-import type { LeaseEventInput, RoomPersistence, RoomReceipt } from './types.js';
+import type { LeaseEventInput, LeaseMembershipPrecondition, RoomPersistence, RoomReceipt } from './types.js';
 import { canonicalJson } from './json.js';
 
 const roomKey = (code: string): string => `room:${code}`;
@@ -31,6 +31,46 @@ const BOARD_CAS_SCRIPT = [
   '  if tonumber(current.version) ~= tonumber(ARGV[2]) then return 0 end',
   'end',
   "redis.call('SET', KEYS[1], ARGV[3], 'EX', tonumber(ARGV[4]))",
+  'return 1',
+].join('\n');
+
+const BOARD_AND_LEASE_EVENTS_CAS_SCRIPT = [
+  'if tonumber(ARGV[6]) >= 0 then',
+  "  local room_raw = redis.call('GET', KEYS[4])",
+  '  if not room_raw then return 0 end',
+  '  local room = cjson.decode(room_raw)',
+  '  if room.status ~= "active" or tonumber(room.version) ~= tonumber(ARGV[6]) then return 0 end',
+  '  local required_members = cjson.decode(ARGV[7])',
+  '  for _, required in ipairs(required_members) do',
+  '    local found = false',
+  '    for _, participant in ipairs(room.participants or {}) do',
+  '      local identity = participant.authenticatedIdentity',
+  '      if identity and identity.cardFingerprint == required.memberId and participant.name == required.name and participant.client == required.client then found = true break end',
+  '    end',
+  '    if not found then return 0 end',
+  '  end',
+  'end',
+  "local raw = redis.call('GET', KEYS[1])",
+  "if ARGV[1] == 'absent' then",
+  '  if raw then return 0 end',
+  'else',
+  '  if not raw then return 0 end',
+  '  local current = cjson.decode(raw)',
+  '  if tonumber(current.version) ~= tonumber(ARGV[2]) then return 0 end',
+  'end',
+  'local event_count = tonumber(ARGV[5])',
+  'for i = 1, event_count do',
+  '  local id_index = 8 + ((i - 1) * 2)',
+  "  if redis.call('SISMEMBER', KEYS[2], ARGV[id_index]) == 1 then return redis.error_reply('lease event id collision') end",
+  'end',
+  "redis.call('SET', KEYS[1], ARGV[3], 'EX', tonumber(ARGV[4]))",
+  'for i = 1, event_count do',
+  '  local id_index = 8 + ((i - 1) * 2)',
+  '  redis.call(\'SADD\', KEYS[2], ARGV[id_index])',
+  '  redis.call(\'RPUSH\', KEYS[3], ARGV[id_index + 1])',
+  'end',
+  "redis.call('EXPIRE', KEYS[2], tonumber(ARGV[4]))",
+  "redis.call('EXPIRE', KEYS[3], tonumber(ARGV[4]))",
   'return 1',
 ].join('\n');
 
@@ -135,6 +175,30 @@ export class RedisRoomPersistence implements RoomPersistence {
       expectedVersion === null ? 'absent' : 'present',
       expectedVersion === null ? '' : String(expectedVersion),
       JSON.stringify(next), String(ROOM_TTL_SECONDS),
+    ]);
+    return Number(result) === 1;
+  }
+
+  async compareAndSwapTaskBoardWithLeaseEvents(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+    events: readonly LeaseEventInput[],
+    membership?: LeaseMembershipPrecondition,
+  ): Promise<boolean> {
+    const receipts: RoomReceipt[] = events.map(event => ({
+      id: event.id, roomCode: event.roomCode, kind: 'lease_event', createdAt: event.at,
+      leaseEvent: event.event,
+      payload: { actor: event.actor, leaseId: event.leaseId, ...(event.details ?? {}) },
+    }));
+    const result = await this.client.command<number>([
+      'EVAL', BOARD_AND_LEASE_EVENTS_CAS_SCRIPT, '4', taskBoardKey(code),
+      receiptIdsKey(code), receiptsKey(code), roomKey(code),
+      expectedVersion === null ? 'absent' : 'present',
+      expectedVersion === null ? '' : String(expectedVersion),
+      JSON.stringify(next), String(ROOM_TTL_SECONDS), String(receipts.length),
+      String(membership?.roomVersion ?? -1), JSON.stringify(membership?.members ?? []),
+      ...receipts.flatMap(receipt => [receipt.id, JSON.stringify(receipt)]),
     ]);
     return Number(result) === 1;
   }

--- a/packages/room-persistence/src/server.ts
+++ b/packages/room-persistence/src/server.ts
@@ -1,6 +1,6 @@
 import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
 import { createRoomPersistence, type PersistenceDependencies, type PersistenceEnvironment } from './factory.js';
-import type { LeaseEventInput, RoomPersistence, RoomReceipt } from './types.js';
+import type { LeaseEventInput, LeaseMembershipPrecondition, RoomPersistence, RoomReceipt } from './types.js';
 
 /**
  * Server-side production entry for durable room records. Business-rule layers
@@ -32,6 +32,15 @@ export class RoomRecordServer {
   }
   updateTaskBoard(code: string, expectedVersion: number | null, next: TaskBoard): Promise<boolean> {
     return this.persistence.compareAndSwapTaskBoard(code, expectedVersion, next);
+  }
+  updateTaskBoardWithLeaseEvents(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+    events: readonly LeaseEventInput[],
+    membership?: LeaseMembershipPrecondition,
+  ): Promise<boolean> {
+    return this.persistence.compareAndSwapTaskBoardWithLeaseEvents(code, expectedVersion, next, events, membership);
   }
   putMinutes(code: string, reportId: string, report: RoomReport): Promise<void> {
     return this.persistence.putMinutes(code, reportId, report);

--- a/packages/room-persistence/src/task-leases.ts
+++ b/packages/room-persistence/src/task-leases.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  ClientKind,
+  Participant,
+  Task,
+  TaskBoard,
+  TaskEvidence,
+  TaskLease,
+} from '@agent-room/shared';
+import { RoomRecordServer } from './server.js';
+import type { LeaseEventInput } from './types.js';
+
+export const DEFAULT_TASK_LEASE_TTL_MS = 15 * 60 * 1000;
+export const MAX_TASK_LEASE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface LeaseActor {
+  memberId: string;
+  name: string;
+  client: ClientKind;
+}
+
+export class TaskLeaseError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = code;
+  }
+}
+
+type EvidenceInput = Omit<TaskEvidence, 'submittedBy' | 'submittedClient' | 'at'>;
+
+function taskAt(board: TaskBoard, taskId: string): Task {
+  const task = board.tasks.find(item => item.id === taskId);
+  if (!task) throw new TaskLeaseError('task_not_found', `Task ${taskId} was not found.`);
+  return task;
+}
+
+function withTask(board: TaskBoard, task: Task, at: number): TaskBoard {
+  return {
+    ...board,
+    version: board.version + 1,
+    lastProgressAt: at,
+    tasks: board.tasks.map(item => item.id === task.id ? task : item),
+  };
+}
+
+export class TaskLeaseServer {
+  constructor(
+    private readonly records: RoomRecordServer,
+    private readonly now: () => number = Date.now,
+    private readonly newId: () => string = randomUUID,
+  ) {}
+
+  private authenticatedActor(room: { status: string; participants: Participant[] } | null, actor: LeaseActor): Participant {
+    const participant = room?.status === 'active' ? room.participants.find(item =>
+      item.authenticatedIdentity?.cardFingerprint === actor.memberId &&
+      item.name === actor.name && item.client === actor.client) : undefined;
+    if (!participant) {
+      throw new TaskLeaseError('task_lease_authenticated_member_required',
+        'Task leases require an active authenticated room member.');
+    }
+    return participant;
+  }
+
+  private ttl(value?: number): number {
+    const ttl = value ?? DEFAULT_TASK_LEASE_TTL_MS;
+    if (!Number.isSafeInteger(ttl) || ttl <= 0 || ttl > MAX_TASK_LEASE_TTL_MS) {
+      throw new TaskLeaseError('task_lease_ttl_invalid', 'Task lease TTL must be between 1 ms and 24 hours.');
+    }
+    return ttl;
+  }
+
+  private expired(task: Task, at: number, makeEventId: () => string, actor: LeaseActor): {
+    task: Task;
+    events: LeaseEventInput[];
+  } {
+    if (!task.lease || task.lease.status !== 'active' || task.lease.expiresAt > at) {
+      return { task, events: [] };
+    }
+    const lease: TaskLease = { ...task.lease, status: 'expired', releasedAt: at, handoff: undefined };
+    return {
+      task: { ...task, lease, updatedAt: at },
+      events: [this.event(makeEventId(), task.id, lease, 'expired', actor, at)],
+    };
+  }
+
+  private event(
+    id: string,
+    taskId: string,
+    lease: TaskLease,
+    event: LeaseEventInput['event'],
+    actor: LeaseActor,
+    at: number,
+    details: Record<string, unknown> = {},
+  ): LeaseEventInput {
+    return {
+      id, roomCode: '', event, actor: actor.memberId, leaseId: lease.id, at,
+      details: { taskId, actorName: actor.name, holderId: lease.holderId, holderName: lease.holderName, ...details },
+    };
+  }
+
+  private async mutate(
+    code: string,
+    taskId: string,
+    actor: LeaseActor,
+    operation: (task: Task, at: number, makeEventId: () => string) =>
+      { task: Task; events: LeaseEventInput[] } | Promise<{ task: Task; events: LeaseEventInput[] }>,
+  ): Promise<{ board: TaskBoard; task: Task }> {
+    const operationId = this.newId();
+    const ids: string[] = [];
+    let idIndex = 0;
+    const makeEventId = () => {
+      const index = idIndex++;
+      return ids[index] ?? (ids[index] = `lease-event-${operationId}-${String(index).padStart(2, '0')}`);
+    };
+    for (let attempt = 0; attempt < 8; attempt++) {
+      idIndex = 0;
+      const room = await this.records.getRoom(code);
+      this.authenticatedActor(room, actor);
+      const board = await this.records.getTaskBoard(code);
+      if (!board) throw new TaskLeaseError('task_board_not_found', 'Task board was not found.');
+      const at = this.now();
+      const swept = this.expired(taskAt(board, taskId), at, makeEventId, actor);
+      let result: { task: Task; events: LeaseEventInput[]; members?: LeaseActor[] };
+      try {
+        result = await operation(swept.task, at, makeEventId);
+      } catch (error) {
+        if (swept.events.length === 0) throw error;
+        const expiredBoard = withTask(board, swept.task, at);
+        const expiryEvents = swept.events.map(event => ({ ...event, roomCode: code }));
+        if (await this.records.updateTaskBoardWithLeaseEvents(
+          code, board.version, expiredBoard, expiryEvents,
+          { roomVersion: room!.version, members: [actor] },
+        )) throw error;
+        continue;
+      }
+      const next = withTask(board, result.task, at);
+      const events = [...swept.events, ...result.events]
+        .map(event => ({ ...event, roomCode: code }));
+      if (await this.records.updateTaskBoardWithLeaseEvents(code, board.version, next, events,
+        { roomVersion: room!.version, members: [actor, ...(result.members ?? [])] })) {
+        return { board: next, task: result.task };
+      }
+    }
+    throw new TaskLeaseError('task_lease_contention', 'Task lease could not be updated after concurrent changes.');
+  }
+
+  claim(code: string, taskId: string, actor: LeaseActor, ttlMs?: number) {
+    const ttl = this.ttl(ttlMs);
+    const leaseId = `task-lease-${this.newId()}`;
+    return this.mutate(code, taskId, actor, (task, at, eventId) => {
+      if (task.lease?.status === 'active') {
+        throw new TaskLeaseError('task_lease_held', `Task lease is held by ${task.lease.holderName}.`);
+      }
+      const lease: TaskLease = {
+        id: leaseId, holderId: actor.memberId, holderName: actor.name, holderClient: actor.client,
+        status: 'active', grantedAt: at, expiresAt: at + ttl,
+      };
+      return {
+        task: { ...task, lease, updatedAt: at },
+        events: [this.event(eventId(), taskId, lease, 'granted', actor, at)],
+      };
+    });
+  }
+
+  renew(code: string, taskId: string, actor: LeaseActor, ttlMs?: number) {
+    const ttl = this.ttl(ttlMs);
+    return this.mutate(code, taskId, actor, (task, at, eventId) => {
+      const lease = task.lease;
+      if (!lease || lease.status !== 'active' || lease.holderId !== actor.memberId) {
+        throw new TaskLeaseError('task_lease_holder_required', 'Only the active lease holder may renew.');
+      }
+      const renewed: TaskLease = { ...lease, renewedAt: at, expiresAt: at + ttl };
+      return { task: { ...task, lease: renewed, updatedAt: at },
+        events: [this.event(eventId(), taskId, renewed, 'renewed', actor, at)] };
+    });
+  }
+
+  release(code: string, taskId: string, actor: LeaseActor) {
+    return this.mutate(code, taskId, actor, (task, at, eventId) => {
+      const lease = task.lease;
+      if (!lease || lease.status !== 'active' || lease.holderId !== actor.memberId) {
+        throw new TaskLeaseError('task_lease_holder_required', 'Only the active lease holder may release.');
+      }
+      const released: TaskLease = { ...lease, status: 'released', releasedAt: at, handoff: undefined };
+      return { task: { ...task, lease: released, updatedAt: at },
+        events: [this.event(eventId(), taskId, released, 'released', actor, at)] };
+    });
+  }
+
+  requestHandoff(code: string, taskId: string, actor: LeaseActor) {
+    return this.mutate(code, taskId, actor, (task, at, eventId) => {
+      const lease = task.lease;
+      if (!lease || lease.status !== 'active') {
+        throw new TaskLeaseError('task_lease_not_active', 'Task has no active lease holder.');
+      }
+      if (lease.holderId === actor.memberId) {
+        throw new TaskLeaseError('task_lease_handoff_self', 'The holder cannot request a handoff from itself.');
+      }
+      const requested: TaskLease = { ...lease, handoff: {
+        requestedById: actor.memberId, requestedByName: actor.name,
+        requestedByClient: actor.client, requestedAt: at,
+      } };
+      return { task: { ...task, lease: requested, updatedAt: at },
+        events: [this.event(eventId(), taskId, requested, 'handoff_requested', actor, at,
+          { routedTo: lease.holderId })] };
+    });
+  }
+
+  grantHandoff(code: string, taskId: string, actor: LeaseActor, ttlMs?: number) {
+    const ttl = this.ttl(ttlMs);
+    return this.mutate(code, taskId, actor, async (task, at, eventId) => {
+      const lease = task.lease;
+      if (!lease || lease.status !== 'active' || lease.holderId !== actor.memberId) {
+        throw new TaskLeaseError('task_lease_holder_required', 'Only the active holder may grant a handoff.');
+      }
+      if (!lease.handoff) throw new TaskLeaseError('task_lease_handoff_missing', 'No handoff is pending.');
+      try {
+        const recipient = {
+          memberId: lease.handoff.requestedById,
+          name: lease.handoff.requestedByName,
+          client: lease.handoff.requestedByClient,
+        };
+        this.authenticatedActor(await this.records.getRoom(code), recipient);
+      } catch (error) {
+        await this.records.appendReceipt({
+          id: `handoff-refusal-${eventId()}`,
+          roomCode: code,
+          kind: 'receipt',
+          createdAt: at,
+          payload: {
+            disposition: 'refused',
+            reason: 'task_lease_authenticated_member_required',
+            taskId,
+            requestedById: lease.handoff.requestedById,
+            holderId: actor.memberId,
+          },
+        });
+        throw error;
+      }
+      const transferred: TaskLease = {
+        ...lease,
+        holderId: lease.handoff.requestedById,
+        holderName: lease.handoff.requestedByName,
+        holderClient: lease.handoff.requestedByClient,
+        grantedAt: at,
+        expiresAt: at + ttl,
+        renewedAt: undefined,
+        releasedAt: undefined,
+        handoff: undefined,
+      };
+      return { task: { ...task, lease: transferred, updatedAt: at }, members: [{
+          memberId: transferred.holderId, name: transferred.holderName, client: transferred.holderClient,
+        }],
+        events: [this.event(eventId(), taskId, transferred, 'granted', actor, at,
+          { transferredFrom: actor.memberId })] };
+    });
+  }
+
+  submit(code: string, taskId: string, actor: LeaseActor, evidence: EvidenceInput) {
+    if (!evidence.fileListing.trim() || !evidence.fileExcerpt.trim() ||
+      !evidence.runOutput.trim() || !Number.isInteger(evidence.exitCode)) {
+      throw new TaskLeaseError('task_evidence_invalid', 'Task evidence must contain all proof fields and an exit code.');
+    }
+    return this.mutate(code, taskId, actor, (task, at) => {
+      const lease = task.lease;
+      if (lease && (lease.status !== 'active' || lease.holderId !== actor.memberId)) {
+        throw new TaskLeaseError('task_lease_holder_required',
+          'Only the active lease holder may submit changes to this task.');
+      }
+      const submitted: Task = { ...task, state: 'awaiting_review', updatedAt: at,
+        evidence: { ...evidence, submittedBy: actor.name, submittedClient: actor.client, at } };
+      return { task: submitted, events: [] };
+    });
+  }
+}

--- a/packages/room-persistence/src/types.ts
+++ b/packages/room-persistence/src/types.ts
@@ -28,6 +28,15 @@ export interface LeaseEventInput {
   details?: Readonly<Record<string, unknown>>;
 }
 
+export interface LeaseMembershipPrecondition {
+  roomVersion: number;
+  members: readonly {
+    memberId: string;
+    name: string;
+    client: string;
+  }[];
+}
+
 export interface RoomPersistence {
   readonly kind: PersistenceKind;
 
@@ -43,6 +52,13 @@ export interface RoomPersistence {
     code: string,
     expectedVersion: number | null,
     next: TaskBoard,
+  ): Promise<boolean>;
+  compareAndSwapTaskBoardWithLeaseEvents(
+    code: string,
+    expectedVersion: number | null,
+    next: TaskBoard,
+    events: readonly LeaseEventInput[],
+    membership?: LeaseMembershipPrecondition,
   ): Promise<boolean>;
 
   putMinutes(code: string, reportId: string, report: RoomReport): Promise<void>;

--- a/packages/room-persistence/test/member-auth.test.ts
+++ b/packages/room-persistence/test/member-auth.test.ts
@@ -50,6 +50,7 @@ class MemoryPersistence implements RoomPersistence {
   async listMessages() { return []; }
   async getTaskBoard() { return null; }
   async compareAndSwapTaskBoard() { return false; }
+  async compareAndSwapTaskBoardWithLeaseEvents() { return false; }
   async putMinutes() {}
   async getMinutes() { return null; }
   async appendReceipt() { return false; }

--- a/packages/room-persistence/test/postgres.integration.test.ts
+++ b/packages/room-persistence/test/postgres.integration.test.ts
@@ -7,6 +7,7 @@ import { PostgresRoomPersistence } from '../src/postgres.js';
 import { PersistenceSchemaError, type RoomReceipt } from '../src/types.js';
 import { proveImmutableRecordParity } from './parity-contract.js';
 import { AgentCardVerifier, AuthenticatedRoomJoinServer, signAgentCard } from '../src/member-auth.js';
+import { TaskLeaseServer } from '../src/task-leases.js';
 
 const databaseUrl = process.env.TEST_POSTGRES_URL;
 const describePostgres = databaseUrl ? describe : describe.skip;
@@ -179,4 +180,108 @@ describePostgres('Postgres durable room production entry', () => {
       await restarted.close();
     }
   });
+
+  it('atomically persists a task lease and its ledger event across restart', async () => {
+    vi.useRealTimers();
+    const server = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    const actor = { memberId: 'fingerprint-lease-ci-a', name: 'Lease Agent A', client: 'cc' as const };
+    const contender = { memberId: 'fingerprint-lease-ci-b', name: 'Lease Agent B', client: 'cc' as const };
+    const participant = (member: typeof actor) => ({
+      name: member.name, initials: 'LA', color: '#789', role: 'builder', client: member.client,
+      joinedAt: 1, lastSeenAt: 1,
+      authenticatedIdentity: {
+        cardFingerprint: member.memberId, fleetId: 'fleet-ci', cardName: member.name,
+        scheme: 'oauth2' as const, keyId: 'key-ci', verifiedAt: 1,
+      },
+    });
+    const durableRoom: Room = {
+      ...room(), code: 'PGS-TSK-LES', version: 1,
+      participants: [participant(actor), participant(contender)],
+    };
+    const durableBoard: TaskBoard = { code: durableRoom.code, version: 1, tasks: [{
+      id: 'T-CI', title: 'Lease persistence', state: 'in_progress', createdBy: 'Host', createdAt: 1, updatedAt: 1,
+    }] };
+    await server.createRoom(durableRoom);
+    expect(await server.updateTaskBoard(durableRoom.code, null, durableBoard)).toBe(true);
+    const leases = new TaskLeaseServer(server, () => 100);
+    const race = await Promise.allSettled([
+      leases.claim(durableRoom.code, 'T-CI', actor),
+      leases.claim(durableRoom.code, 'T-CI', contender),
+    ]);
+    expect(race.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(race.filter(result => result.status === 'rejected')).toHaveLength(1);
+    const winner = race.find(result => result.status === 'fulfilled');
+    const winnerId = winner?.status === 'fulfilled' ? winner.value.task.lease?.holderId : undefined;
+    await server.close();
+
+    const restarted = await RoomRecordServer.fromEnvironment({
+      AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+    });
+    try {
+      expect((await restarted.getTaskBoard(durableRoom.code))?.tasks[0]?.lease)
+        .toMatchObject({ holderId: winnerId, status: 'active' });
+      expect((await restarted.listReceipts(durableRoom.code)).map(item => item.leaseEvent))
+        .toEqual(['granted']);
+    } finally {
+      await restarted.close();
+    }
+  });
+
+  it.each(['claim', 'handoff grant'] as const)(
+    'keeps Postgres %s membership atomic when the member leaves at commit', async operation => {
+      vi.useRealTimers();
+      const server = await RoomRecordServer.fromEnvironment({
+        AGENT_ROOM_PERSISTENCE: 'postgres', DATABASE_URL: databaseUrl,
+      });
+      const alice = { memberId: `pg-${operation}-alice`, name: 'Atomic Alice', client: 'cc' as const };
+      const bob = { memberId: `pg-${operation}-bob`, name: 'Atomic Bob', client: 'cc' as const };
+      const participant = (member: typeof alice) => ({
+        name: member.name, initials: 'AT', color: '#789', role: 'builder', client: member.client,
+        joinedAt: 1, lastSeenAt: 1, authenticatedIdentity: {
+          cardFingerprint: member.memberId, fleetId: 'fleet-ci', cardName: member.name,
+          scheme: 'oauth2' as const, keyId: 'key-ci', verifiedAt: 1,
+        },
+      });
+      const code = operation === 'claim' ? 'PGS-ATM-CLM' : 'PGS-ATM-HOF';
+      const durableRoom: Room = { ...room(), code, version: 1,
+        participants: [participant(alice), participant(bob)] };
+      const durableBoard: TaskBoard = { code, version: 1, tasks: [{
+        id: 'T-ATOMIC', title: 'Atomic membership', state: 'in_progress',
+        createdBy: 'Host', createdAt: 1, updatedAt: 1,
+      }] };
+      await server.createRoom(durableRoom);
+      expect(await server.updateTaskBoard(code, null, durableBoard)).toBe(true);
+      let nextId = 0;
+      const leases = new TaskLeaseServer(server, () => 100, () => `id-${operation}-${++nextId}`);
+      if (operation === 'handoff grant') {
+        await leases.claim(code, 'T-ATOMIC', alice);
+        await leases.requestHandoff(code, 'T-ATOMIC', bob);
+      }
+      const original = server.persistence.compareAndSwapTaskBoardWithLeaseEvents.bind(server.persistence);
+      let armed = true;
+      server.persistence.compareAndSwapTaskBoardWithLeaseEvents = async (...args) => {
+        if (armed) {
+          armed = false;
+          const current = (await server.getRoom(code))!;
+          const leaving = operation === 'claim' ? alice.name : bob.name;
+          expect(await server.updateRoom(code, current.version, { ...current, version: current.version + 1,
+            participants: current.participants.filter(item => item.name !== leaving) })).toBe(true);
+        }
+        return original(...args);
+      };
+      try {
+        await expect(operation === 'claim'
+          ? leases.claim(code, 'T-ATOMIC', alice)
+          : leases.grantHandoff(code, 'T-ATOMIC', alice))
+          .rejects.toMatchObject({ name: 'task_lease_authenticated_member_required' });
+        const saved = await server.getTaskBoard(code);
+        expect(saved?.tasks[0]?.lease?.holderId)
+          .not.toBe(operation === 'claim' ? alice.memberId : bob.memberId);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });

--- a/packages/room-persistence/test/redis.test.ts
+++ b/packages/room-persistence/test/redis.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { ROOM_TTL_SECONDS, type Message, type Room, type RoomReport } from '@agent-room/shared';
+import { ROOM_TTL_SECONDS, type Message, type Room, type RoomReport, type TaskBoard } from '@agent-room/shared';
 import type { UpstashClient } from '@agent-room/upstash-client';
 import { RoomRecordServer } from '../src/server.js';
 import { RedisRoomPersistence } from '../src/redis.js';
+import { TaskLeaseServer, type LeaseActor } from '../src/task-leases.js';
 import type { RoomReceipt } from '../src/types.js';
 import { proveImmutableRecordParity } from './parity-contract.js';
 
@@ -20,6 +21,7 @@ class RecordingRedis implements UpstashClient {
     }
     if (name === 'GET') return (this.values.get(String(key)) ?? null) as T;
     if (name === 'LRANGE') return [] as T;
+    if (name === 'EVAL') return 1 as T;
     throw new Error(`Unsupported fake command ${String(name)}`);
   }
 
@@ -115,6 +117,59 @@ class StatefulRedis implements UpstashClient {
   }
 }
 
+class LeaseCasRedis implements UpstashClient {
+  readonly values = new Map<string, string>();
+  removeParticipant(code: string, name: string): void {
+    const key = `room:${code}`;
+    const current = JSON.parse(this.values.get(key)!) as Room;
+    this.values.set(key, JSON.stringify({ ...current, version: current.version + 1,
+      participants: current.participants.filter(item => item.name !== name) }));
+  }
+  async command<T>(command: readonly (string | number)[]): Promise<T> {
+    const [name] = command;
+    if (name === 'SET') { this.values.set(String(command[1]), String(command[2])); return 'OK' as T; }
+    if (name === 'GET') return (this.values.get(String(command[1])) ?? null) as T;
+    if (name === 'LRANGE') return [] as T;
+    if (name === 'EVAL') {
+      const script = String(command[1]);
+      if (script.includes('Receipt id collision')) return 1 as T;
+      if (!script.includes('lease event id collision')) throw new Error('unexpected script');
+      const boardKey = String(command[3]);
+      const roomKey = String(command[6]);
+      const current = JSON.parse(this.values.get(boardKey)!) as TaskBoard;
+      if (current.version !== Number(command[8])) return 0 as T;
+      if (script.includes('required_members')) {
+        const activeRoom = JSON.parse(this.values.get(roomKey)!) as Room;
+        const required = JSON.parse(String(command[13])) as Array<{ memberId: string; name: string; client: string }>;
+        if (activeRoom.version !== Number(command[12]) || required.some(member =>
+          !activeRoom.participants.some(item => item.authenticatedIdentity?.cardFingerprint === member.memberId &&
+            item.name === member.name && item.client === member.client))) return 0 as T;
+      }
+      this.values.set(boardKey, String(command[9]));
+      return 1 as T;
+    }
+    throw new Error(`Unsupported lease Redis command ${String(name)}`);
+  }
+  async pipeline<T>(): Promise<T[]> { return []; }
+}
+
+const leaseAlice: LeaseActor = { memberId: 'redis-alice', name: 'Alice', client: 'cc' };
+const leaseBob: LeaseActor = { memberId: 'redis-bob', name: 'Bob', client: 'cc' };
+
+function leaseRoom(): Room {
+  const participant = (actor: LeaseActor) => ({
+    name: actor.name, role: 'builder', color: '#123', initials: actor.name.slice(0, 2), client: actor.client,
+    joinedAt: 1, lastSeenAt: 1, authenticatedIdentity: { cardFingerprint: actor.memberId,
+      fleetId: 'fleet', cardName: actor.name, scheme: 'oauth2' as const, keyId: 'key', verifiedAt: 1 },
+  });
+  return { ...room(), version: 1, participants: [participant(leaseAlice), participant(leaseBob)] };
+}
+
+function leaseBoard(): TaskBoard {
+  return { code: room().code, version: 1, tasks: [{ id: 'T-REDIS', title: 'Redis race',
+    state: 'in_progress', createdBy: 'Host', createdAt: 1, updatedAt: 1 }] };
+}
+
 function room(): Room {
   return {
     code: 'ABC-DEF-GHJ', topic: 'Synthetic room', createdAt: 1_700_000_000_000,
@@ -193,5 +248,51 @@ describe('RedisRoomPersistence compatibility', () => {
   it('matches the durable adapter collision contract for minutes and receipts', async () => {
     const store = new RedisRoomPersistence(new StatefulRedis());
     await proveImmutableRecordParity(store, room(), report(), receipt());
+  });
+
+  it('sends the board transition and lease receipts through one Redis script', async () => {
+    const redis = new RecordingRedis();
+    const store = new RedisRoomPersistence(redis);
+    const next = { code: room().code, version: 2, tasks: [] };
+    expect(await store.compareAndSwapTaskBoardWithLeaseEvents(room().code, 1, next, [{
+      id: 'lease-event-1', roomCode: room().code, event: 'granted', actor: 'fingerprint',
+      leaseId: 'task-lease-1', at: 10, details: { taskId: 'T-01' },
+    }])).toBe(true);
+
+    const command = redis.commands.at(-1)!;
+    expect(command.slice(0, 7)).toEqual([
+      'EVAL', expect.any(String), '4', `task-board:${room().code}`,
+      `room-receipt-ids:${room().code}`, `room-receipts:${room().code}`, `room:${room().code}`,
+    ]);
+    expect(command.join(' ')).toContain('lease-event-1');
+    expect(command.join(' ')).toContain('"leaseEvent":"granted"');
+  });
+
+  it.each([
+    ['claim', leaseAlice.name],
+    ['handoff grant', leaseBob.name],
+  ] as const)('keeps Redis %s membership atomic when the member leaves at commit', async (_label, leaving) => {
+    const redis = new LeaseCasRedis();
+    const store = new RedisRoomPersistence(redis);
+    await store.createRoom(leaseRoom());
+    redis.values.set(`task-board:${room().code}`, JSON.stringify(leaseBoard()));
+    const original = store.compareAndSwapTaskBoardWithLeaseEvents.bind(store);
+    let armed = _label === 'claim';
+    store.compareAndSwapTaskBoardWithLeaseEvents = async (...args) => {
+      if (armed) { armed = false; redis.removeParticipant(room().code, leaving); }
+      return original(...args);
+    };
+    const leases = new TaskLeaseServer(new RoomRecordServer(store), () => 100, () => 'id');
+    if (_label === 'handoff grant') {
+      await leases.claim(room().code, 'T-REDIS', leaseAlice);
+      await leases.requestHandoff(room().code, 'T-REDIS', leaseBob);
+      armed = true;
+    }
+    await expect(_label === 'claim'
+      ? leases.claim(room().code, 'T-REDIS', leaseAlice)
+      : leases.grantHandoff(room().code, 'T-REDIS', leaseAlice))
+      .rejects.toMatchObject({ name: 'task_lease_authenticated_member_required' });
+    expect((await store.getTaskBoard(room().code))?.tasks[0]?.lease?.holderId)
+      .not.toBe(leaving === leaseAlice.name ? leaseAlice.memberId : leaseBob.memberId);
   });
 });

--- a/packages/room-persistence/test/task-leases.test.ts
+++ b/packages/room-persistence/test/task-leases.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import type { Message, Room, RoomReport, TaskBoard } from '@agent-room/shared';
+import { RoomRecordServer } from '../src/server.js';
+import { TaskLeaseServer, type LeaseActor } from '../src/task-leases.js';
+import type { LeaseEventInput, LeaseMembershipPrecondition, RoomPersistence, RoomReceipt } from '../src/types.js';
+
+const alice: LeaseActor = { memberId: 'fingerprint-alice', name: 'Alice', client: 'cc' };
+const bob: LeaseActor = { memberId: 'fingerprint-bob', name: 'Bob', client: 'cc' };
+
+function room(): Room {
+  const participant = (actor: LeaseActor) => ({
+    name: actor.name, role: 'builder', color: '#123456', initials: actor.name.slice(0, 2).toUpperCase(),
+    client: actor.client, joinedAt: 1, lastSeenAt: 1,
+    authenticatedIdentity: {
+      cardFingerprint: actor.memberId, fleetId: 'fleet', cardName: actor.name,
+      scheme: 'oauth2' as const, keyId: 'key', verifiedAt: 1,
+    },
+  });
+  return { code: 'LES-TST-001', topic: 'Synthetic', createdAt: 1, createdBy: 'Host',
+    status: 'active', version: 1, participants: [participant(alice), participant(bob)] };
+}
+
+function board(): TaskBoard {
+  return { code: room().code, version: 1, tasks: [{
+    id: 'T-01', title: 'Synthetic task', state: 'in_progress', createdBy: 'Host', createdAt: 1, updatedAt: 1,
+  }] };
+}
+
+class LeaseMemoryPersistence implements RoomPersistence {
+  readonly kind = 'postgres' as const;
+  currentRoom = room();
+  currentBoard = board();
+  receipts: RoomReceipt[] = [];
+  boardWrites = 0;
+  beforeLeaseCas?: () => void;
+  async createRoom(value: Room) { this.currentRoom = structuredClone(value); }
+  async getRoom(code: string) { return code === this.currentRoom.code ? structuredClone(this.currentRoom) : null; }
+  async compareAndSwapRoom() { return false; }
+  async appendMessage(_code: string, _message: Message) { return 0; }
+  async listMessages() { return []; }
+  async getTaskBoard(code: string) { return code === this.currentBoard.code ? structuredClone(this.currentBoard) : null; }
+  async compareAndSwapTaskBoard(_code: string, expected: number | null, next: TaskBoard) {
+    if (expected !== this.currentBoard.version) return false;
+    this.currentBoard = structuredClone(next); this.boardWrites++; return true;
+  }
+  async compareAndSwapTaskBoardWithLeaseEvents(
+    _code: string, expected: number | null, next: TaskBoard, events: readonly LeaseEventInput[],
+    membership?: LeaseMembershipPrecondition,
+  ) {
+    await Promise.resolve();
+    this.beforeLeaseCas?.();
+    this.beforeLeaseCas = undefined;
+    if (expected !== this.currentBoard.version) return false;
+    if (membership && (membership.roomVersion !== this.currentRoom.version ||
+      membership.members.some(required => !this.currentRoom.participants.some(participant =>
+        participant.authenticatedIdentity?.cardFingerprint === required.memberId &&
+        participant.name === required.name && participant.client === required.client)))) return false;
+    this.currentBoard = structuredClone(next);
+    this.receipts.push(...events.map(event => ({
+      id: event.id, roomCode: event.roomCode, kind: 'lease_event' as const,
+      createdAt: event.at, leaseEvent: event.event,
+      payload: { actor: event.actor, leaseId: event.leaseId, ...(event.details ?? {}) },
+    })));
+    this.boardWrites++;
+    return true;
+  }
+  async getTaskBoardUnused() { return null; }
+  async putMinutes(_code: string, _reportId: string, _report: RoomReport) {}
+  async getMinutes() { return null; }
+  async appendReceipt(receipt: RoomReceipt) { this.receipts.push(receipt); return true; }
+  async appendLeaseEvent() { return true; }
+  async listReceipts() { return structuredClone(this.receipts); }
+  async close() {}
+}
+
+function service(store: LeaseMemoryPersistence, clock: { now: number }) {
+  let id = 0;
+  return new TaskLeaseServer(new RoomRecordServer(store), () => clock.now, () => String(++id));
+}
+
+const evidence = { fileListing: 'file', fileExcerpt: 'excerpt', runOutput: 'green', exitCode: 0 };
+
+describe('task lease production entry', () => {
+  it('atomically grants exactly one of two concurrent claims', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    const results = await Promise.allSettled([
+      leases.claim(room().code, 'T-01', alice),
+      leases.claim(room().code, 'T-01', bob),
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(store.currentBoard.tasks[0]?.lease?.status).toBe('active');
+    expect(store.receipts.map(item => item.leaseEvent)).toEqual(['granted']);
+  });
+
+  it('refuses a non-holder submission by name without changing the board', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice);
+    const before = structuredClone(store.currentBoard);
+
+    await expect(leases.submit(room().code, 'T-01', bob, evidence))
+      .rejects.toMatchObject({ name: 'task_lease_holder_required' });
+    expect(store.currentBoard).toEqual(before);
+    const submitted = await leases.submit(room().code, 'T-01', alice, evidence);
+    expect(submitted.task).toMatchObject({ state: 'awaiting_review', evidence: { submittedBy: 'Alice' } });
+  });
+
+  it('lets only the holder renew and release, extending from server time and freeing the task', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice, 50);
+    clock.now = 120;
+    const renewed = await leases.renew(room().code, 'T-01', alice, 80);
+    expect(renewed.task.lease?.expiresAt).toBe(200);
+    await expect(leases.release(room().code, 'T-01', bob))
+      .rejects.toMatchObject({ name: 'task_lease_holder_required' });
+    const released = await leases.release(room().code, 'T-01', alice);
+    expect(released.task.lease?.status).toBe('released');
+    expect(store.receipts.map(item => item.leaseEvent)).toEqual(['granted', 'renewed', 'released']);
+  });
+
+  it('sweeps expiry before claim and records expiry before the replacement grant', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice, 10);
+    clock.now = 111;
+    const claimed = await leases.claim(room().code, 'T-01', bob);
+
+    expect(claimed.task.lease?.holderId).toBe(bob.memberId);
+    expect(store.receipts.map(item => item.leaseEvent)).toEqual(['granted', 'expired', 'granted']);
+  });
+
+  it('routes a handoff to the holder and transfers its grant atomically with ordered ledger events', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice);
+    clock.now = 110;
+    const requested = await leases.requestHandoff(room().code, 'T-01', bob);
+    expect(requested.task.lease?.handoff).toMatchObject({ requestedById: bob.memberId });
+    clock.now = 120;
+    const transferred = await leases.grantHandoff(room().code, 'T-01', alice);
+
+    expect(transferred.task.lease).toMatchObject({ holderId: bob.memberId, status: 'active' });
+    expect(transferred.task.lease?.handoff).toBeUndefined();
+    expect(store.receipts.map(item => item.leaseEvent)).toEqual(['granted', 'handoff_requested', 'granted']);
+    expect(store.receipts[1]?.payload).toMatchObject({ routedTo: alice.memberId });
+  });
+
+  it('refuses a handoff grant when its recipient is no longer an active authenticated member', async () => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice);
+    await leases.requestHandoff(room().code, 'T-01', bob);
+    const before = structuredClone(store.currentBoard);
+    store.currentRoom = { ...store.currentRoom,
+      participants: store.currentRoom.participants.filter(item => item.name !== bob.name) };
+
+    await expect(leases.grantHandoff(room().code, 'T-01', alice))
+      .rejects.toMatchObject({ name: 'task_lease_authenticated_member_required' });
+    expect(store.currentBoard).toEqual(before);
+    expect(store.receipts.at(-1)).toMatchObject({
+      kind: 'receipt',
+      payload: {
+        disposition: 'refused',
+        reason: 'task_lease_authenticated_member_required',
+        requestedById: bob.memberId,
+      },
+    });
+  });
+
+  it('refuses a claim when the actor leaves between authentication and the atomic board commit', async () => {
+    const store = new LeaseMemoryPersistence();
+    const leases = service(store, { now: 100 });
+    store.beforeLeaseCas = () => {
+      store.currentRoom = { ...store.currentRoom, version: store.currentRoom.version + 1,
+        participants: store.currentRoom.participants.filter(item => item.name !== alice.name) };
+    };
+
+    await expect(leases.claim(room().code, 'T-01', alice))
+      .rejects.toMatchObject({ name: 'task_lease_authenticated_member_required' });
+    expect(store.currentBoard.tasks[0]?.lease).toBeUndefined();
+    expect(store.receipts).toEqual([]);
+  });
+
+  it('refuses a handoff grant when the recipient leaves between revalidation and the atomic board commit', async () => {
+    const store = new LeaseMemoryPersistence();
+    const leases = service(store, { now: 100 });
+    await leases.claim(room().code, 'T-01', alice);
+    await leases.requestHandoff(room().code, 'T-01', bob);
+    const before = structuredClone(store.currentBoard);
+    store.beforeLeaseCas = () => {
+      store.currentRoom = { ...store.currentRoom, version: store.currentRoom.version + 1,
+        participants: store.currentRoom.participants.filter(item => item.name !== bob.name) };
+    };
+
+    await expect(leases.grantHandoff(room().code, 'T-01', alice))
+      .rejects.toMatchObject({ name: 'task_lease_authenticated_member_required' });
+    expect(store.currentBoard).toEqual(before);
+    expect(store.currentBoard.tasks[0]?.lease?.holderId).toBe(alice.memberId);
+  });
+
+  it.each([
+    ['renew', (leases: TaskLeaseServer) => leases.renew(room().code, 'T-01', alice),
+      'task_lease_holder_required'],
+    ['release', (leases: TaskLeaseServer) => leases.release(room().code, 'T-01', alice),
+      'task_lease_holder_required'],
+    ['requestHandoff', (leases: TaskLeaseServer) => leases.requestHandoff(room().code, 'T-01', bob),
+      'task_lease_not_active'],
+    ['submit', (leases: TaskLeaseServer) => leases.submit(room().code, 'T-01', alice, evidence),
+      'task_lease_holder_required'],
+  ] as const)('persists lazy expiry before a rejected %s operation', async (_name, operate, errorName) => {
+    const store = new LeaseMemoryPersistence();
+    const clock = { now: 100 };
+    const leases = service(store, clock);
+    await leases.claim(room().code, 'T-01', alice, 10);
+    clock.now = 111;
+
+    await expect(operate(leases)).rejects.toMatchObject({ name: errorName });
+    expect(store.currentBoard.tasks[0]?.lease?.status).toBe('expired');
+    expect(store.receipts.map(item => item.leaseEvent)).toEqual(['granted', 'expired']);
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -385,6 +385,28 @@ export interface TaskRoleChange {
   to?: string;           // new holder's display name
 }
 
+export type TaskLeaseStatus = 'active' | 'released' | 'expired';
+
+export interface TaskLeaseHandoffRequest {
+  requestedById: string;
+  requestedByName: string;
+  requestedByClient: ClientKind;
+  requestedAt: number;
+}
+
+export interface TaskLease {
+  id: string;
+  holderId: string;
+  holderName: string;
+  holderClient: ClientKind;
+  status: TaskLeaseStatus;
+  grantedAt: number;
+  expiresAt: number;
+  renewedAt?: number;
+  releasedAt?: number;
+  handoff?: TaskLeaseHandoffRequest;
+}
+
 export interface Task {
   id: string;            // short human id, e.g. "T-01"
   title: string;
@@ -410,6 +432,9 @@ export interface Task {
   // hatch). Optional + append-only, so boards created before this field
   // existed keep working unchanged.
   roleHistory?: TaskRoleChange[];
+  // Server-enforced exclusive turn on this task. Historical terminal leases
+  // remain attached until a later claim replaces them.
+  lease?: TaskLease;
   createdBy: string;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Stack

Depends on #43, #44, and #45. Review the final commit as the turn-lease layer; dependency commits remain visible because GitHub cannot use contributor-fork branches as base branches in this repository.

## Summary

- add one-holder task turn leases over the durable task board
- persist every grant, renewal, release, expiry, and handoff as an append-only receipt
- enforce authenticated membership inside the same Redis/Postgres compare-and-swap as the lease update
- preserve lazy expiry even when the triggering operation is rejected
- cover claim and handoff leave-at-commit races through both production adapters

## Provenance

Forward-port source: `noogalabs/agent-room` PR #6, merged as `a0f53376ae8dbe0888d546ab477626d83b32c8d9`.

No organization data, deployment, credentials, or live service action is included.
