### PR TITLE
feat: take the join URL wherever a room code is expected

### DIFF
--- a/apps/web/src/components/AgentJoinQuickstart.tsx
+++ b/apps/web/src/components/AgentJoinQuickstart.tsx
@@ -91,7 +91,11 @@ export function AgentJoinQuickstart({ roomCode }: Props) {
       ? 'Prints pasteable configs instead of installing automatically.'
       : 'Run this once. It detects installed clients on this machine and installs every match automatically.';
 
-  const agentPrompt = `Join agent-room ${roomCode} as <your agent name>. After room_join, stay in a room_listen loop: on quiet timeout, call room_listen again with the same cursor; use room_send when you need to speak. Stop only if the host ends the room, removes you, or tells you to leave.`;
+  // Two lines. Everything else an agent needs to know is in the server's own
+  // instructions and tool descriptions, which its client reads at connect —
+  // pasting a paragraph of the same guidance only costs the agent context.
+  // room_join takes the URL as-is, so there is no code to extract first.
+  const agentPrompt = `Join this Agent Room and stay in it: ${joinUrl}\nCall room_join with that link, then keep the room_listen loop running until I tell you to stop.`;
 
   return (
     <div className="mb-5 border border-border-faint rounded-lg overflow-hidden">

--- a/packages/shared/src/codeGen.ts
+++ b/packages/shared/src/codeGen.ts
@@ -24,3 +24,25 @@ const VALID_RE = new RegExp(
 export function isValidCode(code: string): boolean {
   return VALID_RE.test(code);
 }
+
+const CODE_LEN = CODE_SEGMENT_LEN * CODE_SEGMENTS;
+
+/**
+ * Accept what an agent actually has in hand: a join URL, a lowercase code, a
+ * code someone typed without dashes. Returns the canonical dashed code, or
+ * null when the input holds no code at all.
+ */
+export function parseRoomCode(input: string): string | null {
+  if (typeof input !== 'string') return null;
+  let candidate = input.trim();
+  // A URL (with or without scheme): the code is the last path segment.
+  const fromUrl = candidate.match(/(?:^|\/)(?:j|r)\/([^/?#\s]+)/i);
+  if (fromUrl) candidate = fromUrl[1]!;
+  else if (/[/?#]/.test(candidate)) candidate = candidate.split(/[?#]/)[0]!.split('/').filter(Boolean).pop() ?? '';
+  const bare = candidate.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  if (bare.length !== CODE_LEN) return null;
+  const parts: string[] = [];
+  for (let i = 0; i < CODE_SEGMENTS; i++) parts.push(bare.slice(i * CODE_SEGMENT_LEN, (i + 1) * CODE_SEGMENT_LEN));
+  const code = parts.join('-');
+  return isValidCode(code) ? code : null;
+}

--- a/packages/shared/test/codeGen.test.ts
+++ b/packages/shared/test/codeGen.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateCode, isValidCode, CODE_CHARS } from '../src/index.js';
+import { generateCode, isValidCode, parseRoomCode, CODE_CHARS } from '../src/index.js';
 
 describe('generateCode', () => {
   it('returns a string in XXX-XXX-XXX format', () => {
@@ -50,5 +50,44 @@ describe('isValidCode', () => {
 
   it('is case sensitive (uppercase only)', () => {
     expect(isValidCode('abc-def-ghj')).toBe(false);
+  });
+});
+
+describe('parseRoomCode', () => {
+  it('passes a canonical code straight through', () => {
+    const code = generateCode();
+    expect(parseRoomCode(code)).toBe(code);
+  });
+
+  it('accepts the join URLs an agent is actually handed', () => {
+    for (const input of [
+      'https://www.agent-room.com/j/ABC-DEF-GHJ',
+      'https://www.agent-room.com/r/ABC-DEF-GHJ',
+      'www.agent-room.com/j/ABC-DEF-GHJ',
+      'agent-room.com/j/abc-def-ghj',
+      'https://www.agent-room.com/j/ABC-DEF-GHJ?utm=x#top',
+      'https://www.agent-room.com/j/ABC-DEF-GHJ/',
+    ]) {
+      expect(parseRoomCode(input), input).toBe('ABC-DEF-GHJ');
+    }
+  });
+
+  it('accepts a lowercase, undashed, or padded code', () => {
+    expect(parseRoomCode('abc-def-ghj')).toBe('ABC-DEF-GHJ');
+    expect(parseRoomCode('ABCDEFGHJ')).toBe('ABC-DEF-GHJ');
+    expect(parseRoomCode('  abc def ghj  ')).toBe('ABC-DEF-GHJ');
+  });
+
+  it('returns null rather than inventing a code', () => {
+    for (const input of ['', 'hello', 'https://www.agent-room.com/', 'ABC-DEF', 'ABC-DEF-GHJK', 'AB1-DEF-GHJ']) {
+      expect(parseRoomCode(input), input).toBeNull();
+    }
+  });
+
+  it('never produces a code isValidCode rejects', () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateCode();
+      expect(isValidCode(parseRoomCode(`https://www.agent-room.com/j/${code.toLowerCase()}`)!)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Syncs the change released as `agent-room-mcp@0.26.24` (agent-room-alkl/agent-room-mcp#35, #36) and shipped on hosted `/mcp`.

## Why

What a user hands an agent is a link — `https://www.agent-room.com/j/ABC-DEF-GHJ`. Asking the agent to extract a 9-character substring before it can call `room_join` is a step it can get wrong, and one more excuse to answer in prose instead of calling the tool.

## What

`parseRoomCode` in `@agent-room/shared`:

| input | → |
| --- | --- |
| `https://www.agent-room.com/j/ABC-DEF-GHJ` | `ABC-DEF-GHJ` |
| `https://www.agent-room.com/r/ABC-DEF-GHJ?utm=x#top` | `ABC-DEF-GHJ` |
| `agent-room.com/j/abc-def-ghj` | `ABC-DEF-GHJ` |
| `abc-def-ghj` / `ABCDEFGHJ` | `ABC-DEF-GHJ` |
| `hello`, `ABC-DEF`, `AB1-DEF-GHJ` | `null` |

It returns `null` rather than inventing a code, so a caller leaves unreadable input untouched and the error still names what was sent. The MCP server (0.26.24) normalizes with this once at its `CallTool` entry, so `room_join`, `room_listen`, `room_send` and the rest all take either spelling.

The web quickstart's copy button now pastes two lines — the join URL and one sentence — instead of a paragraph restating what the MCP server already tells every client in its own instructions at connect.

## Verification

- 5 new `parseRoomCode` cases in `packages/shared/test/codeGen.test.ts`; `npm test` → `1 + 107 + 193 + 15` pass.
- 4 suites fail (`member-auth`, `redis`, `task-leases`, `postgres.integration`) — the identical set fails on `main` with these changes stashed.
- `apps/web` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)