### PR TITLE
feat(upstash-client): port seven protocol functions from commercial

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -336,8 +336,10 @@ export type TaskState =
   | 'todo'             // created, nobody working it yet
   | 'in_progress'      // a producer claimed it
   | 'awaiting_review'  // producer submitted evidence; verifier must rule
+  | 'blocked'          // owner/host declared it stuck — see Task.blocked; open work
   | 'done'             // verifier confirmed the evidence
-  | 'rejected';        // verifier rejected; back to the producer
+  | 'rejected'         // verifier rejected; back to the producer
+  | 'cancelled';       // participant archived it; terminal, visible history only
 
 // The three-part proof a producer must attach to move a task to
 // 'awaiting_review'. All three text fields must be non-empty.
@@ -357,6 +359,28 @@ export interface TaskVerdict {
   by: string;            // verifier display name
   byClient: ClientKind;
   at: number;            // epoch ms
+}
+
+// Archive record written when a task is moved to 'cancelled'. Cancelling is
+// deliberately NOT a verdict: it says the task should never have been open,
+// not that it was judged. Only tasks without submitted evidence can be
+// cancelled (see cancelTask), so this never destroys a delivery record.
+export interface TaskCancellation {
+  by: string;
+  byClient: ClientKind;
+  at: number;            // epoch ms
+  reason?: string;
+}
+
+// Owner/host declaration that a task cannot proceed — missing deploy/access
+// rights, missing input files, or a spec still ambiguous after one
+// clarification. NOT a completion claim, so no verifier gate; the record is
+// kept (latest wins) even after a reopen, as history.
+export interface TaskBlock {
+  by: string;
+  byClient: ClientKind;
+  at: number;            // epoch ms
+  reason: string;        // what exactly is missing — required
 }
 
 // A lightweight checklist item under a Task. Subtasks are intentionally NOT
@@ -428,6 +452,8 @@ export interface Task {
   readinessNote?: string;
   evidence?: TaskEvidence; // latest submitted evidence (kept across rejects)
   verdict?: TaskVerdict;   // latest verifier ruling
+  cancellation?: TaskCancellation; // set when archived to 'cancelled'
+  blocked?: TaskBlock;     // latest block declaration (kept after reopen as history)
   // Audit trail of owner/verifier reassignments (host / moderator escape
   // hatch). Optional + append-only, so boards created before this field
   // existed keep working unchanged.

--- a/packages/upstash-client/src/messages.ts
+++ b/packages/upstash-client/src/messages.ts
@@ -396,3 +396,13 @@ export async function listMessages(
     return m;
   });
 }
+
+/**
+ * Status-ping body posted after a task submit in turn-taking rooms. Kept here
+ * (not at the call site) so every client emits the same recognisable prefix —
+ * the room UI and the minutes digest both key off `[STATUS]`.
+ */
+export function buildTaskSubmitStatusText(taskId: string, evidenceSummary: string): string {
+  const summary = evidenceSummary.trim().replace(/\s+/g, ' ').slice(0, 180);
+  return `[STATUS] 待审核 / awaiting_review ${taskId}: ${summary || '(no run output)'}`;
+}

--- a/packages/upstash-client/src/rooms.ts
+++ b/packages/upstash-client/src/rooms.ts
@@ -4,7 +4,7 @@ import type {
   ReplyMode,
   ReplyModeConfig,
 } from '@agent-room/shared';
-import { AVATAR_PALETTE, DEFAULT_TURN_TIMEOUTS_MS, ROOM_TTL_SECONDS } from '@agent-room/shared';
+import { AVATAR_PALETTE, DEFAULT_TURN_TIMEOUTS_MS, PRESENCE_DISCONNECTED_MS, ROOM_TTL_SECONDS } from '@agent-room/shared';
 import type { UpstashClient } from './client.js';
 import { RoomNotFoundError, ConcurrencyError } from './errors.js';
 
@@ -662,4 +662,20 @@ export async function setListenUntil(
       p.name === name ? { ...p, listenUntil: until, lastSeenAt: Date.now() } : p
     ),
   }));
