### PR TITLE
Render the task board in the web client, and make the room usable on a phone

### DIFF
--- a/apps/web/src/components/TaskBoard.tsx
+++ b/apps/web/src/components/TaskBoard.tsx
@@ -1,0 +1,696 @@
+import { useState } from 'react';
+import type { ClientKind, Participant, RoomArtifact, Task, TaskState } from '@agent-room/shared';
+import { artifactLabel } from '@agent-room/shared';
+import {
+  blockTask,
+  cancelTask,
+  createTask,
+  reassignTaskRoles,
+  updateTask,
+  verifyTask,
+} from '@agent-room/upstash-client';
+import type { useTaskBoard } from '../hooks/useTaskBoard.js';
+
+interface Props {
+  code: string;
+  me: { name: string };
+  isHost: boolean;
+  ended: boolean;
+  /** Agent participants (client === 'cc'), the assignable owners/verifiers. */
+  agents: Participant[];
+  artifacts: RoomArtifact[];
+  /** Rooms with no messages have nothing to freeze into a report. */
+  canExport: boolean;
+  reportBusy: boolean;
+  onExportReport: () => void;
+  /** Drops text into the room composer so the host can chase a task in chat. */
+  onMention: (text: string) => void;
+  /**
+   * Owned by Room so the mobile tab strip can badge "needs review" without a
+   * second poller running against the same board key.
+   */
+  taskBoard: ReturnType<typeof useTaskBoard>;
+}
+
+const STATE_TONE: Record<TaskState, { label: string; chip: string; rail: string }> = {
+  todo:            { label: 'To do',       chip: 'bg-surface-sunken text-ink-muted ring-border',            rail: 'bg-ink-faint' },
+  in_progress:     { label: 'In progress', chip: 'bg-blue-50 text-blue-800 ring-blue-200',                  rail: 'bg-blue-500' },
+  awaiting_review: { label: 'Needs review', chip: 'bg-amber-50 text-amber-800 ring-amber-200',              rail: 'bg-amber-500' },
+  blocked:         { label: 'Blocked',     chip: 'bg-rose-50 text-rose-800 ring-rose-200',                  rail: 'bg-rose-500' },
+  done:            { label: 'Done',        chip: 'bg-emerald-50 text-emerald-800 ring-emerald-200',         rail: 'bg-emerald-500' },
+  rejected:        { label: 'Rejected',    chip: 'bg-rose-50 text-rose-800 ring-rose-200',                  rail: 'bg-rose-500' },
+  cancelled:       { label: 'Cancelled',   chip: 'bg-surface-sunken text-ink-faint ring-border-faint',      rail: 'bg-border' },
+};
+
+// Action-first ordering: what needs the host's thumb comes before what is
+// merely running. Closed states drop below the fold entirely.
+const OPEN_ORDER: TaskState[] = ['awaiting_review', 'blocked', 'in_progress', 'todo'];
+const CLOSED: ReadonlySet<TaskState> = new Set<TaskState>(['done', 'rejected', 'cancelled']);
+
+/** Split the board into the action-ordered open list and the closed archive. */
+export function partitionTasks(tasks: Task[]): { open: Task[]; closed: Task[] } {
+  return {
+    open: tasks.filter(t => !CLOSED.has(t.state))
+      .sort((a, b) => OPEN_ORDER.indexOf(a.state) - OPEN_ORDER.indexOf(b.state) || a.id.localeCompare(b.id)),
+    closed: tasks.filter(t => CLOSED.has(t.state)).sort((a, b) => b.updatedAt - a.updatedAt),
+  };
+}
+
+/**
+ * Whether this viewer may rule on a task, mirroring verifyTask's server-side
+ * guards: only 'awaiting_review' is rulable, the owner never rules on their
+ * own delivery, and a designated verifier excludes everyone else. Kept in sync
+ * deliberately so the UI never renders an Approve button the server rejects.
+ */
+export function canRuleOn(task: Task, viewer: { name: string; client: ClientKind }, ended: boolean): boolean {
+  if (ended || task.state !== 'awaiting_review') return false;
+  // Identity is (name, client) everywhere in this app, and a room can hold
+  // both "Robin - web" and "Robin - cc". Matching on name alone hid Approve
+  // from a host who shares a display name with the agent that owns the task.
+  // An unrecorded client matches, same direction the server takes.
+  if (task.owner === viewer.name
+    && (task.ownerClient === undefined || task.ownerClient === viewer.client)) return false;
+  if (task.verifier && !(task.verifier === viewer.name
+    && (task.verifierClient === undefined || task.verifierClient === viewer.client))) return false;
+  return true;
+}
+
+// Shared control sizing. 40px tall on touch, 32px from `sm:` up — the old
+// board-less UI used 28px controls that were unhittable on a phone.
+const CTRL = 'min-h-10 sm:min-h-8 rounded-lg px-2.5 text-[13px] sm:text-xs font-semibold transition active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed';
+const FIELD = 'w-full min-h-10 rounded-lg border border-border bg-white px-3 text-[15px] sm:text-[13px] text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60';
+
+export function TaskBoard({ code, me, isHost, ended, agents, artifacts, canExport, reportBusy, onExportReport, onMention, taskBoard }: Props) {
+  const { board, loaded, busy, run } = taskBoard;
+  const [composing, setComposing] = useState(false);
+  const [showClosed, setShowClosed] = useState(false);
+
+  const tasks = board?.tasks ?? [];
+  const { open, closed } = partitionTasks(tasks);
+  const needsMe = open.filter(t => canRuleOn(t, { name: me.name, client: 'web' }, ended)).length;
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className="shrink-0 border-b border-border-faint bg-surface p-3 sm:p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-ink">Tasks</h2>
+            <p className="text-[11px] text-ink-soft">
+              {!loaded ? 'Loading board' : open.length === 0 && closed.length === 0
+                ? 'No tasks yet'
+                : `${open.length} open · ${closed.length} closed`}
+            </p>
+          </div>
+          {needsMe > 0 && (
+            <span className="shrink-0 rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-bold text-amber-800 ring-1 ring-inset ring-amber-200">
+              {needsMe} to review
+            </span>
+          )}
+        </div>
+        {!ended && (
+          <button
+            type="button"
+            onClick={() => setComposing(v => !v)}
+            className={`mt-3 w-full ${CTRL} ${composing
+              ? 'border border-border bg-surface-softer text-ink-muted'
+              : 'bg-accent text-white shadow-sm hover:opacity-90'}`}
+          >
+            {composing ? 'Cancel' : 'New task'}
+          </button>
+        )}
+        {composing && (
+          <NewTaskForm
+            agents={agents}
+            busy={busy}
+            onCancel={() => setComposing(false)}
+            onSubmit={async (input) => {
+              const ok = await run(
+                c => createTask(c, code, { ...input, createdBy: me.name }),
+                'Could not create task',
+              );
+              if (ok) setComposing(false);
+            }}
+          />
+        )}
+      </div>
+
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 sm:p-4">
+        {!loaded ? (
+          <BoardSkeleton />
+        ) : tasks.length === 0 ? (
+          <EmptyBoard hasAgents={agents.length > 0} />
+        ) : (
+          <div className="space-y-2.5">
+            {open.map(task => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                me={me}
+                isHost={isHost}
+                ended={ended}
+                agents={agents}
+                busy={busy}
+                run={run}
+                code={code}
+                onMention={onMention}
+              />
+            ))}
+
+            {closed.length > 0 && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setShowClosed(v => !v)}
+                  className="mt-4 flex w-full items-center justify-between rounded-lg border border-border-faint bg-surface-softer px-3 py-2.5 text-[13px] sm:text-xs font-semibold text-ink-muted transition hover:border-border"
+                >
+                  <span>Closed ({closed.length})</span>
+                  <span className="text-ink-faint">{showClosed ? 'Hide' : 'Show'}</span>
+                </button>
+                {showClosed && closed.map(task => (
+                  <TaskCard
+                    key={task.id}
+                    task={task}
+                    me={me}
+                    isHost={isHost}
+                    ended={ended}
+                    agents={agents}
+                    busy={busy}
+                    run={run}
+                    code={code}
+                    onMention={onMention}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        )}
+
+        <DeliverySection
+          artifacts={artifacts}
+          canExport={canExport}
+          reportBusy={reportBusy}
+          onExportReport={onExportReport}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TaskCard({ task, me, isHost, ended, agents, busy, run, code, onMention }: {
+  task: Task;
+  me: { name: string };
+  isHost: boolean;
+  ended: boolean;
+  agents: Participant[];
+  busy: boolean;
+  run: ReturnType<typeof useTaskBoard>['run'];
+  code: string;
+  onMention: (text: string) => void;
+}) {
+  const [panel, setPanel] = useState<'none' | 'reject' | 'block' | 'assign'>('none');
+  const [note, setNote] = useState('');
+  const tone = STATE_TONE[task.state];
+
+  const iAmOwner = task.owner === me.name
+    && (task.ownerClient === undefined || task.ownerClient === 'web');
+  const canRule = canRuleOn(task, { name: me.name, client: 'web' }, ended);
+  const canBlock = !ended && (isHost || iAmOwner) && (task.state === 'in_progress' || task.state === 'todo');
+  const canReopen = !ended && isHost
+    && (task.state === 'blocked' || task.state === 'rejected' || task.state === 'awaiting_review');
+  const canAssign = !ended && isHost && !CLOSED.has(task.state);
+  const canCancel = !ended && isHost && !CLOSED.has(task.state)
+    && !task.evidence && !task.readinessNote?.trim();
+
+  const closePanel = () => { setPanel('none'); setNote(''); };
+
+  return (
+    <article className="overflow-hidden rounded-xl border border-border-faint bg-surface">
+      <div className="flex">
+        <div className={`w-1 shrink-0 ${tone.rail}`} aria-hidden="true" />
+        <div className="min-w-0 flex-1 p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-[11px] font-semibold text-ink-faint">{task.id}</span>
+                <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ring-1 ring-inset ${tone.chip}`}>
+                  {tone.label}
+                </span>
+              </div>
+              <h3 className="mt-1.5 text-[14px] font-semibold leading-snug text-ink break-words">{task.title}</h3>
+            </div>
+          </div>
+
+          <dl className="mt-2 flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-[11px] text-ink-soft">
+            <div className="flex gap-1">
+              <dt className="text-ink-faint">Owner</dt>
+              <dd className="font-semibold text-ink-muted break-all">{task.owner ?? 'unassigned'}</dd>
+            </div>
+            <div className="flex gap-1">
+              <dt className="text-ink-faint">Verifier</dt>
+              <dd className="font-semibold text-ink-muted break-all">{task.verifier ?? 'any peer'}</dd>
+            </div>
+          </dl>
+
+          {task.dod && (
+            <p className="mt-2 rounded-lg bg-surface-softer px-2.5 py-2 text-[12px] leading-relaxed text-ink-muted break-words">
+              <span className="font-semibold text-ink-faint">Done when: </span>{task.dod}
+            </p>
+          )}
+          {task.subtasks?.length ? (
+            <p className="mt-2 text-[11px] font-semibold text-ink-soft">
+              Subtasks {task.subtasks.filter(s => s.done).length}/{task.subtasks.length}
+            </p>
+          ) : null}
+          {task.state === 'awaiting_review' && (task.readinessNote || task.evidence) && (
+            <ReviewEvidence task={task} />
+          )}
+          {task.state === 'blocked' && task.blocked && (
+            <Callout tone="rose" title={`Blocked by ${task.blocked.by}`} body={task.blocked.reason} />
+          )}
+          {task.verdict && CLOSED.has(task.state) && task.verdict.note && (
+            <Callout
+              tone={task.verdict.verdict === 'done' ? 'emerald' : 'rose'}
+              title={`${task.verdict.verdict === 'done' ? 'Approved' : 'Rejected'} by ${task.verdict.by}`}
+              body={task.verdict.note}
+            />
+          )}
+
+          {panel === 'none' ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {canRule && (
+                <>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void run(
+                      c => verifyTask(c, code, task.id, { name: me.name, client: 'web' }, 'done', undefined),
+                      'Approve failed',
+                    )}
+                    className={`${CTRL} bg-emerald-600 text-white hover:bg-emerald-700`}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => setPanel('reject')}
+                    className={`${CTRL} border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100`}
+                  >
+                    Reject
+                  </button>
+                </>
+              )}
+              {canReopen && (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void run(c => updateTask(c, code, task.id, { state: 'todo' }), 'Reopen failed')}
+                  className={`${CTRL} border border-border bg-surface-softer text-ink-muted hover:border-accent/40 hover:text-accent`}
+                >
+                  Reopen
+                </button>
+              )}
+              {canBlock && (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setPanel('block')}
+                  className={`${CTRL} border border-border bg-surface-softer text-ink-muted hover:border-rose-300 hover:text-rose-600`}
+                >
+                  Block
+                </button>
+              )}
+              {canAssign && (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setPanel('assign')}
+                  className={`${CTRL} border border-border bg-surface-softer text-ink-muted hover:border-accent/40 hover:text-accent`}
+                >
+                  Reassign
+                </button>
+              )}
+              {task.owner && !ended && (
+                <button
+                  type="button"
+                  onClick={() => onMention(`@${task.owner} status on ${task.id} (${task.title})?`)}
+                  className={`${CTRL} border border-accent-tint-border bg-accent-tint text-accent hover:bg-accent-tint-border`}
+                >
+                  Ask owner
+                </button>
+              )}
+              {canCancel && (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void run(
+                    c => cancelTask(c, code, task.id, { name: me.name, client: 'web' }, 'Cancelled by host'),
+                    'Cancel failed',
+                  )}
+                  className={`${CTRL} ml-auto text-ink-faint hover:text-rose-600`}
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          ) : panel === 'assign' ? (
+            <AssignPanel
+              agents={agents}
+              task={task}
+              busy={busy}
+              onCancel={closePanel}
+              onSubmit={async (patch) => {
+                const ok = await run(
+                  c => reassignTaskRoles(c, code, task.id, patch, { name: me.name, client: 'web' }),
+                  'Reassign failed',
+                );
+                if (ok) closePanel();
+              }}
+            />
+          ) : (
+            <NotePanel
+              id={`task-note-${task.id}`}
+              label={panel === 'reject' ? 'What has to change before this passes?' : 'What exactly is missing?'}
+              submitLabel={panel === 'reject' ? 'Reject task' : 'Mark blocked'}
+              destructive
+              value={note}
+              onChange={setNote}
+              busy={busy}
+              onCancel={closePanel}
+              onSubmit={async () => {
+                const ok = await run(
+                  c => panel === 'reject'
+                    ? verifyTask(c, code, task.id, { name: me.name, client: 'web' }, 'rejected', note.trim())
+                    : blockTask(c, code, task.id, { name: me.name, client: 'web' }, note.trim()),
+                  panel === 'reject' ? 'Reject failed' : 'Block failed',
+                );
+                if (ok) closePanel();
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ReviewEvidence({ task }: { task: Task }) {
+  const [open, setOpen] = useState(false);
+  const ev = task.evidence;
+  return (
+    <div className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5">
+      <p className="text-[12px] leading-relaxed text-amber-900 break-words">
+        {task.readinessNote ?? 'Evidence submitted and waiting on a peer ruling.'}
+      </p>
+      {ev && (
+        <>
+          <button
+            type="button"
+            onClick={() => setOpen(v => !v)}
+            className="mt-2 text-[11px] font-semibold text-amber-800 underline underline-offset-2"
+          >
+            {open ? 'Hide evidence' : `Evidence from ${ev.submittedBy} (exit ${ev.exitCode})`}
+          </button>
+          {open && (
+            <div className="mt-2 space-y-2">
+              {([['Files', ev.fileListing], ['Excerpt', ev.fileExcerpt], ['Run output', ev.runOutput]] as const).map(([label, body]) => (
+                <div key={label}>
+                  <div className="text-[10px] font-bold uppercase tracking-wide text-amber-700">{label}</div>
+                  <pre className="mt-1 max-h-40 overflow-auto rounded-md bg-ink px-2.5 py-2 text-[11px] leading-relaxed text-white/90">
+                    <code>{body}</code>
+                  </pre>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Callout({ tone, title, body }: { tone: 'emerald' | 'rose'; title: string; body: string }) {
+  const skin = tone === 'emerald'
+    ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+    : 'border-rose-200 bg-rose-50 text-rose-800';
+  return (
+    <div className={`mt-2 rounded-lg border p-2.5 ${skin}`}>
+      <div className="text-[11px] font-bold">{title}</div>
+      <p className="mt-0.5 text-[12px] leading-relaxed break-words">{body}</p>
+    </div>
+  );
+}
+
+function NotePanel({ id, label, submitLabel, destructive, value, onChange, busy, onCancel, onSubmit }: {
+  id: string;
+  label: string;
+  submitLabel: string;
+  destructive?: boolean;
+  value: string;
+  onChange: (v: string) => void;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="mt-3 rounded-lg border border-border bg-surface-softer p-2.5">
+      <label className="block text-[11px] font-semibold text-ink-muted" htmlFor={id}>{label}</label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        rows={3}
+        className={`mt-1.5 ${FIELD} resize-none py-2 leading-relaxed`}
+      />
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          disabled={busy || !value.trim()}
+          onClick={onSubmit}
+          className={`${CTRL} flex-1 ${destructive ? 'bg-rose-600 text-white hover:bg-rose-700' : 'bg-accent text-white hover:opacity-90'}`}
+        >
+          {submitLabel}
+        </button>
+        <button type="button" onClick={onCancel} className={`${CTRL} border border-border bg-white text-ink-muted`}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AssignPanel({ agents, task, busy, onCancel, onSubmit }: {
+  agents: Participant[];
+  task: Task;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (patch: { owner?: string; ownerClient?: 'cc'; verifier?: string; verifierClient?: 'cc' }) => void;
+}) {
+  const [owner, setOwner] = useState(task.owner ?? '');
+  const [verifier, setVerifier] = useState(task.verifier ?? '');
+  // An empty select omits the field from the patch, so the existing holder
+  // survives. Validate the pair the server will actually end up with, and
+  // case-insensitively, the way reassignTaskRoles does.
+  const resultOwner = owner || task.owner;
+  const resultVerifier = verifier || task.verifier;
+  const conflict = Boolean(resultOwner) && Boolean(resultVerifier)
+    && resultOwner!.trim().toLowerCase() === resultVerifier!.trim().toLowerCase();
+  const unchanged = !owner && !verifier;
+
+  return (
+    <div className="mt-3 space-y-2 rounded-lg border border-border bg-surface-softer p-2.5">
+      <AgentSelect id={`owner-${task.id}`} label="Owner" value={owner} onChange={setOwner} agents={agents} anyLabel="Leave unchanged" />
+      <AgentSelect id={`verifier-${task.id}`} label="Verifier" value={verifier} onChange={setVerifier} agents={agents} anyLabel="Leave unchanged" />
+      {conflict && (
+        <p className="text-[11px] font-semibold text-rose-700">
+          That leaves {resultOwner} as both owner and verifier. Nobody signs off on their own delivery.
+        </p>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy || conflict || unchanged}
+          onClick={() => onSubmit({
+            ...(owner ? { owner, ownerClient: 'cc' as const } : {}),
+            ...(verifier ? { verifier, verifierClient: 'cc' as const } : {}),
+          })}
+          className={`${CTRL} flex-1 bg-accent text-white hover:opacity-90`}
+        >
+          Save roles
+        </button>
+        <button type="button" onClick={onCancel} className={`${CTRL} border border-border bg-white text-ink-muted`}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AgentSelect({ id, label, value, onChange, agents, anyLabel }: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  agents: Participant[];
+  anyLabel: string;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-[11px] font-semibold text-ink-muted">{label}</label>
+      <select id={id} value={value} onChange={e => onChange(e.target.value)} className={`mt-1 ${FIELD} font-semibold`}>
+        <option value="">{anyLabel}</option>
+        {agents.map(a => <option key={`${a.name}-${a.client}`} value={a.name}>{a.name}</option>)}
+      </select>
+    </div>
+  );
+}
+
+function NewTaskForm({ agents, busy, onCancel, onSubmit }: {
+  agents: Participant[];
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (input: { title: string; dod?: string; owner?: string; ownerClient?: 'cc'; verifier?: string; verifierClient?: 'cc' }) => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [dod, setDod] = useState('');
+  const [owner, setOwner] = useState(agents[0]?.name ?? '');
+  const [verifier, setVerifier] = useState(agents.find(a => a.name !== agents[0]?.name)?.name ?? '');
+  const conflict = Boolean(owner) && owner === verifier;
+
+  return (
+    <form
+      className="mt-3 space-y-2.5 rounded-lg border border-border bg-surface-softer p-3"
+      onSubmit={e => {
+        e.preventDefault();
+        if (!title.trim() || conflict) return;
+        onSubmit({
+          title: title.trim(),
+          ...(dod.trim() ? { dod: dod.trim() } : {}),
+          ...(owner ? { owner, ownerClient: 'cc' as const } : {}),
+          ...(verifier ? { verifier, verifierClient: 'cc' as const } : {}),
+        });
+      }}
+    >
+      <div>
+        <label htmlFor="new-task-title" className="block text-[11px] font-semibold text-ink-muted">What needs doing</label>
+        <input
+          id="new-task-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Add rate limiting to the login route"
+          autoFocus
+          className={`mt-1 ${FIELD}`}
+        />
+      </div>
+      <div>
+        <label htmlFor="new-task-dod" className="block text-[11px] font-semibold text-ink-muted">
+          Done when <span className="font-medium text-ink-faint">optional but recommended</span>
+        </label>
+        <textarea
+          id="new-task-dod"
+          value={dod}
+          onChange={e => setDod(e.target.value)}
+          rows={2}
+          placeholder="Tests pass and a 6th request inside a minute returns 429"
+          className={`mt-1 ${FIELD} resize-none py-2 leading-relaxed`}
+        />
+      </div>
+      {agents.length === 0 ? (
+        <p className="rounded-lg bg-white px-2.5 py-2 text-[11px] leading-relaxed text-ink-soft">
+          No agents in the room yet. Create the task anyway and assign it once an agent joins.
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 [&>*]:min-w-0">
+          <AgentSelect id="new-task-owner" label="Owner" value={owner} onChange={setOwner} agents={agents} anyLabel="Unassigned" />
+          <AgentSelect id="new-task-verifier" label="Verifier" value={verifier} onChange={setVerifier} agents={agents} anyLabel="Any peer" />
+        </div>
+      )}
+      {conflict && (
+        <p className="text-[11px] font-semibold text-rose-700">
+          Pick a different verifier. An agent cannot sign off on its own work.
+        </p>
+      )}
+      <div className="flex gap-2">
+        <button type="submit" disabled={busy || !title.trim() || conflict} className={`${CTRL} flex-1 bg-accent text-white hover:opacity-90`}>
+          {busy ? 'Creating' : 'Create task'}
+        </button>
+        <button type="button" onClick={onCancel} className={`${CTRL} border border-border bg-white text-ink-muted`}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function BoardSkeleton() {
+  return (
+    <div className="space-y-2.5" aria-hidden="true">
+      {[0, 1, 2].map(i => (
+        <div key={i} className="animate-pulse overflow-hidden rounded-xl border border-border-faint bg-surface">
+          <div className="flex">
+            <div className="w-1 shrink-0 bg-border" />
+            <div className="flex-1 space-y-2 p-3">
+              <div className="h-3 w-20 rounded bg-surface-sunken" />
+              <div className="h-4 w-3/4 rounded bg-surface-sunken" />
+              <div className="h-3 w-1/2 rounded bg-surface-sunken" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyBoard({ hasAgents }: { hasAgents: boolean }) {
+  return (
+    <div className="rounded-xl border border-dashed border-border bg-surface-softer p-5 text-center">
+      <h3 className="text-[13px] font-semibold text-ink">Nothing assigned yet</h3>
+      <p className="mx-auto mt-1.5 max-w-xs text-[12px] leading-relaxed text-ink-soft">
+        {hasAgents
+          ? 'Create a task to hand real work to an agent. Every task gets an owner and a different verifier, so nothing is done just because its owner says so.'
+          : 'Bring an agent into the room first, then create a task to hand it real work with an owner and a separate verifier.'}
+      </p>
+    </div>
+  );
+}
+
+function DeliverySection({ artifacts, canExport, reportBusy, onExportReport }: {
+  artifacts: RoomArtifact[];
+  canExport: boolean;
+  reportBusy: boolean;
+  onExportReport: () => void;
+}) {
+  return (
+    <section className="mt-6 border-t border-border-faint pt-4">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-ink">Delivery log</h2>
+        <span className="text-[11px] text-ink-soft">{artifacts.length}</span>
+      </div>
+      {artifacts.length ? (
+        <div className="mt-2.5 space-y-2">
+          {artifacts.slice(-8).reverse().map(a => (
+            <div key={a.id} className="rounded-lg border border-border-faint bg-surface-softer p-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[10px] font-bold uppercase tracking-wide text-ink-muted">{artifactLabel(a.kind)}</span>
+                <span className="text-[10px] text-ink-faint">{a.author}</span>
+              </div>
+              <p className="mt-1 text-[12px] leading-relaxed text-ink break-words">{a.text}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 rounded-lg border border-border-faint bg-surface-softer p-3 text-[12px] leading-relaxed text-ink-soft">
+          Mark a message with [DECISION], [TODO], [STATUS], or [RESULT] and it lands here.
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={onExportReport}
+        disabled={reportBusy || !canExport}
+        className={`mt-3 w-full ${CTRL} border border-accent-tint-border bg-accent-tint text-accent hover:bg-accent-tint-border`}
+      >
+        {reportBusy ? 'Saving' : 'Save and share report'}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/components/VoiceButton.tsx
+++ b/apps/web/src/components/VoiceButton.tsx
@@ -88,13 +88,16 @@ export function VoiceButton({ onTranscript, disabled }: Props) {
         onClick={listening ? stop : start}
         aria-label={listening ? 'Stop voice input' : 'Start voice input'}
         title={listening ? 'Stop voice input' : 'Start voice input'}
-        className={`text-base leading-none w-9 h-9 flex items-center justify-center rounded-lg transition ${
+        className={`leading-none w-10 h-10 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition ${
           listening
             ? 'bg-red-100 text-red-600 animate-pulse'
             : 'bg-surface-softer text-ink-soft hover:bg-accent-tint hover:text-accent'
         } disabled:opacity-50 disabled:cursor-not-allowed`}
       >
-        🎤
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="6" y="2" width="4" height="7" rx="2" />
+          <path d="M4 7.5a4 4 0 0 0 8 0M8 11.5V14" />
+        </svg>
       </button>
       {listening && interim && (
         <div className="absolute left-3 right-3 -top-7 px-3 py-1 bg-accent-tint text-accent-deep text-[11px] italic rounded-full shadow-sm truncate pointer-events-none">

--- a/apps/web/src/components/taskBoard.test.ts
+++ b/apps/web/src/components/taskBoard.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { Task, TaskState } from '@agent-room/shared';
+import { canRuleOn, partitionTasks } from './TaskBoard.js';
+
+function task(id: string, state: TaskState, extra: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `task ${id}`,
+    state,
+    createdBy: 'Robin',
+    createdAt: 0,
+    updatedAt: 0,
+    ...extra,
+  };
+}
+
+describe('partitionTasks', () => {
+  it('puts what needs a ruling first and drops closed states into the archive', () => {
+    const { open, closed } = partitionTasks([
+      task('T-01', 'todo'),
+      task('T-02', 'done', { updatedAt: 10 }),
+      task('T-03', 'awaiting_review'),
+      task('T-04', 'in_progress'),
+      task('T-05', 'blocked'),
+      task('T-06', 'cancelled', { updatedAt: 30 }),
+      task('T-07', 'rejected', { updatedAt: 20 }),
+    ]);
+
+    expect(open.map(t => t.id)).toEqual(['T-03', 'T-05', 'T-04', 'T-01']);
+    // Closed is newest-first so the most recent ruling is at the top.
+    expect(closed.map(t => t.id)).toEqual(['T-06', 'T-07', 'T-02']);
+  });
+
+  it('breaks ties within a state by id so the list does not reshuffle between polls', () => {
+    const { open } = partitionTasks([task('T-09', 'todo'), task('T-02', 'todo'), task('T-05', 'todo')]);
+    expect(open.map(t => t.id)).toEqual(['T-02', 'T-05', 'T-09']);
+  });
+});
+
+describe('canRuleOn', () => {
+  const web = { name: 'Robin', client: 'web' as const };
+
+  it('allows a non-owner peer when no verifier is designated', () => {
+    expect(canRuleOn(task('T-01', 'awaiting_review', { owner: 'Claude' }), web, false)).toBe(true);
+  });
+
+  it('never lets the owner rule on their own delivery', () => {
+    expect(canRuleOn(task('T-01', 'awaiting_review', { owner: 'Robin' }), web, false)).toBe(false);
+  });
+
+  it('locks ruling to the designated verifier', () => {
+    const t = task('T-01', 'awaiting_review', { owner: 'Claude', verifier: 'Codex' });
+    expect(canRuleOn(t, { name: 'Codex', client: 'web' }, false)).toBe(true);
+    expect(canRuleOn(t, web, false)).toBe(false);
+  });
+
+  it('only rules on submitted work, and never in an ended room', () => {
+    for (const state of ['todo', 'in_progress', 'blocked', 'done', 'rejected', 'cancelled'] as TaskState[]) {
+      expect(canRuleOn(task('T-01', state, { owner: 'Claude' }), web, false)).toBe(false);
+    }
+    expect(canRuleOn(task('T-01', 'awaiting_review', { owner: 'Claude' }), web, true)).toBe(false);
+  });
+
+  // A room can hold both "Robin - web" (the host) and "Robin - cc" (an agent).
+  // Matching on name alone hid Approve from the host whenever an agent shared
+  // their display name, even though the server would have accepted the ruling.
+  it('separates same-name participants by client, as the server does', () => {
+    const ownedByAgentRobin = task('T-01', 'awaiting_review', { owner: 'Robin', ownerClient: 'cc' });
+    expect(canRuleOn(ownedByAgentRobin, web, false)).toBe(true);
+    expect(canRuleOn(ownedByAgentRobin, { name: 'Robin', client: 'cc' }, false)).toBe(false);
+  });
+
+  it('treats an unrecorded owner client as a match, failing closed', () => {
+    expect(canRuleOn(task('T-01', 'awaiting_review', { owner: 'Robin' }), web, false)).toBe(false);
+  });
+
+  it('lets a designated verifier rule only from the recorded client', () => {
+    const t = task('T-01', 'awaiting_review', { owner: 'Claude', verifier: 'Robin', verifierClient: 'cc' });
+    expect(canRuleOn(t, web, false)).toBe(false);
+    expect(canRuleOn(t, { name: 'Robin', client: 'cc' }, false)).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useTaskBoard.ts
+++ b/apps/web/src/hooks/useTaskBoard.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TaskBoard } from '@agent-room/shared';
+import { ROOM_POLL_MS, ROOM_POLL_HIDDEN_MS } from '@agent-room/shared';
+import { createClient, getTaskBoard } from '@agent-room/upstash-client';
+import { ENV } from '../env.js';
+
+/**
+ * Polls the room's task board. The board already exists server-side (created
+ * by room_task via MCP); the web client was the only participant that never
+ * read it, so a host on a phone could not see what their agents were working
+ * on. Mirrors useRoom's visibility handling: slow down when hidden rather
+ * than stopping, so a backgrounded tab still catches state changes.
+ */
+export function useTaskBoard(code: string) {
+  const [board, setBoard] = useState<TaskBoard | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const clientRef = useRef(createClient(ENV.upstash));
+  const busyRef = useRef(false);
+
+  // Bumped whenever the effect re-runs for a new room. An in-flight fetch
+  // that resolves after the switch belongs to the old room, and two polls can
+  // resolve out of order, so a stale result is dropped rather than written.
+  const epochRef = useRef(0);
+
+  const reload = useCallback(async () => {
+    const epoch = epochRef.current;
+    try {
+      const next = await getTaskBoard(clientRef.current, code);
+      if (epoch !== epochRef.current) return;
+      setBoard(next);
+    } catch {
+      // Leave the last good board on screen; the next poll retries.
+    } finally {
+      if (epoch === epochRef.current) setLoaded(true);
+    }
+  }, [code]);
+
+  useEffect(() => {
+    epochRef.current += 1;
+    setBoard(null);
+    setLoaded(false);
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const start = (slow: boolean) => {
+      if (timer) return;
+      void reload();
+      timer = setInterval(() => void reload(), slow ? ROOM_POLL_HIDDEN_MS : ROOM_POLL_MS);
+    };
+    const stop = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const onVis = () => { stop(); start(document.hidden); };
+
+    document.addEventListener('visibilitychange', onVis);
+    start(document.hidden);
+    return () => {
+      document.removeEventListener('visibilitychange', onVis);
+      stop();
+    };
+  }, [code, reload]);
+
+  /**
+   * Runs one board mutation, then refreshes. Serialized via `busy` so a
+   * double-tap on a phone cannot fire two writes against the same CAS
+   * version. Errors surface as a toast and leave the board untouched.
+   */
+  const run = useCallback(async (
+    action: (client: ReturnType<typeof createClient>) => Promise<unknown>,
+    failureLabel: string,
+  ): Promise<boolean> => {
+    // Guard on a ref, not the `busy` state. Two taps inside one tick (an
+    // easy double-tap on a phone) both read the pre-render state value and
+    // would both fire a write against the same CAS version; the ref is
+    // already true by the time the second one checks.
+    if (busyRef.current) {
+      const { showToast } = await import('../components/Toast.js');
+      showToast('Still saving the last change, try again in a moment');
+      return false;
+    }
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      await action(clientRef.current);
+      await reload();
+      return true;
+    } catch (e) {
+      const { showToast } = await import('../components/Toast.js');
+      showToast(e instanceof Error ? `${failureLabel}: ${e.message}` : failureLabel);
+      return false;
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [reload]);
+
+  return { board, loaded, busy, reload, run };
+}

--- a/apps/web/src/screens/Room.tsx
+++ b/apps/web/src/screens/Room.tsx
@@ -1,13 +1,15 @@
 import { useRef, useState, useEffect, useCallback, type ClipboardEvent, type DragEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useRoom } from '../hooks/useRoom.js';
+import { useTaskBoard } from '../hooks/useTaskBoard.js';
 import { Bubble } from '../components/Bubble.js';
+import { TaskBoard, canRuleOn } from '../components/TaskBoard.js';
 import { VoiceButton } from '../components/VoiceButton.js';
 import { MeetingCodePill } from '../components/MeetingCodePill.js';
 import { Avatar } from '../components/Avatar.js';
 import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
 import { colorForName, initialsFor } from '../lib/colors.js';
-import { PRESENCE_STALE_MS, PRESENCE_DISCONNECTED_MS, artifactLabel, extractArtifacts, type ArtifactKind, type Message, type MessageAttachment, type Participant, type ReplyMode, type ReplyModeConfig, type RoomArtifact, type SystemEventType } from '@agent-room/shared';
+import { PRESENCE_STALE_MS, PRESENCE_DISCONNECTED_MS, extractArtifacts, type Message, type MessageAttachment, type Participant, type ReplyMode, type ReplyModeConfig, type SystemEventType } from '@agent-room/shared';
 import { appendSystemMessage, directInvoke, getTurnState, hostSkipCurrent, setMuted, setReplyMode, createClient, createRoomReport, endRoom as endRoomApi, reactivateRoom as reactivateRoomApi, removeParticipant, type TurnState } from '@agent-room/upstash-client';
 import { ENV } from '../env.js';
 import { copyText } from '../lib/copy.js';
@@ -286,9 +288,18 @@ export function Room() {
     }
   }
 
-  const [mobilePanel, setMobilePanel] = useState<'chat' | 'people' | 'outputs'>('chat');
+  const [mobilePanel, setMobilePanel] = useState<'chat' | 'tasks' | 'people'>('chat');
   const [reportBusy, setReportBusy] = useState(false);
   const artifacts = extractArtifacts(messages);
+  // Board lives here, not inside TaskBoard, so the tab strip can badge how
+  // many deliveries are waiting on a ruling while the user is on Chat.
+  const taskBoard = useTaskBoard(code);
+  const openTaskCount = taskBoard.board?.tasks.filter(
+    t => t.state !== 'done' && t.state !== 'rejected' && t.state !== 'cancelled',
+  ).length ?? 0;
+  const reviewTaskCount = taskBoard.board?.tasks.filter(
+    t => canRuleOn(t, { name: self?.name ?? '', client: 'web' }, ended),
+  ).length ?? 0;
 
   async function handleExportReport() {
     if (!room) return;
@@ -660,19 +671,27 @@ export function Room() {
   }
 
   return (
-    <div className="h-full flex items-center justify-center px-3 py-4">
-      <div className="w-full max-w-7xl h-[88vh] grid grid-rows-[auto_auto_1fr] bg-surface border border-border rounded-xl shadow-card overflow-hidden">
-        <header className="px-4 py-3 border-b border-border-faint flex justify-between items-center bg-surface">
-          <div className="min-w-0 flex items-center gap-3">
-            <AgentRoomLogo showWordmark={false} markClassName="h-8 w-8" />
+    <div className="h-full flex items-center justify-center p-0 sm:px-3 sm:py-4">
+      <div className="w-full max-w-7xl h-full sm:h-[88vh] grid grid-rows-[auto_auto_1fr] bg-surface border-0 sm:border border-border rounded-none sm:rounded-xl shadow-none sm:shadow-card overflow-hidden">
+        <header className="px-3.5 py-2.5 sm:px-4 sm:py-3 border-b border-border-faint flex justify-between items-center bg-surface shrink-0">
+          <div className="min-w-0 flex items-center gap-2.5 sm:gap-3">
+            <AgentRoomLogo showWordmark={false} markClassName="h-7 w-7 sm:h-8 sm:w-8" />
             <div className="min-w-0">
-              <div className="text-sm font-semibold truncate">{room.topic}</div>
-              <div className="text-[10px] text-ink-soft">
-                {ended ? <span className="text-red-500 font-semibold">Meeting ended</span> : `${room.participants.length} participants`}
+              <div className="text-xs sm:text-sm font-semibold truncate text-ink">{room.topic}</div>
+              <div className="text-[10px] text-ink-soft flex items-center gap-1.5">
+                {ended ? (
+                  <span className="text-red-500 font-semibold">Meeting ended</span>
+                ) : (
+                  <>
+                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
+                    <span>{room.participants.length} participants</span>
+                    <span className="hidden lg:inline">· {messages.length} messages</span>
+                  </>
+                )}
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 shrink-0">
             <div className="hidden sm:flex">
               {room.participants.slice(0, 5).map((p, i) => (
                 <div key={p.name} style={{ marginLeft: i === 0 ? 0 : -6 }} className="ring-2 ring-white rounded-full">
@@ -682,7 +701,7 @@ export function Room() {
             </div>
             <button
               onClick={() => copyText(joinUrl, 'Invite link copied')}
-              className="text-[10px] font-semibold text-accent bg-accent-tint px-2 py-1 rounded hover:bg-accent/20"
+              className="text-[11px] sm:text-[10px] font-semibold text-accent bg-accent-tint px-2.5 py-1.5 sm:px-2 sm:py-1 rounded-md hover:bg-accent/20 active:scale-95 transition"
             >
               Share
             </button>
@@ -690,42 +709,66 @@ export function Room() {
           </div>
         </header>
 
-        <div className="lg:hidden grid grid-cols-3 gap-1 border-b border-border-faint bg-surface p-2 text-[11px]">
-          {[
-            ['chat', 'Chat'],
-            ['people', 'People'],
-            ['outputs', 'Outputs'],
-          ].map(([key, label]) => (
-            <button
-              key={key}
-              onClick={() => setMobilePanel(key as 'chat' | 'people' | 'outputs')}
-              className={`rounded-lg px-2 py-1.5 font-semibold ${mobilePanel === key ? 'bg-accent text-white' : 'text-ink-soft bg-surface-softer'}`}
-            >
-              {label}
-            </button>
-          ))}
+        {/*
+          Mobile tab strip. Tasks sits second because handing work to an agent
+          and ruling on what came back is the reason a host opens this on a
+          phone; People is the occasional admin trip. 44px targets (the old
+          38px row was hard to hit one-handed), and the Tasks tab carries an
+          amber count when deliveries are waiting on a ruling so the signal
+          reaches the user while they are still reading Chat.
+        */}
+        <div className="lg:hidden grid grid-cols-3 gap-1.5 border-b border-border-faint bg-surface-softer p-1.5 shrink-0" role="tablist">
+          {([
+            ['chat', 'Chat', messages.length, false],
+            ['tasks', 'Tasks', openTaskCount, reviewTaskCount > 0],
+            ['people', 'People', room.participants.length, false],
+          ] as const).map(([key, label, count, alert]) => {
+            const active = mobilePanel === key;
+            return (
+              <button
+                key={key}
+                role="tab"
+                aria-selected={active}
+                onClick={() => setMobilePanel(key)}
+                className={`min-h-11 rounded-lg px-2 text-[13px] font-semibold flex items-center justify-center gap-1.5 transition active:scale-[0.98] ${
+                  active
+                    ? 'bg-accent text-white shadow-sm'
+                    : 'text-ink-muted hover:text-ink bg-surface border border-border-faint'
+                }`}
+              >
+                <span>{label}</span>
+                <span
+                  className={`text-[11px] px-1.5 py-0.5 rounded-full font-bold ${
+                    active
+                      ? 'bg-white/25 text-white'
+                      : alert
+                        ? 'bg-amber-100 text-amber-800'
+                        : 'bg-surface-sunken text-ink-faint'
+                  }`}
+                >
+                  {alert ? `${reviewTaskCount} review` : count}
+                </span>
+              </button>
+            );
+          })}
         </div>
 
-        <div className="min-h-0 grid lg:grid-cols-[260px_minmax(0,1fr)_300px] bg-surface-soft">
-          <aside className={`${mobilePanel === 'people' ? 'flex' : 'hidden'} lg:flex min-h-0 flex-col border-r border-border-faint bg-surface`}>
+        <div className="min-h-0 min-w-0 overflow-x-hidden grid lg:grid-cols-[260px_minmax(0,1fr)_340px] bg-surface-soft">
+          <aside className={`${mobilePanel === 'people' ? 'flex' : 'hidden'} lg:flex min-h-0 min-w-0 flex-col border-r border-border-faint bg-surface`}>
             <div className="p-4 border-b border-border-faint">
-              <div className="text-[10px] font-semibold uppercase text-ink-faint mb-2">Room</div>
-              <h2 className="text-sm font-semibold leading-snug">{room.topic}</h2>
-              <div className="mt-3">
+              <h2 className="hidden lg:block text-sm font-semibold leading-snug">{room.topic}</h2>
+              <div className="hidden lg:block mt-3">
                 <MeetingCodePill code={code} />
               </div>
               <button
                 onClick={() => copyText(joinUrl, 'Invite link copied')}
-                className="mt-3 w-full text-[11px] font-semibold text-accent bg-accent-tint px-3 py-2 rounded-lg hover:bg-accent/20"
+                className="mt-3 w-full min-h-10 sm:min-h-8 text-[13px] sm:text-xs font-semibold text-accent bg-accent-tint px-3 rounded-lg transition active:scale-[0.98] hover:bg-accent/20"
               >
                 Copy invite link
               </button>
-              <div className="mt-3 rounded-lg border border-border-faint bg-surface-softer p-2.5">
+              <div className="mt-3 lg:mt-3 rounded-lg border border-border-faint bg-surface-softer p-2.5">
                 <div className="mb-2 flex items-center justify-between gap-2">
-                  <span className="text-[10px] font-semibold uppercase text-ink-faint">Reply mode</span>
-                  <span className="rounded bg-white px-1.5 py-0.5 text-[9px] font-semibold text-ink-soft">
-                    {modeLabel(replyMode)}
-                  </span>
+                  <span className="text-[12px] font-semibold text-ink-muted">Who replies</span>
                 </div>
                 {canConfigureReplyMode ? (
                   <div className="space-y-2">
@@ -733,7 +776,7 @@ export function Room() {
                       value={replyMode}
                       onChange={e => { void updateReplyMode(e.target.value as ReplyMode); }}
                       disabled={modeBusy}
-                      className="h-9 w-full rounded-md border border-border bg-white px-2 text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
+                      className="h-11 sm:h-9 w-full rounded-lg border border-border bg-white px-2.5 text-[15px] sm:text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
                     >
                       <option value="open">Open</option>
                       <option value="sequential">Sequential</option>
@@ -744,7 +787,7 @@ export function Room() {
                         value={selectedLeadAgentName}
                         onChange={e => { void updateReplyMode('sequential', { leadAgentName: e.target.value, leadAgentClient: 'cc' }); }}
                         disabled={modeBusy || activeRoomAgents.length === 0}
-                        className="h-9 w-full rounded-md border border-border bg-white px-2 text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
+                        className="h-11 sm:h-9 w-full rounded-lg border border-border bg-white px-2.5 text-[15px] sm:text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
                         aria-label="Lead agent"
                       >
                         {activeRoomAgents.length === 0 ? (
@@ -759,7 +802,7 @@ export function Room() {
                         value={selectedModeratorAgentName}
                         onChange={e => { void updateReplyMode('moderator', { moderatorAgentName: e.target.value, moderatorAgentClient: 'cc' }); }}
                         disabled={modeBusy || activeRoomAgents.length === 0}
-                        className="h-9 w-full rounded-md border border-border bg-white px-2 text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
+                        className="h-11 sm:h-9 w-full rounded-lg border border-border bg-white px-2.5 text-[15px] sm:text-xs font-semibold text-ink outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint disabled:opacity-60"
                         aria-label="Moderator agent"
                       >
                         {activeRoomAgents.length === 0 ? (
@@ -773,10 +816,10 @@ export function Room() {
                       <div className="rounded-md border border-border-faint bg-white px-2 py-1.5">
                         <div className="flex items-center justify-between gap-2">
                           <div className="min-w-0">
-                            <div className="truncate text-[11px] font-semibold text-ink">
+                            <div className="truncate text-[12px] font-semibold text-ink">
                               {currentSpeaker ? `Now: ${currentSpeaker.name}` : 'No active turn'}
                             </div>
-                            <div className="text-[9px] text-ink-soft">
+                            <div className="text-[11px] text-ink-soft">
                               {currentSpeaker && currentDeadlineMs !== null
                                 ? `${Math.ceil(currentDeadlineMs / 1000)}s left`
                                 : 'Waiting'}
@@ -787,7 +830,7 @@ export function Room() {
                               type="button"
                               onClick={() => { void handleSkipCurrent(); }}
                               disabled={modeBusy}
-                              className="h-7 rounded-md border border-amber-200 bg-amber-50 px-2 text-[10px] font-semibold text-amber-700 transition hover:bg-amber-100 disabled:opacity-60"
+                              className="h-10 sm:h-8 rounded-lg border border-amber-200 bg-amber-50 px-3 text-[12px] sm:text-[11px] font-semibold text-amber-700 transition active:scale-[0.98] hover:bg-amber-100 disabled:opacity-60"
                             >
                               Skip
                             </button>
@@ -803,10 +846,7 @@ export function Room() {
             </div>
 
             <div className="flex-1 overflow-y-auto p-4">
-              <div className="text-[10px] font-semibold uppercase text-ink-faint mb-1">Participants</div>
-              <p className="mb-3 text-[10px] leading-relaxed text-ink-soft">
-                Listening = inside an active listen window. Disconnected = no heartbeat for 5+ min, likely the CLI session was killed without leaving cleanly — host can remove with the × button.
-              </p>
+              <div className="mb-2.5 text-[13px] font-semibold text-ink">In the room</div>
               <div className="space-y-2">
                 {room.participants.map(p => {
                   const isMeHost = room.createdBy === self.name;
@@ -831,15 +871,15 @@ export function Room() {
                     >
                       <Avatar initials={p.initials} color={p.color} size="sm" />
                       <div className="min-w-0 flex-1">
-                        <div className="text-xs font-semibold truncate flex items-center gap-1 flex-wrap">
+                        <div className="text-[13px] sm:text-xs font-semibold truncate flex items-center gap-1 flex-wrap">
                           {p.name}
-                          {p.name === room.createdBy && <span className="text-[9px] font-semibold text-accent bg-accent-tint px-1 py-px rounded">host</span>}
-                          {isMuted && <span className="text-[9px] font-semibold text-amber-700 bg-amber-100 px-1 py-px rounded">muted</span>}
+                          {p.name === room.createdBy && <span className="text-[10px] font-semibold text-accent bg-accent-tint px-1.5 py-0.5 rounded">host</span>}
+                          {isMuted && <span className="text-[10px] font-semibold text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded">muted</span>}
                         </div>
-                        <div className="text-[10px] text-ink-soft truncate">
-                          {[p.role, p.client].filter(Boolean).join(' · ')}
+                        <div className="text-[11px] text-ink-soft truncate">
+                          {[p.role, p.client === 'cc' ? 'CLI' : 'browser'].filter(Boolean).join(' · ')}
                         </div>
-                        <div className={`mt-0.5 flex items-center gap-1 text-[9px] font-medium ${presence.className}`}>
+                        <div className={`mt-1 flex items-center gap-1 text-[11px] font-medium ${presence.className}`}>
                           <span className={`h-1.5 w-1.5 rounded-full ${presence.dotClassName}`} />
                           <span>{presence.label}</span>
                           {presence.detail && <span className="text-ink-faint">· {presence.detail}</span>}
@@ -862,7 +902,7 @@ export function Room() {
                               title={`Ask ${p.name}`}
                               aria-label={`Ask ${p.name}`}
                               disabled={modeBusy}
-                              className="flex h-7 min-w-7 items-center justify-center rounded-md border border-accent-tint-border bg-accent-tint px-1.5 text-[10px] font-semibold text-accent transition hover:bg-accent-tint-border disabled:opacity-60"
+                              className="flex h-10 min-w-10 sm:h-8 sm:min-w-8 items-center justify-center rounded-lg border border-accent-tint-border bg-accent-tint px-2.5 text-[12px] sm:text-[11px] font-semibold text-accent transition hover:bg-accent-tint-border active:scale-[0.98] disabled:opacity-60"
                             >
                               Ask
                             </button>
@@ -872,7 +912,7 @@ export function Room() {
                               onClick={() => handleToggleMute({ name: p.name, client: p.client, canSpeak: p.canSpeak })}
                               title={isMuted ? `Unmute ${p.name}` : `Mute ${p.name}`}
                               aria-label={isMuted ? `Unmute ${p.name}` : `Mute ${p.name}`}
-                              className={`flex h-7 w-7 items-center justify-center rounded-md border text-[11px] transition ${isMuted
+                              className={`flex h-10 w-10 sm:h-8 sm:w-8 items-center justify-center rounded-lg border text-[11px] transition active:scale-[0.98] ${isMuted
                                 ? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
                                 : 'border-border-faint bg-surface text-ink-soft hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700'}`}
                             >
@@ -895,7 +935,7 @@ export function Room() {
                               onClick={() => handleKick({ name: p.name, client: p.client })}
                               title={`Remove ${p.name}`}
                               aria-label={`Remove ${p.name}`}
-                              className="flex h-7 w-7 items-center justify-center rounded-md border border-border-faint bg-surface text-ink-soft transition hover:border-red-300 hover:bg-red-50 hover:text-red-600"
+                              className="flex h-10 w-10 sm:h-8 sm:w-8 items-center justify-center rounded-lg border border-border-faint bg-surface text-ink-soft transition active:scale-[0.98] hover:border-red-300 hover:bg-red-50 hover:text-red-600"
                             >
                               <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" aria-hidden="true">
                                 <path d="m4 4 8 8M12 4l-8 8" />
@@ -914,19 +954,19 @@ export function Room() {
               {!ended && room.createdBy === self.name && (
                 <button
                   onClick={handleEndMeeting}
-                  className="flex-1 text-[11px] font-semibold text-red-600 bg-red-50 px-3 py-2 rounded-lg hover:bg-red-100"
+                  className="flex-1 min-h-10 sm:min-h-8 text-[13px] sm:text-xs font-semibold text-red-600 bg-red-50 px-3 rounded-lg transition active:scale-[0.98] hover:bg-red-100"
                 >
                   End
                 </button>
               )}
-              <button onClick={() => navigate('/')} className="flex-1 text-[11px] font-semibold text-ink-muted bg-surface-softer px-3 py-2 rounded-lg">
+              <button onClick={() => navigate('/')} className="flex-1 min-h-10 sm:min-h-8 text-[13px] sm:text-xs font-semibold text-ink-muted bg-surface-softer px-3 rounded-lg transition active:scale-[0.98]">
                 Home
               </button>
             </div>
           </aside>
 
-          <section className={`${mobilePanel === 'chat' ? 'flex' : 'hidden'} lg:flex min-h-0 flex-col`}>
-            <div className="px-5 py-3 border-b border-border-faint bg-surface flex items-center justify-between">
+          <section className={`${mobilePanel === 'chat' ? 'flex' : 'hidden'} lg:flex min-h-0 min-w-0 flex-col`}>
+            <div className="hidden lg:flex px-5 py-3 border-b border-border-faint bg-surface items-center justify-between">
               <div>
                 <div className="text-sm font-semibold">Discussion</div>
                 <div className="text-[10px] text-ink-soft">Live room chat</div>
@@ -934,7 +974,7 @@ export function Room() {
               {ended && <span className="text-[10px] font-semibold text-red-500">Ended</span>}
             </div>
 
-            <div ref={feedRef} className="flex-1 overflow-y-auto p-5 flex flex-col gap-3 bg-surface-soft relative">
+            <div ref={feedRef} className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden p-3 sm:p-5 flex flex-col gap-3 bg-surface-soft relative">
               {(() => {
                 // Names that appear with more than one client in the room get
                 // disambiguated as "Name · web" / "Name · cc" in each bubble.
@@ -954,6 +994,26 @@ export function Room() {
                   />
                 ));
               })()}
+
+              {messages.length === 0 && (
+                <div className="m-auto max-w-xs px-2 text-center">
+                  <h2 className="text-[15px] font-semibold text-ink">Nothing said yet</h2>
+                  <p className="mt-2 text-[13px] leading-relaxed text-ink-soft">
+                    {roomAgents.length === 0
+                      ? 'Share the room code and tell your agent to join it. Once it is here, tap its name above the message box to hand it work.'
+                      : 'Tap an agent name above the message box to address it, or open Tasks to hand it something with a definition of done.'}
+                  </p>
+                  {roomAgents.length === 0 && (
+                    <button
+                      type="button"
+                      onClick={() => copyText(joinUrl, 'Invite link copied')}
+                      className="mt-4 min-h-10 rounded-lg bg-accent px-4 text-[13px] font-semibold text-white shadow-sm transition active:scale-[0.98] hover:opacity-90"
+                    >
+                      Copy invite link
+                    </button>
+                  )}
+                </div>
+              )}
 
               {showIdlePrompt && !ended && (
                 <div className="sticky bottom-0 mx-auto bg-white border border-border rounded-xl shadow-lg p-4 text-center max-w-sm">
@@ -1020,15 +1080,20 @@ export function Room() {
               </div>
             ) : !myCanSpeak ? (
               <div className="border-t border-border-faint p-5 bg-amber-50 text-center">
-                <div className="text-2xl mb-1">🔇</div>
+                <div className="mb-2 flex justify-center text-amber-700">
+                  <svg viewBox="0 0 16 16" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M8 3.5 4.5 6.25H2.5v3.5h2L8 12.5z" />
+                    <path d="m11 6 3 4M14 6l-3 4" />
+                  </svg>
+                </div>
                 <p className="text-sm font-semibold text-amber-900 mb-1">You've been muted by the host</p>
                 <p className="text-xs text-amber-800/80 max-w-xs mx-auto">
-                  The host ({room.createdBy}) has muted your messages. You can still read the conversation — ask them to unmute (🔊) when you're ready to speak again.
+                  The host ({room.createdBy}) has muted your messages. You can still read the conversation. Ask them to unmute you when you are ready to speak again.
                 </p>
               </div>
             ) : (
               <div
-                className={`relative border-t border-border-faint p-3 bg-surface flex flex-col gap-2 transition ${dragActive ? 'ring-2 ring-inset ring-accent bg-accent-tint/40' : ''}`}
+                className={`relative min-w-0 border-t border-border-faint p-2.5 sm:p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] bg-surface flex flex-col gap-2 transition ${dragActive ? 'ring-2 ring-inset ring-accent bg-accent-tint/40' : ''}`}
                 onDragEnter={handleDragEnter}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
@@ -1041,8 +1106,11 @@ export function Room() {
                 )}
                 {isHost && mutedCount > 0 && (
                   <div className="text-[11px] font-semibold text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5 flex items-center gap-2">
-                    <span>🔇</span>
-                    <span>{mutedCount} {mutedCount === 1 ? 'participant is' : 'participants are'} muted — open the People panel to unmute (🔊).</span>
+                    <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="shrink-0">
+                      <path d="M8 3.5 4.5 6.25H2.5v3.5h2L8 12.5z" />
+                      <path d="m11 6 3 4M14 6l-3 4" />
+                    </svg>
+                    <span>{mutedCount} {mutedCount === 1 ? 'participant is' : 'participants are'} muted. Open People to unmute.</span>
                   </div>
                 )}
                 {attachments.length > 0 && (
@@ -1056,144 +1124,142 @@ export function Room() {
                     ))}
                   </div>
                 )}
-                <div className="flex flex-wrap items-center gap-2 text-[10px]">
-                  <span className="font-semibold text-ink-faint">Ask your agents:</span>
+                {/*
+                  Command deck. Targeting an agent used to live only as an
+                  "Ask" button inside each People row, so on a phone giving one
+                  agent a job meant leaving Chat, finding the row, tapping Ask,
+                  then coming back. The agents are now chips on the composer
+                  itself: tap to address one (or to hand it the turn directly
+                  in sequential / moderator mode) without losing the thread.
+                */}
+                <div className="flex w-full min-w-0 flex-wrap items-center gap-2 py-0.5 shrink-0">
+                  {roomAgents.length === 0 ? (
+                    messages.length > 0 && (
+                      <span className="w-full text-[12px] text-ink-soft">
+                        No agents here yet. Share the room code to bring one in.
+                      </span>
+                    )
+                  ) : (
+                    roomAgents.map(agent => {
+                      const muted = agent.canSpeak === false;
+                      return (
+                        <button
+                          key={`${agent.name}-${agent.client}`}
+                          type="button"
+                          disabled={modeBusy || muted}
+                          onClick={() => { void handleAskAgent(agent); }}
+                          title={muted ? `${agent.name} is muted` : `Ask ${agent.name}`}
+                          className="shrink-0 min-h-10 rounded-full border border-accent-tint-border bg-accent-tint px-3.5 text-[13px] font-semibold text-accent transition hover:bg-accent-tint-border active:scale-[0.98] disabled:opacity-45 disabled:cursor-not-allowed"
+                        >
+                          @{agent.name}
+                        </button>
+                      );
+                    })
+                  )}
+                  {roomAgents.length > 0 && (<>
                   <button
                     type="button"
                     onClick={() => fillPrompt('minutes')}
-                    className="rounded-full border border-accent-tint-border bg-accent-tint px-2.5 py-1 font-semibold text-accent hover:bg-accent-tint-border transition"
+                    className="shrink-0 min-h-10 rounded-full border border-border bg-surface-softer px-3.5 text-[13px] font-semibold text-ink-muted transition hover:border-accent/40 hover:text-accent active:scale-[0.98]"
                   >
-                    Ask for minutes
+                    Minutes
                   </button>
                   <button
                     type="button"
                     onClick={() => fillPrompt('reply')}
-                    className="rounded-full border border-border bg-surface-softer px-2.5 py-1 font-semibold text-ink-muted hover:border-accent/40 hover:text-accent transition"
+                    className="shrink-0 min-h-10 rounded-full border border-border bg-surface-softer px-3.5 text-[13px] font-semibold text-ink-muted transition hover:border-accent/40 hover:text-accent active:scale-[0.98]"
                   >
-                    Ask for reply draft
+                    Reply draft
                   </button>
-                  <span className="hidden sm:inline text-ink-faint">Prefills your message. You choose the agent and send.</span>
+                  </>)}
                 </div>
-                <div className="flex items-center gap-2">
-                  <VoiceButton
-                    onTranscript={(t) => setText(prev => prev.trim() ? `${prev.trim()} ${t}` : t)}
-                    disabled={ended}
-                  />
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    className="hidden"
-                    accept={Array.from(ALLOWED_ATTACHMENT_TYPES).join(',')}
-                    onChange={e => { if (e.target.files) void addFiles(e.target.files); }}
-                  />
-                  <button
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={attachBusy || attachments.length >= MAX_ATTACHMENTS_PER_MESSAGE}
-                    title="Attach files"
-                    className="h-9 rounded-lg bg-surface-softer border border-border px-2 text-xs font-semibold text-ink-muted disabled:opacity-50"
-                  >
-                    {attachBusy ? '...' : 'Attach'}
-                  </button>
-                  <textarea
-                    ref={textareaRef}
-                    value={text}
-                    onChange={e => setText(e.target.value)}
-                    onPaste={e => { void handlePaste(e); }}
-                    onKeyDown={e => {
-                      // Enter sends; Shift+Enter / IME composition lets newlines through.
-                      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                        e.preventDefault();
-                        send();
-                      }
-                    }}
-                    placeholder="Message the room… (Enter to send, Shift+Enter for newline)"
-                    rows={1}
-                    style={{ height: TEXTAREA_MIN_HEIGHT, maxHeight: TEXTAREA_MAX_HEIGHT }}
-                    className="flex-1 resize-none overflow-y-auto px-3 py-2 bg-surface-softer border border-border rounded-lg text-sm leading-relaxed outline-none focus:border-accent focus:ring-4 focus:ring-accent-tint"
-                  />
-                  <button
-                    onClick={send}
-                    disabled={!text.trim() && attachments.length === 0}
-                    className="self-end bg-accent text-white px-4 py-2 rounded-lg text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    Send
-                  </button>
+                <div className="flex flex-col sm:flex-row sm:items-end gap-2">
+                  <div className="relative flex-1 min-w-0">
+                    <textarea
+                      ref={textareaRef}
+                      value={text}
+                      onChange={e => setText(e.target.value)}
+                      onPaste={e => { void handlePaste(e); }}
+                      onKeyDown={e => {
+                        // Desktop: Enter sends; Shift+Enter for new line.
+                        // Mobile touch: let Enter insert a newline so user can type freely without accidental send.
+                        const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+                        if (!isTouch && e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                          e.preventDefault();
+                          send();
+                        }
+                      }}
+                      placeholder="Message the room…"
+                      rows={1}
+                      style={{ height: TEXTAREA_MIN_HEIGHT, maxHeight: TEXTAREA_MAX_HEIGHT }}
+                      className="w-full resize-none overflow-y-auto px-3.5 py-2.5 bg-surface-softer border border-border rounded-xl text-base sm:text-sm leading-relaxed outline-none focus:border-accent focus:ring-2 focus:ring-accent-tint"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between sm:justify-start gap-2 shrink-0">
+                    <div className="flex items-center gap-1.5">
+                      <VoiceButton
+                        onTranscript={(t) => setText(prev => prev.trim() ? `${prev.trim()} ${t}` : t)}
+                        disabled={ended}
+                      />
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        accept={Array.from(ALLOWED_ATTACHMENT_TYPES).join(',')}
+                        onChange={e => { if (e.target.files) void addFiles(e.target.files); }}
+                      />
+                      <button
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={attachBusy || attachments.length >= MAX_ATTACHMENTS_PER_MESSAGE}
+                        title="Attach files"
+                        className="h-10 w-10 sm:h-9 sm:w-auto justify-center rounded-lg bg-surface-softer border border-border sm:px-2 text-xs font-semibold text-ink-muted disabled:opacity-50 flex items-center gap-1.5 active:scale-95 transition"
+                      >
+                        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                          <path d="M13 7.5v3a4 4 0 0 1-8 0v-5a2.5 2.5 0 0 1 5 0v5a1 1 0 0 1-2 0v-4.5" />
+                        </svg>
+                        <span className="hidden sm:inline sm:text-xs">{attachBusy ? '...' : 'Attach'}</span>
+                      </button>
+                    </div>
+                    <button
+                      onClick={send}
+                      disabled={!text.trim() && attachments.length === 0}
+                      className="min-h-[40px] sm:min-h-[36px] min-w-[78px] sm:min-w-[64px] bg-accent text-white px-5 sm:px-4 py-2 rounded-xl text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition shadow-sm flex items-center justify-center gap-1.5"
+                    >
+                      <span>Send</span>
+                      <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true">
+                        <path d="M1.5 1.5l13 6.5-13 6.5 2-6.5-2-6.5zm3.2 6.5h5.8-5.8z" />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
             )}
           </section>
 
-          <aside className={`${mobilePanel === 'outputs' ? 'flex' : 'hidden'} lg:flex min-h-0 flex-col border-l border-border-faint bg-surface`}>
-            <div className="p-4 border-b border-border-faint">
-              <div className="text-[10px] font-semibold uppercase text-ink-faint mb-2">Outputs</div>
-              <div className="grid grid-cols-2 gap-2">
-                <div className="rounded-lg bg-surface-softer border border-border-faint p-2">
-                  <div className="text-base font-semibold">{messages.length}</div>
-                  <div className="text-[10px] text-ink-soft">Messages</div>
-                </div>
-                <div className="rounded-lg bg-surface-softer border border-border-faint p-2">
-                  <div className="text-base font-semibold">{room.participants.length}</div>
-                  <div className="text-[10px] text-ink-soft">People</div>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex-1 min-h-0 overflow-y-auto p-4">
-              <div className="mb-5 rounded-xl border border-accent-tint-border bg-accent-tint p-4">
-                <h2 className="text-sm font-semibold text-accent-deep mb-2">Report</h2>
-                <p className="text-[11px] leading-relaxed text-accent-deep/80 mb-3">Freeze this room into a shareable delivery report.</p>
-                <button
-                  onClick={handleExportReport}
-                  disabled={reportBusy || messages.length === 0}
-                  className="w-full bg-accent text-white text-[11px] font-semibold px-3 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {reportBusy ? 'Saving…' : 'Save & Share'}
-                </button>
-              </div>
-
-              <div className="mb-5">
-                <div className="flex items-center justify-between mb-3">
-                  <h2 className="text-sm font-semibold">Artifacts</h2>
-                  <span className="text-[10px] text-ink-soft">{artifacts.length}</span>
-                </div>
-                {artifacts.length ? (
-                  <div className="space-y-2">
-                    {artifacts.slice(-8).reverse().map(artifact => (
-                      <ArtifactCard key={artifact.id} artifact={artifact} />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="rounded-lg border border-border-faint bg-surface-softer p-3 text-[11px] leading-relaxed text-ink-soft">
-                    Use [DECISION], [TODO], [STATUS], or [RESULT] in messages to build the delivery log.
-                  </div>
-                )}
-              </div>
-
-              <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-semibold">Minutes</h2>
-              </div>
-              <div className="rounded-lg border border-border-faint bg-surface-softer p-3 text-[11px] leading-relaxed text-ink-soft">
-                Ask an agent to generate minutes from the composer. The result will appear in the transcript and can be captured in the delivery report.
-              </div>
-            </div>
+          <aside className={`${mobilePanel === 'tasks' ? 'flex' : 'hidden'} lg:flex min-h-0 min-w-0 flex-col border-l border-border-faint bg-surface`}>
+            {/*
+              The task board the MCP server has always had (room_task: owner,
+              a different verifier, evidence, verdicts) but the web client
+              never rendered. Before this, a host on a phone could only infer
+              agent progress from chat prose and regex-scraped [TODO] markers.
+            */}
+            <TaskBoard
+              code={code}
+              me={me}
+              isHost={isHost}
+              ended={ended}
+              agents={roomAgents}
+              artifacts={artifacts}
+              canExport={messages.length > 0}
+              reportBusy={reportBusy}
+              onExportReport={handleExportReport}
+              onMention={appendText}
+              taskBoard={taskBoard}
+            />
           </aside>
         </div>
       </div>
-    </div>
-  );
-}
-
-function ArtifactCard({ artifact }: { artifact: RoomArtifact }) {
-  return (
-    <div className="rounded-lg border border-border-faint bg-surface-softer p-3">
-      <div className="mb-1 flex items-center justify-between gap-2">
-        <span className={`text-[9px] font-semibold uppercase ${artifactTone(artifact.kind)}`}>
-          {artifactLabel(artifact.kind)}
-        </span>
-        <span className="text-[9px] text-ink-faint">{artifact.author}</span>
-      </div>
-      <p className="text-[11px] leading-relaxed text-ink">{artifact.text}</p>
     </div>
   );
 }
@@ -1219,19 +1285,6 @@ function PendingAttachment({ attachment, onRemove }: { attachment: MessageAttach
   );
 }
 
-function artifactTone(kind: ArtifactKind): string {
-  switch (kind) {
-    case 'decision':
-      return 'text-emerald-700';
-    case 'todo':
-      return 'text-amber-700';
-    case 'status':
-      return 'text-blue-700';
-    case 'result':
-      return 'text-violet-700';
-  }
-}
-
 function participantPresence(p: Participant, now: number) {
   if (p.listenUntil && p.listenUntil > now) {
     return {
@@ -1247,7 +1300,7 @@ function participantPresence(p: Participant, now: number) {
     return {
       kind: 'online' as const,
       label: 'Online',
-      detail: p.client === 'cc' ? 'hook unknown' : '',
+      detail: '',
       className: 'text-blue-700',
       dotClassName: 'bg-blue-500',
     };

--- a/packages/upstash-client/src/rooms.ts
+++ b/packages/upstash-client/src/rooms.ts
@@ -6,6 +6,7 @@ import type {
 } from '@agent-room/shared';
 import { AVATAR_PALETTE, DEFAULT_TURN_TIMEOUTS_MS, PRESENCE_DISCONNECTED_MS, ROOM_TTL_SECONDS } from '@agent-room/shared';
 import type { UpstashClient } from './client.js';
+import { sha256Hex } from './sha256.js';
 import { RoomNotFoundError, ConcurrencyError } from './errors.js';
 
 function roomKey(code: string): string { return `room:${code}`; }
@@ -21,11 +22,10 @@ function generateHostKey(): string {
   return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-async function sha256Hex(input: string): Promise<string> {
-  const cryptoObj: Crypto = (globalThis as unknown as { crypto: Crypto }).crypto;
-  const buf = await cryptoObj.subtle.digest('SHA-256', new TextEncoder().encode(input));
-  return Array.from(new Uint8Array(buf), b => b.toString(16).padStart(2, '0')).join('');
-}
+// Hashing goes through sha256.ts, which falls back to a pure-JS SHA-256 when
+// `crypto.subtle` is missing. That happens on any non-secure origin, notably
+// the dev server opened on a phone at http://<lan-ip>:5173, where this used to
+// throw and take room creation down with it.
 
 export interface CreateRoomInput {
   code: string;

--- a/packages/upstash-client/src/sha256.ts
+++ b/packages/upstash-client/src/sha256.ts
@@ -1,0 +1,89 @@
+// Pure-JS SHA-256, used only when WebCrypto's subtle API is unavailable.
+//
+// Why this exists: `crypto.subtle` is exposed ONLY in a secure context, which
+// means HTTPS or localhost. Opening the dev server on a phone over a plain
+// HTTP LAN address (http://192.168.x.x:5173) leaves `crypto.subtle` undefined,
+// so hashing the host key threw "Cannot read properties of undefined (reading
+// 'digest')" and creating a room failed outright. Production is HTTPS and was
+// never affected; testing on a real device was.
+//
+// This is a byte-exact SHA-256, not a weaker substitute: sha256.test.ts pins
+// every output against WebCrypto's own digest, so the stored `hostKeyHash` is
+// identical whichever path produced it.
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+function rotr(x: number, n: number): number {
+  return ((x >>> n) | (x << (32 - n))) >>> 0;
+}
+
+/** Synchronous SHA-256 over a UTF-8 string, returned as lowercase hex. */
+export function sha256HexSync(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const bitLenHi = Math.floor((bytes.length * 8) / 0x100000000);
+  const bitLenLo = (bytes.length * 8) >>> 0;
+  // message + 0x80 marker + 8-byte length, rounded up to whole 64-byte blocks
+  const blocks = Math.ceil((bytes.length + 9) / 64);
+  const buf = new Uint8Array(blocks * 64);
+  buf.set(bytes);
+  buf[bytes.length] = 0x80;
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(blocks * 64 - 8, bitLenHi, false);
+  dv.setUint32(blocks * 64 - 4, bitLenLo, false);
+
+  let h0 = 0x6a09e667, h1 = 0xbb67ae85, h2 = 0x3c6ef372, h3 = 0xa54ff53a;
+  let h4 = 0x510e527f, h5 = 0x9b05688c, h6 = 0x1f83d9ab, h7 = 0x5be0cd19;
+  const w = new Uint32Array(64);
+
+  for (let block = 0; block < blocks; block++) {
+    const off = block * 64;
+    for (let i = 0; i < 16; i++) w[i] = dv.getUint32(off + i * 4, false);
+    for (let i = 16; i < 64; i++) {
+      const p = w[i - 15]!, q = w[i - 2]!;
+      const s0 = (rotr(p, 7) ^ rotr(p, 18) ^ (p >>> 3)) >>> 0;
+      const s1 = (rotr(q, 17) ^ rotr(q, 19) ^ (q >>> 10)) >>> 0;
+      w[i] = (w[i - 16]! + s0 + w[i - 7]! + s1) >>> 0;
+    }
+
+    let a = h0, b = h1, c = h2, d = h3, e = h4, f = h5, g = h6, h = h7;
+    for (let i = 0; i < 64; i++) {
+      const S1 = (rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)) >>> 0;
+      const ch = ((e & f) ^ (~e & g)) >>> 0;
+      const t1 = (h + S1 + ch + K[i]! + w[i]!) >>> 0;
+      const S0 = (rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)) >>> 0;
+      const maj = ((a & b) ^ (a & c) ^ (b & c)) >>> 0;
+      const t2 = (S0 + maj) >>> 0;
+      h = g; g = f; f = e; e = (d + t1) >>> 0;
+      d = c; c = b; b = a; a = (t1 + t2) >>> 0;
+    }
+
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0; h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0; h5 = (h5 + f) >>> 0; h6 = (h6 + g) >>> 0; h7 = (h7 + h) >>> 0;
+  }
+
+  return [h0, h1, h2, h3, h4, h5, h6, h7]
+    .map(x => x.toString(16).padStart(8, '0'))
+    .join('');
+}
+
+/**
+ * SHA-256 hex, preferring WebCrypto and falling back to the JS implementation
+ * when `crypto.subtle` is missing (any non-secure context).
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const cryptoObj: Crypto | undefined = (globalThis as unknown as { crypto?: Crypto }).crypto;
+  if (cryptoObj?.subtle) {
+    const buf = await cryptoObj.subtle.digest('SHA-256', new TextEncoder().encode(input));
+    return Array.from(new Uint8Array(buf), b => b.toString(16).padStart(2, '0')).join('');
+  }
+  return sha256HexSync(input);
+}

--- a/packages/upstash-client/test/sha256.test.ts
+++ b/packages/upstash-client/test/sha256.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { sha256Hex, sha256HexSync } from '../src/sha256.js';
+
+async function viaWebCrypto(input: string): Promise<string> {
+  const buf = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf), b => b.toString(16).padStart(2, '0')).join('');
+}
+
+describe('sha256HexSync', () => {
+  it('matches the published vectors', async () => {
+    expect(sha256HexSync('')).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+    expect(sha256HexSync('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  // The fallback only earns its place if it is byte-identical to the path it
+  // replaces: a host key hashed on a LAN phone must verify against one hashed
+  // in a browser on HTTPS.
+  it('agrees with WebCrypto across lengths, unicode and block boundaries', async () => {
+    const cases = [
+      '',
+      'a',
+      'abc',
+      'host-key-3f9a2c1b8e4d7605',
+      'ห้องประชุม agent room',
+      'x'.repeat(55),  // one byte under a padded block
+      'x'.repeat(56),  // forces a second block
+      'x'.repeat(64),
+      'x'.repeat(1000),
+    ];
+    for (const input of cases) {
+      expect(sha256HexSync(input), `mismatch for ${JSON.stringify(input.slice(0, 24))}`)
+        .toBe(await viaWebCrypto(input));
+    }
+  });
+});
+
+describe('sha256Hex', () => {
+  it('produces the same digest whether or not crypto.subtle exists', async () => {
+    const input = 'host-key-3f9a2c1b8e4d7605';
+    const withSubtle = await sha256Hex(input);
+
+    // Simulate a plain-HTTP LAN origin, where the browser exposes `crypto`
+    // but not `crypto.subtle`. This is the case that broke room creation.
+    const real = globalThis.crypto;
+    try {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { getRandomValues: real.getRandomValues.bind(real) },
+        configurable: true,
+      });
+      expect(await sha256Hex(input)).toBe(withSubtle);
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: real, configurable: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

`room_task` is a complete evidence-gated board server-side: owner, a *different* verifier, three-part evidence, verdicts, leases, subtasks. The web client never read it. The Outputs panel regex-scraped `[TODO]` markers out of chat prose instead, so the one human in the room could not see what their agents were actually working on, and had no way to hand out work with a definition of done.

Most of this PR is surfacing what already exists rather than adding new capability.

## What changed

**The board is now rendered.** Create a task with an owner and a separate verifier; approve or reject submitted work with the evidence inline; block, reassign, reopen. Ordered by what needs a ruling rather than by id, with closed work collapsed.

`canRuleOn` mirrors `verifyTask`'s server guards exactly, including the `(name, client)` identity match, so the UI never offers a button the server will reject. `taskBoard.test.ts` pins that, since the two can silently drift. Notably, matching on name alone hid Approve from a host who shares a display name with the agent that owns the task, which is a collision the codebase already handles elsewhere in `Bubble.tsx`.

**Mobile.** Tabs are Chat / Tasks / People, with a count when deliveries await a ruling. Agent targeting moved onto the composer; it previously existed only as an "Ask" button inside each People row, so addressing one agent meant leaving the conversation and coming back. Panels were grid items with `min-h-0` but no `min-w-0`, so long task titles pushed content up to 152px past the clipping edge at 320px wide. Touch targets are 40px throughout. Empty rooms get an empty state instead of half a screen of blank grey. Internal jargon is gone from the UI (`cc` reads as CLI, `hook unknown` removed), and emoji glyphs are replaced with the inline SVG language used elsewhere in the app.

**Room creation over plain HTTP is fixed.** `crypto.subtle` exists only in a secure context, so opening the dev server on a phone at `http://<lan-ip>:5173` left it `undefined` and `sha256Hex` threw `Cannot read properties of undefined (reading 'digest')` before a room could be created. Production over HTTPS was never affected; testing on a real device was impossible. `sha256.ts` falls back to a byte-exact JS SHA-256, pinned against WebCrypto's own digest across lengths, unicode and block boundaries, so `hostKeyHash` is identical whichever path runs. No weakening, and the fallback only engages where the secure API is absent.

## Verification

- `tsc --noEmit` clean; web 15/15, upstash-client 193/193; `vite build` clean
- Playwright against the LAN origin with an iPhone 13 profile (390x664 @3x): zero elements past the right edge at 320 / 360 / 390, no console errors
- The clipping regression was measured before and after rather than assumed: 152px / 112px / 82px past the edge at 320 / 360 / 390 beforehand, zero after
- Room creation confirmed working with `crypto.subtle available: false`

## Note for the reviewer

`Room.tsx` also carries a small pre-existing local change of mine that predates this work and could not be cleanly separated: the responsive header and its presence indicator. Happy to split it out if you would rather take it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2RkCumW7zbViNkvo96DXt
