### PR TITLE
fix(tasks): make a rejected task terminal, matching the commercial board

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -338,7 +338,7 @@ export type TaskState =
   | 'awaiting_review'  // producer submitted evidence; verifier must rule
   | 'blocked'          // owner/host declared it stuck — see Task.blocked; open work
   | 'done'             // verifier confirmed the evidence
-  | 'rejected'         // verifier rejected; back to the producer
+  | 'rejected'         // verifier rejected; terminal until explicitly reopened
   | 'cancelled';       // participant archived it; terminal, visible history only
 
 // The three-part proof a producer must attach to move a task to

--- a/packages/upstash-client/src/tasks.ts
+++ b/packages/upstash-client/src/tasks.ts
@@ -820,22 +820,28 @@ export function agentBlocks(board: TaskBoard, name: string): number {
   return board.reliability?.[name]?.blocks ?? 0;
 }
 
+/**
+ * Tasks that still need work — end-room guards, stall nudges, progress UI.
+ * `blocked` stays included: it is open work waiting on an external unblock.
+ * `rejected` is a terminal disposition (no further work unless explicitly
+ * reopened), so it is excluded alongside `done` and `cancelled`.
+ */
 export function openTasks(board: TaskBoard): Task[] {
-  return board.tasks.filter(t => t.state !== 'done' && t.state !== 'cancelled');
+  return board.tasks.filter(t => t.state !== 'done' && t.state !== 'rejected' && t.state !== 'cancelled');
 }
 
 /**
  * True when nothing actionable remains — every task is done, rejected or
- * cancelled. Distinct from allTasksDone, which is the stricter "everything was
- * verified done" test; a mixed done+rejected board has no open work but is not
- * all-done. Note this deliberately treats `rejected` as closed, matching the
- * commercial definition, while openTasks above keeps OSS's existing contract of
- * counting a rejected task as still open (a producer may retry it).
+ * cancelled. Used to stop periodic board review / prune the cron index without
+ * treating a mixed board as “all verified done” (that is allTasksDone).
+ *
+ * Derived from openTasks so the two can never disagree. They used to: this
+ * function called a rejected task closed while openTasks called it open, so a
+ * board with one reject could report "1 unfinished" and "nothing left to do"
+ * at the same time.
  */
 export function boardHasNoOpenWork(board: TaskBoard): boolean {
-  return board.tasks.every(
-    t => t.state === 'done' || t.state === 'rejected' || t.state === 'cancelled',
-  );
+  return openTasks(board).length === 0;
 }
 
 export function doneTasks(board: TaskBoard): Task[] {
@@ -885,16 +891,33 @@ export function summarizeBoard(board: TaskBoard): string {
   const icon: Record<TaskState, string> = {
     todo: '⬜', in_progress: '🔵', awaiting_review: '🟡', blocked: '🟠', done: '✅', rejected: '🔴', cancelled: '🗑️',
   };
-  const open = board.tasks.filter(t => t.state !== 'done' && t.state !== 'cancelled');
+  const open = openTasks(board);
+  const rejected = board.tasks.filter(t => t.state === 'rejected');
+  const cancelled = board.tasks.filter(t => t.state === 'cancelled');
   const doneCount = board.tasks.filter(t => t.state === 'done').length;
-  const lines = open.map((t) => {
-    // A blocked task is useless on the board without the reason it is stuck —
-    // that reason is the whole point of the state.
-    const blockedSuffix = t.state === 'blocked' && t.blocked?.reason?.trim()
-      ? `: ${t.blocked.reason.trim().slice(0, 80)}`
-      : '';
-    return `${icon[t.state]} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — ${t.state}${blockedSuffix}`;
-  });
+  const lines = [
+    ...open.map((t) => {
+      // A blocked task is useless on the board without the reason it is stuck —
+      // that reason is the whole point of the state.
+      const blockedSuffix = t.state === 'blocked' && t.blocked?.reason?.trim()
+        ? `: ${t.blocked.reason.trim().slice(0, 80)}`
+        : '';
+      return `${icon[t.state]} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — ${t.state}${blockedSuffix}`;
+    }),
+    // Terminal, so not open work — but still listed, because "why was this
+    // rejected / cancelled" is the part a reader actually needs.
+    ...rejected.map((t) => {
+      const note = t.verdict?.note?.trim();
+      const noteSuffix = note ? `: ${note.slice(0, 80)}` : '';
+      return `${icon.rejected} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — rejected${noteSuffix}`;
+    }),
+    ...cancelled.map((t) => {
+      const reason = t.cancellation?.reason?.trim();
+      const reasonSuffix = reason ? `: ${reason.slice(0, 80)}` : '';
+      const by = t.cancellation?.by ? ` by @${t.cancellation.by}` : '';
+      return `${icon.cancelled} ${t.id} ${t.title}${t.owner ? ` (@${t.owner})` : ''} — cancelled${by}${reasonSuffix}`;
+    }),
+  ];
   if (doneCount > 0) lines.push(`✅ ${doneCount} done`);
   return lines.join('\n');
 }

--- a/packages/upstash-client/test/protocolPort.test.ts
+++ b/packages/upstash-client/test/protocolPort.test.ts
@@ -5,6 +5,7 @@ import {
   createTask,
   claimTask,
   submitTask,
+  verifyTask,
   submitForReview,
   updateTask,
   hostSetTaskState,
@@ -151,7 +152,11 @@ describe('cancelTask', () => {
 
     const board = (await getTaskBoard(client, CODE))!;
     expect(openTasks(board).map(t => t.title)).toEqual(['Real work']);
-    expect(summarizeBoard(board)).not.toContain('Dead end');
+    // Terminal, so not open work — but still listed, with who archived it and
+    // why. "Where did that task go" is the question the summary has to answer.
+    const summary = summarizeBoard(board);
+    expect(summary).toContain('🗑️ T-01 Dead end');
+    expect(summary).toContain('cancelled by @Claude');
   });
 });
 