+}
+
+/**
+ * Has this participant gone quiet long enough to count as disconnected?
+ *
+ * `listenUntil` is a lease an agent renews on every room_listen, so a seat
+ * holding a live lease is never stale even if lastSeenAt is momentarily old —
+ * the lease can only veto staleness, never assert it. Everything else falls
+ * back to the lastSeenAt clock, which is what actually decides abandonment.
+ */
+export function isParticipantStale(p: Participant, now: number = Date.now()): boolean {
+  if (typeof p.listenUntil === 'number' && Number.isFinite(p.listenUntil) && p.listenUntil >= now) {
+    return false;
+  }
+  const lastSeen = typeof p.lastSeenAt === 'number' && Number.isFinite(p.lastSeenAt) ? p.lastSeenAt : 0;
+  return now - lastSeen > PRESENCE_DISCONNECTED_MS;
 }

--- a/packages/upstash-client/src/tasks.ts
+++ b/packages/upstash-client/src/tasks.ts
@@ -413,6 +413,63 @@ export async function reassignTaskRoles(
   return { board, task: updated! };
 }
 
+// 'cancelled' is terminal: an archived task must be reopened (updateTask) before
+// new work can be submitted against it. Without this guard, cancelling a task and
+// then submitting evidence would silently resurrect it into awaiting_review.
+function assertNotCancelled(task: Task): void {
+  if (task.state === 'cancelled') {
+    throw new TaskStateError(
+      `Task ${task.id} is cancelled — reopen it before submitting new evidence.`,
+    );
+  }
+}
+
+/** True when a task has submitted work that must be preserved until reopen. */
+function taskHasSubmittedEvidence(task: Task): boolean {
+  return !!(task.evidence || task.readinessNote?.trim());
+}
+
+// Participant archive: move a task to terminal 'cancelled' (visible history,
+// not open work). Safe only for tasks without submitted evidence — todo and
+// in_progress duplicates can be archived; done and evidence-backed tasks stay
+// locked. Authorization is the caller's job (any joined participant / host).
+export async function cancelTask(
+  client: UpstashClient,
+  code: string,
+  id: string,
+  actor: { name: string; client: ClientKind },
+  reason?: string,
+  now: number = Date.now(),
+): Promise<{ board: TaskBoard; task: Task }> {
+  let updated: Task;
+  const board = await casTaskBoard(client, code, (current) => {
+    const task = findTask(current, id);
+    if (task.state === 'done') throw new TaskDoneImmutableError(id);
+    if (task.state === 'cancelled') {
+      throw new TaskStateError(`Task ${id} is already cancelled.`);
+    }
+    if (taskHasSubmittedEvidence(task)) {
+      throw new TaskStateError(
+        `Task ${id} has submitted evidence — reopen it to todo/in_progress before cancelling.`,
+      );
+    }
+    const cleanReason = reason?.trim();
+    updated = {
+      ...task,
+      state: 'cancelled',
+      cancellation: {
+        by: actor.name,
+        byClient: actor.client,
+        at: now,
+        ...(cleanReason ? { reason: cleanReason } : {}),
+      },
+      updatedAt: now,
+    };
+    return { ...replaceTask(current, updated), lastProgressAt: now };
+  });
+  return { board, task: updated! };
+}
+
 function assertEvidenceComplete(e: Partial<TaskEvidence>): void {
   if (!e.fileListing || !e.fileListing.trim()) throw new EvidenceIncompleteError('fileListing is empty');
   if (!e.fileExcerpt || !e.fileExcerpt.trim()) throw new EvidenceIncompleteError('fileExcerpt is empty');
@@ -438,6 +495,7 @@ export async function submitTask(
   let updated: Task;
   const board = await casTaskBoard(client, code, (current) => {
     const task = findTask(current, id);
+    assertNotCancelled(task);
     const fullEvidence: TaskEvidence = {
       fileListing: evidence.fileListing,
       fileExcerpt: evidence.fileExcerpt,
@@ -479,6 +537,7 @@ export async function submitForReview(
   let updated: Task;
   const board = await casTaskBoard(client, code, (current) => {
     const task = findTask(current, id);
+    assertNotCancelled(task);
     updated = {
       ...task,
       owner: task.owner ?? submitter.name,
@@ -580,6 +639,39 @@ export async function updateTask(
   return { board, task: updated! };
 }
 
+// Owner/host declares a task cannot proceed — missing deploy/access rights,
+// missing input files, or a spec still ambiguous after one clarification.
+// `blocked` stays OPEN work (it counts for end-room guards and shows on the
+// board), and it is NOT a completion claim, so there is no verifier gate.
+// Ownership enforcement lives at the marker/tool layer; reopen via updateTask
+// once the blocker is gone.
+export async function blockTask(
+  client: UpstashClient,
+  code: string,
+  id: string,
+  by: { name: string; client: ClientKind },
+  reason: string,
+  now: number = Date.now(),
+): Promise<{ board: TaskBoard; task: Task }> {
+  const clean = reason.trim();
+  if (!clean) throw new TaskStateError('A reason is required to block a task — say exactly what is missing.');
+  let updated: Task;
+  const board = await casTaskBoard(client, code, (current) => {
+    const task = findTask(current, id);
+    if (task.state !== 'todo' && task.state !== 'in_progress') {
+      throw new TaskStateError(`Task ${id} is '${task.state}' — only todo / in_progress tasks can be blocked.`);
+    }
+    updated = {
+      ...task,
+      state: 'blocked',
+      blocked: { by: by.name, byClient: by.client, at: now, reason: clean },
+      updatedAt: now,
+    };
+    return { ...replaceTask(current, updated), lastProgressAt: now };
+  });
+  return { board, task: updated! };
+}
+
 export class TaskDoneImmutableError extends UpstashError {
   constructor(id: string) {
     super(`Task ${id} is 'done' — completed tasks are locked and cannot be changed.`);
@@ -606,7 +698,7 @@ export async function hostSetTaskState(
   let updated: Task;
   const board = await casTaskBoard(client, code, (current) => {
     const task = findTask(current, id);
-    if (task.state === 'done') throw new TaskDoneImmutableError(id);
+    if (task.state === 'done' || task.state === 'cancelled') throw new TaskDoneImmutableError(id);
     if (task.state === state) return current;
     updated = {
       ...task,
@@ -729,7 +821,21 @@ export function agentBlocks(board: TaskBoard, name: string): number {
 }
 
 export function openTasks(board: TaskBoard): Task[] {
-  return board.tasks.filter(t => t.state !== 'done');
+  return board.tasks.filter(t => t.state !== 'done' && t.state !== 'cancelled');
+}
+
+/**
+ * True when nothing actionable remains — every task is done, rejected or
+ * cancelled. Distinct from allTasksDone, which is the stricter "everything was
+ * verified done" test; a mixed done+rejected board has no open work but is not
+ * all-done. Note this deliberately treats `rejected` as closed, matching the
+ * commercial definition, while openTasks above keeps OSS's existing contract of
+ * counting a rejected task as still open (a producer may retry it).
+ */
+export function boardHasNoOpenWork(board: TaskBoard): boolean {
+  return board.tasks.every(
+    t => t.state === 'done' || t.state === 'rejected' || t.state === 'cancelled',
+  );
 }
 
 export function doneTasks(board: TaskBoard): Task[] {
@@ -777,13 +883,18 @@ export function boardDeliveredSection(board: TaskBoard | null | undefined): stri
 // each; verified-done tasks collapse to a single trailing "✅ N done" line.
 export function summarizeBoard(board: TaskBoard): string {
   const icon: Record<TaskState, string> = {
-    todo: '⬜', in_progress: '🔵', awaiting_review: '🟡', done: '✅', rejected: '🔴',
+    todo: '⬜', in_progress: '🔵', awaiting_review: '🟡', blocked: '🟠', done: '✅', rejected: '🔴', cancelled: '🗑️',
   };
-  const open = board.tasks.filter(t => t.state !== 'done');
-  const doneCount = board.tasks.length - open.length;
-  const lines = open.map(
-    t => `${icon[t.state]} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — ${t.state}`,
-  );
+  const open = board.tasks.filter(t => t.state !== 'done' && t.state !== 'cancelled');
+  const doneCount = board.tasks.filter(t => t.state === 'done').length;
+  const lines = open.map((t) => {
+    // A blocked task is useless on the board without the reason it is stuck —
+    // that reason is the whole point of the state.
+    const blockedSuffix = t.state === 'blocked' && t.blocked?.reason?.trim()
+      ? `: ${t.blocked.reason.trim().slice(0, 80)}`
+      : '';
+    return `${icon[t.state]} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — ${t.state}${blockedSuffix}`;
+  });
   if (doneCount > 0) lines.push(`✅ ${doneCount} done`);
   return lines.join('\n');
 }

--- a/packages/upstash-client/src/turnState.ts
+++ b/packages/upstash-client/src/turnState.ts
@@ -1077,3 +1077,36 @@ export function myRoleInTurn(
   }
   return 'observer';
 }
+
+// Is this sender the room's configured Moderator? Identity comes from the
+// room config (modeConfig), NOT from turn state — the Moderator is still the
+// Moderator between turns, and turn state is wiped outright on every mode
+// switch. Callers that need "does the Moderator hold the floor right now"
+// want the turn-state helpers instead.
+export function isConfiguredModerator(
+  room: Room,
+  name: string,
+  client: ClientKind,
+): boolean {
+  const wantName = room.modeConfig?.moderatorAgentName;
+  if (!wantName || wantName !== name) return false;
+  const wantClient = room.modeConfig?.moderatorAgentClient;
+  // moderatorAgentClient is required by setReplyMode, but older rooms may
+  // carry only the name — fall back to name-only.
+  return wantClient === undefined || wantClient === client;
+}
+
+// Is the room's configured Moderator actually IN the room and able to speak?
+// When this is false the room is in moderator mode in name only: no moderator
+// turn can ever open, so nothing can hold the floor and every agent reply is
+// off-floor traffic.
+export function isModeratorPresent(room: Room): boolean {
+  const wantName = room.modeConfig?.moderatorAgentName;
+  if (!wantName) return false;
+  const wantClient = room.modeConfig?.moderatorAgentClient;
+  return room.participants.some(p =>
+    p.name === wantName
+    && (wantClient === undefined || p.client === wantClient)
+    && p.canSpeak !== false,
+  );
+}

--- a/packages/upstash-client/test/protocolPort.test.ts
+++ b/packages/upstash-client/test/protocolPort.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PRESENCE_DISCONNECTED_MS, type Participant, type Room } from '@agent-room/shared';
+import {
+  createClient,
+  createTask,
+  claimTask,
+  submitTask,
+  submitForReview,
+  updateTask,
+  hostSetTaskState,
+  getTaskBoard,
+  openTasks,
+  summarizeBoard,
+  cancelTask,
+  blockTask,
+  boardHasNoOpenWork,
+  isConfiguredModerator,
+  isModeratorPresent,
+  isParticipantStale,
+  buildTaskSubmitStatusText,
+  TaskStateError,
+  TaskDoneImmutableError,
+} from '../src/index.js';
+
+const ENV = { url: 'https://example.upstash.io', token: 't' };
+const CODE = 'ABC-DEF-GHJ';
+
+// Same in-memory Upstash fake as tasks.test.ts: the CAS read-modify-write loop
+// in tasks.ts has to actually round-trip against state for these to mean
+// anything.
+function installFakeRedis(): Map<string, string> {
+  const store = new Map<string, string>();
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init: any) => {
+    const cmd = JSON.parse(init.body) as string[];
+    const op = cmd[0];
+    const key = cmd[1];
+    let result: unknown = null;
+    if (op === 'GET') result = store.has(key) ? store.get(key) : null;
+    else if (op === 'SET') { store.set(key, cmd[2]); result = 'OK'; }
+    else if (op === 'DEL') { result = store.delete(key) ? 1 : 0; }
+    else if (op === 'EVAL') {
+      const evalKey = cmd[3];
+      const mode = cmd[4];
+      const expected = cmd[5];
+      const next = cmd[6];
+      const cur = store.has(evalKey) ? store.get(evalKey) : undefined;
+      const ok = mode === 'absent' ? cur === undefined : cur === expected;
+      if (ok) { store.set(evalKey, next); result = 1; } else { result = 0; }
+    }
+    return new Response(JSON.stringify({ result }), { headers: { 'Content-Type': 'application/json' } });
+  }));
+  return store;
+}
+
+const FULL_EVIDENCE = {
+  fileListing: 'models.py\nmain.py',
+  fileExcerpt: 'class Activity(Base): ...',
+  runOutput: '1 passed in 0.12s',
+  exitCode: 0,
+};
+
+const ACTOR = { name: 'Claude', client: 'cc' as const };
+const OWNER = { name: 'Qwen', client: 'cc' as const };
+
+describe('cancelTask', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('archives a todo task to cancelled with an audit record', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'Duplicate', createdBy: 'Claude' });
+
+    const { task: cancelled } = await cancelTask(client, CODE, task.id, ACTOR, '  wrong premise  ');
+    expect(cancelled.state).toBe('cancelled');
+    expect(cancelled.cancellation).toMatchObject({ by: 'Claude', byClient: 'cc', reason: 'wrong premise' });
+  });
+
+  it('omits the reason field entirely when none is given', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    const { task: cancelled } = await cancelTask(client, CODE, task.id, ACTOR);
+    expect(cancelled.cancellation).toBeDefined();
+    expect('reason' in cancelled.cancellation!).toBe(false);
+  });
+
+  it('refuses a task that already carries submitted evidence', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await submitTask(client, CODE, task.id, OWNER, FULL_EVIDENCE);
+
+    await expect(cancelTask(client, CODE, task.id, ACTOR)).rejects.toBeInstanceOf(TaskStateError);
+    const board = await getTaskBoard(client, CODE);
+    expect(board!.tasks[0]!.state).toBe('awaiting_review');
+  });
+
+  it('refuses a task whose only evidence is a readiness note', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await submitForReview(client, CODE, task.id, OWNER, 'wrote the doc');
+
+    await expect(cancelTask(client, CODE, task.id, ACTOR)).rejects.toBeInstanceOf(TaskStateError);
+  });
+
+  it('refuses to cancel twice, and refuses a done task', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await cancelTask(client, CODE, task.id, ACTOR);
+    await expect(cancelTask(client, CODE, task.id, ACTOR)).rejects.toBeInstanceOf(TaskStateError);
+
+    const { task: t2 } = await createTask(client, CODE, { title: 'Y', createdBy: 'Claude' });
+    await hostSetTaskState(client, CODE, t2.id, 'done', 'Robin');
+    await expect(cancelTask(client, CODE, t2.id, ACTOR)).rejects.toBeInstanceOf(TaskDoneImmutableError);
+  });
+
+  it('keeps cancelled terminal: no new submission can resurrect it', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await cancelTask(client, CODE, task.id, ACTOR);
+
+    await expect(submitTask(client, CODE, task.id, OWNER, FULL_EVIDENCE)).rejects.toBeInstanceOf(TaskStateError);
+    await expect(submitForReview(client, CODE, task.id, OWNER, 'done-ish')).rejects.toBeInstanceOf(TaskStateError);
+    await expect(hostSetTaskState(client, CODE, task.id, 'todo', 'Robin')).rejects.toBeInstanceOf(TaskDoneImmutableError);
+
+    const board = await getTaskBoard(client, CODE);
+    expect(board!.tasks[0]!.state).toBe('cancelled');
+  });
+
+  it('can be reopened by the host escape hatch (updateTask), then submitted again', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await cancelTask(client, CODE, task.id, ACTOR);
+
+    const { task: reopened } = await updateTask(client, CODE, task.id, { state: 'todo' });
+    expect(reopened.state).toBe('todo');
+    const { task: submitted } = await submitTask(client, CODE, task.id, OWNER, FULL_EVIDENCE);
+    expect(submitted.state).toBe('awaiting_review');
+  });
+
+  it('drops the task out of openTasks and the board summary', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'Dead end', createdBy: 'Claude' });
+    await createTask(client, CODE, { title: 'Real work', createdBy: 'Claude' });
+    await cancelTask(client, CODE, task.id, ACTOR);
+
+    const board = (await getTaskBoard(client, CODE))!;
+    expect(openTasks(board).map(t => t.title)).toEqual(['Real work']);
+    expect(summarizeBoard(board)).not.toContain('Dead end');
+  });
+});
+
+describe('blockTask', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('moves todo/in_progress to blocked and records who and why', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'Deploy', createdBy: 'Claude' });
+    await claimTask(client, CODE, task.id, OWNER);
+
+    const { task: blocked } = await blockTask(client, CODE, task.id, OWNER, '  no prod credentials  ');
+    expect(blocked.state).toBe('blocked');
+    expect(blocked.blocked).toMatchObject({ by: 'Qwen', byClient: 'cc', reason: 'no prod credentials' });
+  });
+
+  it('requires a non-empty reason', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await expect(blockTask(client, CODE, task.id, OWNER, '   ')).rejects.toBeInstanceOf(TaskStateError);
+
+    const board = await getTaskBoard(client, CODE);
+    expect(board!.tasks[0]!.state).toBe('todo');
+  });
+
+  it('refuses any state other than todo / in_progress', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await submitTask(client, CODE, task.id, OWNER, FULL_EVIDENCE); // awaiting_review
+
+    await expect(blockTask(client, CODE, task.id, OWNER, 'stuck')).rejects.toBeInstanceOf(TaskStateError);
+  });
+
+  it('stays OPEN work — a blocked board is not a finished board', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await blockTask(client, CODE, task.id, OWNER, 'missing input file');
+
+    const board = (await getTaskBoard(client, CODE))!;
+    expect(openTasks(board)).toHaveLength(1);
+    expect(boardHasNoOpenWork(board)).toBe(false);
+    expect(summarizeBoard(board)).toContain('missing input file');
+  });
+
+  it('keeps the block record as history after a reopen', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await blockTask(client, CODE, task.id, OWNER, 'waiting on Robin');
+    const { task: reopened } = await updateTask(client, CODE, task.id, { state: 'in_progress' });
+
+    expect(reopened.state).toBe('in_progress');
+    expect(reopened.blocked?.reason).toBe('waiting on Robin');
+  });
+});
+
+describe('boardHasNoOpenWork', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('is false while anything is todo / in_progress / awaiting_review / blocked', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    expect(boardHasNoOpenWork((await getTaskBoard(client, CODE))!)).toBe(false);
+  });
+
+  it('is true for a board that is only done / rejected / cancelled', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task: a } = await createTask(client, CODE, { title: 'A', createdBy: 'Claude' });
+    const { task: b } = await createTask(client, CODE, { title: 'B', createdBy: 'Claude' });
+    const { task: c } = await createTask(client, CODE, { title: 'C', createdBy: 'Claude' });
+    await hostSetTaskState(client, CODE, a.id, 'done', 'Robin');
+    await hostSetTaskState(client, CODE, b.id, 'rejected', 'Robin');
+    await cancelTask(client, CODE, c.id, ACTOR);
+
+    expect(boardHasNoOpenWork((await getTaskBoard(client, CODE))!)).toBe(true);
+  });
+
+  it('is true for an empty board — nothing to do is not open work', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'X', createdBy: 'Claude' });
+    await cancelTask(client, CODE, task.id, ACTOR);
+    const board = (await getTaskBoard(client, CODE))!;
+    expect(boardHasNoOpenWork({ ...board, tasks: [] })).toBe(true);
+  });
+});
+
+// ── Pure helpers: no Redis needed ────────────────────────────────────────────
+
+function room(over: Partial<Room> = {}): Room {
+  return {
+    code: CODE,
+    topic: 'T',
+    createdBy: 'Robin',
+    createdAt: 0,
+    participants: [],
+    ...over,
+  } as unknown as Room;
+}
+
+function participant(over: Partial<Participant> = {}): Participant {
+  return { name: 'Claude', client: 'cc', joinedAt: 0, lastSeenAt: 0, ...over } as unknown as Participant;
+}
+
+describe('isConfiguredModerator', () => {
+  it('matches on name + client when both are configured', () => {
+    const r = room({ modeConfig: { moderatorAgentName: 'Claude', moderatorAgentClient: 'cc' } });
+    expect(isConfiguredModerator(r, 'Claude', 'cc')).toBe(true);
+    expect(isConfiguredModerator(r, 'Claude', 'web')).toBe(false);
+    expect(isConfiguredModerator(r, 'Cursor', 'cc')).toBe(false);
+  });
+
+  it('falls back to name-only for older rooms that carry no moderator client', () => {
+    const r = room({ modeConfig: { moderatorAgentName: 'Claude' } });
+    expect(isConfiguredModerator(r, 'Claude', 'cc')).toBe(true);
+    expect(isConfiguredModerator(r, 'Claude', 'web')).toBe(true);
+  });
+
+  it('is false when no moderator is configured at all', () => {
+    expect(isConfiguredModerator(room(), 'Claude', 'cc')).toBe(false);
+    expect(isConfiguredModerator(room({ modeConfig: {} }), 'Claude', 'cc')).toBe(false);
+  });
+});
+
+describe('isModeratorPresent', () => {
+  it('is true only when the configured moderator is seated and able to speak', () => {
+    const r = room({
+      modeConfig: { moderatorAgentName: 'Claude', moderatorAgentClient: 'cc' },
+      participants: [participant({ name: 'Claude', client: 'cc' })],
+    });
+    expect(isModeratorPresent(r)).toBe(true);
+  });
+
+  it('is false when the moderator is present but muted', () => {
+    const r = room({
+      modeConfig: { moderatorAgentName: 'Claude', moderatorAgentClient: 'cc' },
+      participants: [participant({ name: 'Claude', client: 'cc', canSpeak: false })],
+    });
+    expect(isModeratorPresent(r)).toBe(false);
+  });
+
+  it('is false when only a same-named seat on another client is present', () => {
+    const r = room({
+      modeConfig: { moderatorAgentName: 'Claude', moderatorAgentClient: 'cc' },
+      participants: [participant({ name: 'Claude', client: 'web' })],
+    });
+    expect(isModeratorPresent(r)).toBe(false);
+  });
+
+  it('is false when the room names no moderator', () => {
+    expect(isModeratorPresent(room({ participants: [participant()] }))).toBe(false);
+  });
+});
+
+describe('isParticipantStale', () => {
+  const NOW = 1_000_000_000;
+
+  it('is false while a listen lease is still live, even with an old lastSeenAt', () => {
+    const p = participant({ lastSeenAt: 0, listenUntil: NOW + 1000 });
+    expect(isParticipantStale(p, NOW)).toBe(false);
+  });
+
+  it('falls back to lastSeenAt once the lease has expired', () => {
+    const expired = participant({ lastSeenAt: NOW - PRESENCE_DISCONNECTED_MS - 1, listenUntil: NOW - 1 });
+    expect(isParticipantStale(expired, NOW)).toBe(true);
+
+    const recent = participant({ lastSeenAt: NOW - 1000, listenUntil: NOW - 1 });
+    expect(isParticipantStale(recent, NOW)).toBe(false);
+  });
+
+  it('treats the threshold as exclusive', () => {
+    expect(isParticipantStale(participant({ lastSeenAt: NOW - PRESENCE_DISCONNECTED_MS }), NOW)).toBe(false);
+    expect(isParticipantStale(participant({ lastSeenAt: NOW - PRESENCE_DISCONNECTED_MS - 1 }), NOW)).toBe(true);
+  });
+
+  it('treats a missing or non-finite lastSeenAt as never seen', () => {
+    expect(isParticipantStale(participant({ lastSeenAt: undefined as unknown as number }), NOW)).toBe(true);
+    expect(isParticipantStale(participant({ lastSeenAt: NaN }), NOW)).toBe(true);
+  });
+
+  it('ignores a non-finite listenUntil rather than trusting it', () => {
+    const p = participant({ lastSeenAt: 0, listenUntil: NaN });
+    expect(isParticipantStale(p, NOW)).toBe(true);
+  });
+});
+
+describe('buildTaskSubmitStatusText', () => {
+  it('collapses whitespace and keeps the [STATUS] prefix and task id', () => {
+    expect(buildTaskSubmitStatusText('T-07', '  12 passed\n  0 failed  '))
+      .toBe('[STATUS] 待审核 / awaiting_review T-07: 12 passed 0 failed');
+  });
+
+  it('caps the summary at 180 characters', () => {
+    const text = buildTaskSubmitStatusText('T-01', 'x'.repeat(500));
+    expect(text.endsWith('x'.repeat(180))).toBe(true);
+    expect(text).not.toContain('x'.repeat(181));
+  });
+
+  it('falls back to a placeholder when there is no run output', () => {
+    expect(buildTaskSubmitStatusText('T-01', '   ')).toContain('(no run output)');
+  });
+});


