### PR TITLE
chore: keep deliverables/ out of a public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ apps/web/src/**/*.d.ts.map
 # Local-only strategic notes (z.html etc)
 z.html
 # Internal handoff / strategy / cleanup docs — never publish
+# deliverables/ is a working directory for client-facing documents; it is
+# untracked on purpose, and this repo is public, so `git add -A` must not
+# be able to sweep it in.
+deliverables/
 HANDOFF.md
 agentroom-research-report.html
 agent_room_cleanup.md


### PR DESCRIPTION
`deliverables/` is a working directory for client-facing documents, kept untracked on purpose. This repo is **public**, so "untracked on purpose" is one `git add -A` away from published.

That is exactly what happened while preparing #54: `Agent_Room_Interview_Guide_EN.docx` (672 KB) was swept into a commit and pushed. The branch was force-pushed within about two minutes and #54 contains only the clean commit, but the orphaned commit is still served by SHA until GitHub garbage-collects it.

One line, so it cannot happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)