@@ -209,6 +214,39 @@ describe('blockTask', () => {
 
     expect(reopened.state).toBe('in_progress');
     expect(reopened.blocked?.reason).toBe('waiting on Robin');
+  });
+});
+
+describe('rejected is terminal, matching the commercial definition', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('leaves a rejected task out of openTasks but keeps it in the summary', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task: dead } = await createTask(client, CODE, { title: 'Old approach', createdBy: 'Claude' });
+    await createTask(client, CODE, { title: 'Real work', createdBy: 'Claude' });
+    await submitTask(client, CODE, dead.id, OWNER, FULL_EVIDENCE);
+    await verifyTask(client, CODE, dead.id, ACTOR, 'rejected', 'use plan B instead');
+
+    const board = (await getTaskBoard(client, CODE))!;
+    expect(openTasks(board).map(t => t.title)).toEqual(['Real work']);
+    // Not open work, but the reason it was rejected is exactly what a reader
+    // needs, so it keeps a line of its own.
+    const summary = summarizeBoard(board);
+    expect(summary).toContain('🔴 T-01 Old approach');
+    expect(summary).toContain('use plan B instead');
+  });
+
+  it('agrees with boardHasNoOpenWork — the two used to disagree', async () => {
+    installFakeRedis();
+    const client = createClient(ENV);
+    const { task } = await createTask(client, CODE, { title: 'Old approach', createdBy: 'Claude' });
+    await submitTask(client, CODE, task.id, OWNER, FULL_EVIDENCE);
+    await verifyTask(client, CODE, task.id, ACTOR, 'rejected', 'superseded');
+
+    const board = (await getTaskBoard(client, CODE))!;
+    expect(openTasks(board)).toHaveLength(0);
+    expect(boardHasNoOpenWork(board)).toBe(true);
   });
 });
 


### PR DESCRIPTION
> **This PR was force-pushed and now does the opposite of what it originally did.** The first version made `rejected` count as open work. The host reversed that decision 53 seconds before I opened the PR and I missed the message — I had stopped calling `room_listen` while working and acted on a stale premise. `Composer` caught it in review. The paired commercial PR (robine198351/agent-room-commercial#599) is closed; this one carries the whole change instead.

Host decision, room `JAK-7F2-HCE`:

- **`rejected` is terminal** — "就终结了，和商业版保持一致". The work stops there unless someone explicitly reopens it.
- **`cancelled` follows this repo** — "cancelled 和开源保持一致". Any joined participant may cancel.

## The inconsistency this fixes

This repo gave two answers to *"is this still open?"* at once:

| | rejected counted as |
|---|---|
| `openTasks` | open |
| `boardHasNoOpenWork` | closed |

A board with one reject could report **"1 unfinished"** and **"nothing left to do"** simultaneously — both true, from two different definitions. (I introduced that split in #50, documenting it as deliberate; the host has now settled which side is right, so the split goes away rather than staying documented.)

`openTasks` now excludes `rejected` alongside `done` and `cancelled`, and `boardHasNoOpenWork` is **derived from `openTasks`**, so the two cannot drift apart again.

## Terminal is not the same as invisible

`summarizeBoard` takes the commercial shape: `rejected` and `cancelled` get their own sections instead of being dropped from the list or folded into the open one.

That matters. "Why was this rejected" (the verdict note) and "who cancelled this, and why" are exactly what a reader needs — a board that silently swallows a terminal task makes the work look like it evaporated. So a terminal task keeps a line; it just is not counted as outstanding.

## Not changed

The `cancelled` comment stays as it reads here — any joined participant may cancel, no host/moderator privilege — which is the side the host chose for that state. The commercial repo moves to match, in its own PR.

## Tests

`drops the task out of openTasks and the board summary` asserted a cancelled task vanishes from the summary. It no longer does, and shouldn't, so it now pins the line's content (`🗑️ T-01 Dead end`, `cancelled by @Claude`) instead of its absence.

Two new cases pin the newly-settled rule end to end: a rejected task stays out of `openTasks` while keeping its verdict note in the summary, and `openTasks` / `boardHasNoOpenWork` agree — the thing that used to be false.

## Evidence

```
npm run build:ordered → exit 0
npm test
    shared           11 files, 102/102 passed
    upstash-client    9 files, 190/190 passed   (protocolPort 33, +2 new)
    web               1 file,    6/6   passed
    room-persistence  1 failed — test/schema.test.ts "migration custody"
```

The single failure is the known Windows `autocrlf` checkout artefact (committed blob is LF, working tree CRLF). Nothing here touches `packages/room-persistence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