### PR DESCRIPTION
Ports seven protocol-layer functions from the commercial `upstash-client` into
this repo. Function by function, not file by file: the two repos' copies of
`tasks.ts` / `turnState.ts` / `rooms.ts` / `messages.ts` have diverged, and a
whole-file copy would have dragged hosted-only orchestration, game state, and
Projects/knowledge-base code across with it.

## What came over

| Function | File | Notes |
|---|---|---|
| `cancelTask` | `tasks.ts` | Archives a task to terminal `cancelled`. Refuses tasks that carry submitted evidence (`evidence` or a `readinessNote`) — those must be reopened first, so a delivery record is never destroyed. |
| `blockTask` | `tasks.ts` | Owner/host declares a task stuck. `blocked` stays **open** work; a reason is required. |
| `boardHasNoOpenWork` | `tasks.ts` | "Nothing actionable remains", distinct from the stricter `allTasksDone`. |
| `isConfiguredModerator` | `turnState.ts` | Moderator identity from `room.modeConfig`, not from turn state. Falls back to name-only for older rooms with no `moderatorAgentClient`. |
| `isModeratorPresent` | `turnState.ts` | Is the configured moderator seated **and** able to speak. When false the room is in moderator mode in name only. |
| `isParticipantStale` | `rooms.ts` | Presence check. A live `listenUntil` lease can only *veto* staleness; `lastSeenAt` is what decides abandonment. |
| `buildTaskSubmitStatusText` | `messages.ts` | Shared `[STATUS]` ping body so every client emits the same recognisable prefix. |

Deliberately **not** brought over, per scope: `isMultiAgentMode` /
`multiAgentRoster` / `newMultiAgentTurn` / `multiAgentPhaseStart` (hosted
orchestration), `newGameTurn` / `bumpGameVersion` (game), `attachProject` /
`markKnowledgeImportCheckpoint` (Projects + knowledge base), and the
`gameState` / `tableGames` / `tableGameState` / `werewolfState` / `playbooks` /
`oauth` files wholesale.

## Dependencies each function needed, and how they were handled

`cancelTask` and `blockTask` write states this repo's type system did not have.
Rather than rewrite them onto existing OSS types (which would have meant
inventing a different, silently incompatible protocol), the **minimal** type
dependency came with them:

1. **`TaskState` gains `'blocked'` and `'cancelled'`** (`packages/shared/src/types.ts`),
   matching the commercial union exactly.
2. **`TaskCancellation` and `TaskBlock`** interfaces added, plus the optional
   `Task.cancellation` / `Task.blocked` fields. Both optional, so every board
   written before this change deserialises unchanged.

Extending the union forced three consequential edits. Each is a direct
consequence of the new states, not scope creep:

3. **`summarizeBoard` typechecks against `Record<TaskState, string>`** — adding
   union members without adding icons is a hard compile error. Added `🟠`
   (blocked) and `🗑️` (cancelled), stopped counting cancelled tasks as open or
   as done, and appended the block reason to a blocked line (a blocked task on
   the board is useless without the reason it is stuck).
4. **`openTasks` now excludes `cancelled`** — a terminal archived task is by
   definition not open work. Its treatment of `rejected` is left alone, so this
   repo's existing contract there is unchanged.
5. **`cancelled` is terminal**, enforced where it can be reached:
   `hostSetTaskState` treats it like `done`, and a new `assertNotCancelled`
   guard in `submitTask` / `submitForReview` stops a cancelled task being
   silently resurrected into `awaiting_review`. `updateTask` can still reopen
   one to `todo` / `in_progress` — that is the intended escape hatch and
   matches commercial.

One deliberate divergence, called out rather than hidden: commercial defines
`boardHasNoOpenWork` as `openTasks(board).length === 0`, where its `openTasks`
also excludes `rejected`. This repo's `openTasks` counts a rejected task as
still open (a producer may retry it). To get commercial's *behaviour* without
silently changing this repo's `openTasks` contract, `boardHasNoOpenWork` states
its own predicate: done, rejected or cancelled.

The other five functions needed no new types — `modeConfig.moderatorAgentName`
/ `moderatorAgentClient`, `Participant.listenUntil` / `lastSeenAt`, and
`PRESENCE_DISCONNECTED_MS` all already exist here.

## Evidence

```
npm run build:ordered   → exit 0  (shared, upstash-client, room-persistence, web)

npm test
  @agent-room/shared            11 files, 102/102 passed
  @agent-room/upstash-client     9 files, 188/188 passed  (incl. new protocolPort.test.ts, 31 tests)
  @agent-room/web                1 file,    6/6   passed
  @agent-room/room-persistence   1 failed — test/schema.test.ts "migration custody"
```

The single failure is the known Windows `autocrlf` checkout artefact: the
committed migration blob is LF in the repo, CRLF in the working tree. It is
unrelated to this change — nothing here touches `packages/room-persistence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
