### PR TITLE
fix(join): tell a browsing agent to call room_join, on the page it la…

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/prerender.mjs",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -1,0 +1,100 @@
+// No shebang: this module is imported by prerender.test.ts, and vite-node
+// evaluates module source through vm.Script, which does not strip one.
+// It is only ever run as `node scripts/prerender.mjs` from the build script.
+/**
+ * Post-vite prerender for the room routes.
+ *
+ * /j/:code and /r/:code fall through the SPA rewrite to dist/index.html, whose
+ * #root is empty until React boots. An agent that fetches the HTML without
+ * running JS therefore gets a blank page and no way to know the room is
+ * reachable over MCP. These shells carry the same join-over-MCP notice the
+ * React component renders (components/AgentJoinNotice.tsx), so both readers get
+ * the same text. They are per-room URLs, so they are noindex.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { buildJoinPageAgentNotice } from '@agent-room/shared';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST = join(__dirname, '..', 'dist');
+
+const ROUTES = [
+  {
+    path: '/j',
+    file: 'j/index.html',
+    title: 'Join a room — Agent Room',
+    description: 'Join an Agent Room meeting. AI agents should join over MCP with room_join rather than this page.',
+  },
+  {
+    path: '/r',
+    file: 'r/index.html',
+    title: 'Agent Room',
+    description: 'An Agent Room meeting. AI agents should join over MCP with room_join rather than this page.',
+  },
+];
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function setAttr(html, tagPattern, attr, value) {
+  const re = new RegExp(`(<${tagPattern}[^>]*\\s${attr}=)("[^"]*"|'[^']*')`, 'i');
+  if (re.test(html)) return html.replace(re, `$1"${escapeHtml(value)}"`);
+  return html;
+}
+
+function setTitle(html, title) {
+  return html.replace(/<title>[^<]*<\/title>/i, `<title>${escapeHtml(title)}</title>`);
+}
+
+function setNoIndex(html) {
+  if (/<meta[^>]*name=["']robots["']/i.test(html)) {
+    return setAttr(html, 'meta[^>]*name=["\']robots["\']', 'content', 'noindex');
+  }
+  return html.replace(/<\/head>/i, '  <meta name="robots" content="noindex" />\n  </head>');
+}
+
+// The code is only in the URL, which this build step cannot see, so the notice
+// is emitted in its no-code form — buildJoinPageAgentNotice still names the
+// tool and its arguments, and the agent already has the code it navigated to.
+function injectAgentRoot(html) {
+  const lines = buildJoinPageAgentNotice()
+    .map(line => `<p>${escapeHtml(line)}</p>`)
+    .join('');
+  const shell = `<main data-agent-notice="join-over-mcp"><h1>For AI agents</h1>${lines}</main>`;
+  return html.replace(/<div id="root"><\/div>/i, `<div id="root">${shell}</div>`);
+}
+
+function applyRoute(template, route) {
+  let html = template;
+  html = setTitle(html, route.title);
+  html = setAttr(html, 'meta[^>]*name=["\']description["\']', 'content', route.description);
+  html = setNoIndex(html);
+  html = injectAgentRoot(html);
+  return html;
+}
+
+function main() {
+  const templatePath = join(DIST, 'index.html');
+  if (!existsSync(templatePath)) {
+    console.error(`[prerender] missing ${templatePath} — run vite build first`);
+    process.exit(1);
+  }
+  const template = readFileSync(templatePath, 'utf8');
+  for (const route of ROUTES) {
+    const out = join(DIST, route.file);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, applyRoute(template, route));
+    console.log(`[prerender] wrote ${route.file} → ${route.path}`);
+  }
+}
+
+export { ROUTES, applyRoute };
+
+// Importable from tests; still runs as the build step.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/apps/web/scripts/prerender.test.ts
+++ b/apps/web/scripts/prerender.test.ts
@@ -1,0 +1,46 @@
+// Without these shells the room routes fall through the SPA rewrite to
+// dist/index.html, whose #root is empty until React boots — an agent that
+// fetches the HTML without running JS gets a blank page.
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - plain .mjs build script, deliberately untyped
+import { ROUTES, applyRoute } from './prerender.mjs';
+
+const TEMPLATE = [
+  '<!doctype html><html><head>',
+  '<title>shell</title>',
+  '<meta name="description" content="shell" />',
+  '<meta name="robots" content="index, follow" />',
+  '</head><body><div id="root"></div></body></html>',
+].join('\n');
+
+describe('room route prerender', () => {
+  it('covers both room URL shapes', () => {
+    expect(ROUTES.map((r: { path: string }) => r.path).sort()).toEqual(['/j', '/r']);
+    expect(ROUTES.map((r: { file: string }) => r.file).sort()).toEqual(['j/index.html', 'r/index.html']);
+  });
+
+  it.each(ROUTES)('$path serves the join-over-MCP notice', (route: unknown) => {
+    const html = applyRoute(TEMPLATE, route);
+
+    expect(html).toContain('data-agent-notice="join-over-mcp"');
+    expect(html).toContain('room_join');
+    expect(html).toContain('room_listen');
+    expect(html).toContain('deferred, not missing');
+    // #root must still be replaced on hydrate, so the SPA has to boot.
+    expect(html).toContain('<div id="root">');
+  });
+
+  it.each(ROUTES)('$path is noindex — these URLs are per-room', (route: unknown) => {
+    const html = applyRoute(TEMPLATE, route);
+    expect(html).toContain('content="noindex"');
+    expect(html).not.toContain('content="index, follow"');
+  });
+
+  it('escapes the notice into the shell', () => {
+    const html = applyRoute(TEMPLATE, ROUTES[0]);
+    // The notice contains an ALL_TOOLS filter with `=>` and `/…/` in it.
+    expect(html).not.toMatch(/<p>[^<]*=><\/p>/);
+    expect(html).toContain('&gt;');
+  });
+});

--- a/apps/web/src/components/AgentJoinNotice.tsx
+++ b/apps/web/src/components/AgentJoinNotice.tsx
@@ -1,0 +1,34 @@
+import { buildJoinPageAgentNotice } from '@agent-room/shared';
+
+/**
+ * The redirect an agent reads when it opened a room page instead of calling
+ * room_join.
+ *
+ * Handed a bare room URL, a browser-driving client opens the page and reads its
+ * accessibility tree — it never sees the MCP server's own `instructions`,
+ * because a client that lazy-loads MCP tools does not put them in the model's
+ * context until after the first tool call. The page is the last point where the
+ * choice can still be corrected, so this must stay IN that tree: de-emphasized
+ * for humans, but never `hidden`, `aria-hidden`, `sr-only`, or inside a
+ * collapsed <details> — every one of those drops it from the tree and quietly
+ * undoes the point.
+ *
+ * Kept in sync with the prerendered copy in scripts/prerender.mjs, which serves
+ * the same lines to clients that fetch HTML without running JS.
+ */
+export function AgentJoinNotice({ code }: { code?: string }) {
+  const lines = buildJoinPageAgentNotice(code);
+  return (
+    <section
+      data-agent-notice="join-over-mcp"
+      className="mb-4 rounded-lg border border-dashed border-border-faint bg-surface-softer px-3 py-2.5"
+    >
+      <h2 className="text-[9px] font-semibold uppercase tracking-widest text-ink-faint">
+        For AI agents
+      </h2>
+      <div className="mt-1 space-y-1 text-[10px] leading-relaxed text-ink-faint">
+        {lines.map(line => <p key={line}>{line}</p>)}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/screens/Join.tsx
+++ b/apps/web/src/screens/Join.tsx
@@ -7,6 +7,7 @@ import { ENV } from '../env.js';
 import { CodeInput } from '../components/CodeInput.js';
 import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
 import { AgentJoinQuickstart } from '../components/AgentJoinQuickstart.js';
+import { AgentJoinNotice } from '../components/AgentJoinNotice.js';
 import { colorForName, initialsFor } from '../lib/colors.js';
 
 function stripDashes(s: string) { return s.replace(/-/g, ''); }
@@ -91,6 +92,8 @@ export function Join() {
       <div className="max-w-md mx-auto mt-10 p-8 bg-surface border border-border rounded-xl shadow-card">
       <h1 className="text-lg font-semibold tracking-tight">Join a meeting</h1>
       <p className="text-xs text-ink-soft mt-1 mb-6">Enter the 9-character code from your invite.</p>
+
+      <AgentJoinNotice code={raw.length === CODE_LEN ? withDashes(raw) : undefined} />
 
       <div className="mb-4">
         <CodeInput value={raw} onChange={setRaw} />

--- a/apps/web/src/screens/Room.tsx
+++ b/apps/web/src/screens/Room.tsx
@@ -8,6 +8,7 @@ import { VoiceButton } from '../components/VoiceButton.js';
 import { MeetingCodePill } from '../components/MeetingCodePill.js';
 import { Avatar } from '../components/Avatar.js';
 import { AgentRoomLogo } from '../components/AgentRoomLogo.js';
+import { AgentJoinNotice } from '../components/AgentJoinNotice.js';
 import { colorForName, initialsFor } from '../lib/colors.js';
 import { PRESENCE_STALE_MS, PRESENCE_DISCONNECTED_MS, extractArtifacts, type Message, type MessageAttachment, type Participant, type ReplyMode, type ReplyModeConfig, type SystemEventType } from '@agent-room/shared';
 import { appendSystemMessage, directInvoke, getTurnState, hostSkipCurrent, setMuted, setReplyMode, createClient, createRoomReport, endRoom as endRoomApi, reactivateRoom as reactivateRoomApi, removeParticipant, type TurnState } from '@agent-room/upstash-client';
@@ -338,7 +339,19 @@ export function Room() {
   }, []);
 
   if (error) return <div className="p-10 text-red-600">{error}</div>;
-  if (!self) return <div className="p-10 text-ink-soft">Redirecting to join…</div>;
+  // An agent handed /r/CODE lands here, not on Join: there is no stored
+  // identity, so the effect above bounces it to /j/CODE. That bounce is a
+  // client-side navigation, and an agent that snapshots the page before it
+  // settles would otherwise read a bare "Redirecting to join…" and learn
+  // nothing. Carry the same notice through the interstitial.
+  if (!self) {
+    return (
+      <div className="mx-auto max-w-md p-10">
+        <AgentJoinNotice code={code} />
+        <div className="text-ink-soft">Redirecting to join…</div>
+      </div>
+    );
+  }
   if (!room) return <div className="p-10 text-ink-soft">Loading…</div>;
 
   // From here down `self` is non-null (early-returned above). Capture it in a

--- a/apps/web/src/screens/agentJoinSurfaces.test.ts
+++ b/apps/web/src/screens/agentJoinSurfaces.test.ts
@@ -1,0 +1,81 @@
+// Guards the surfaces an agent reaches when it opened a room page instead of
+// calling room_join. There is no DOM test setup here, so these are source-level
+// invariants — worth pinning because each regression they catch is invisible in
+// review and only shows up as an agent silently joining as a web participant.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(here, rel), 'utf8');
+
+describe('AgentJoinNotice', () => {
+  const file = read('../components/AgentJoinNotice.tsx');
+  // The doc comment above the component names the very escapes this asserts
+  // against, so scan the component itself, not the file.
+  const src = file.slice(file.indexOf('export function AgentJoinNotice'));
+
+  // A browser-driving agent reads the accessibility tree, so anything that
+  // takes the notice out of that tree makes it useless — while still looking
+  // perfectly reasonable in the diff.
+  it('stays in the accessibility tree', () => {
+    expect(src).not.toBe('');
+    for (const escape of ['aria-hidden', 'sr-only', 'hidden', 'display:none', 'display: none', '<details']) {
+      expect(src).not.toContain(escape);
+    }
+  });
+});
+
+describe('/j/:code', () => {
+  const src = read('Join.tsx');
+
+  it('shows the notice above the human form', () => {
+    expect(src).toContain('<AgentJoinNotice');
+    expect(src.indexOf('<AgentJoinNotice')).toBeLessThan(src.indexOf('<CodeInput'));
+  });
+
+  it('passes the room code through once the URL supplies one', () => {
+    expect(src).toContain('raw.length === CODE_LEN ? withDashes(raw) : undefined');
+  });
+});
+
+describe('/r/:code', () => {
+  const src = read('Room.tsx');
+
+  // Visiting /r/CODE without a stored identity bounces to /j/CODE. That bounce
+  // is client-side, so the interstitial has to carry the notice too — an agent
+  // may snapshot the page before the redirect settles.
+  it('carries the notice through the redirect interstitial', () => {
+    const start = src.indexOf('if (!self) {');
+    expect(start).toBeGreaterThan(-1);
+    // The comment above the branch quotes the same string, so search forward.
+    const branch = src.slice(start, src.indexOf('Redirecting to join', start) + 20);
+    expect(branch).toContain('<AgentJoinNotice code={code} />');
+  });
+});
+
+describe('vercel rewrites', () => {
+  const config = JSON.parse(read('../../../../vercel.json')) as {
+    rewrites: { source: string; destination: string }[];
+  };
+  const at = (source: string) => config.rewrites.findIndex(r => r.source === source);
+
+  // Order is the whole point: the SPA catch-all matches /j/:code too, so a room
+  // route placed after it would never reach its own shell.
+  it('routes room URLs to their own shell before the SPA catch-all', () => {
+    const catchAll = at('/((?!api/).*)');
+    expect(catchAll).toBeGreaterThan(-1);
+    for (const [source, destination] of [['/j/:code', '/j/index.html'], ['/r/:code', '/r/index.html']]) {
+      const i = at(source!);
+      expect(i).toBeGreaterThan(-1);
+      expect(config.rewrites[i]!.destination).toBe(destination);
+      expect(i).toBeLessThan(catchAll);
+    }
+  });
+
+  it('keeps the report bot rewrite ahead of /r/:code', () => {
+    expect(at('/r/:code/report')).toBeLessThan(at('/r/:code'));
+  });
+});

--- a/packages/shared/src/agentJoinNotice.test.ts
+++ b/packages/shared/src/agentJoinNotice.test.ts
@@ -1,0 +1,48 @@
+// SERVER_INSTRUCTIONS cannot steer a client that lazy-loads MCP tools: the text
+// first reaches the model inside a tool result, after it has already picked
+// between the browser and room_join. These lines are the fallback for that case,
+// so they have to stand alone.
+
+import { describe, it, expect } from 'vitest';
+import { buildJoinPageAgentNotice, AGENT_ROOM_MCP_URL } from './agentJoinNotice.js';
+
+const CODE = 'ABC-DEF-GHJ';
+const text = (code?: string) => buildJoinPageAgentNotice(code).join('\n');
+
+describe('buildJoinPageAgentNotice', () => {
+  it('tells the agent not to use the page it is looking at', () => {
+    const t = text(CODE);
+    // Shown on /r/CODE too, where there is no form — so it cannot presuppose one.
+    expect(t).toContain('this page is for humans');
+    expect(t).toContain('do not join as a web participant');
+    expect(t).toContain('Do not fall back to this page');
+  });
+
+  it('carries a callable room_join, not a description of one', () => {
+    const t = text(CODE);
+    expect(t).toContain(AGENT_ROOM_MCP_URL);
+    expect(t).toContain(`room_join({ code: "${CODE}", name: "<your agent name>" })`);
+    // The observed failure was the agent stopping to ask for a display name.
+    expect(t).toContain('do not ask the user for one');
+  });
+
+  it('explains that a missing tool is a deferred tool', () => {
+    const t = text(CODE);
+    expect(t).toContain('deferred, not missing');
+    expect(t).toContain('agent_room');
+    expect(t).toContain('ALL_TOOLS');
+  });
+
+  it('covers staying in the room, not just getting in', () => {
+    const t = text(CODE);
+    expect(t).toContain('room_listen');
+    expect(t).toContain('quiet timeout is not a stop condition');
+    expect(t).toContain('reply with no tool call ends your turn');
+  });
+
+  it('still names the tool when the code is not known yet', () => {
+    const t = text();
+    expect(t).toContain('room_join({ code, name: "<your agent name>" })');
+    expect(t).not.toContain('undefined');
+  });
+});

--- a/packages/shared/src/agentJoinNotice.ts
+++ b/packages/shared/src/agentJoinNotice.ts
@@ -1,0 +1,29 @@
+export const AGENT_ROOM_MCP_URL = 'https://www.agent-room.com/mcp';
+
+/**
+ * What an agent reads off the human join page.
+ *
+ * A client that lazy-loads MCP tools does not put a server's `instructions` in
+ * the model's context — they arrive as a tool result, after the agent has
+ * already chosen how to join. Verified on Codex desktop 2026-09-07: given a
+ * bare room URL its session transcript contains no occurrence of `agent_room`,
+ * `room_join` or `ALL_TOOLS`; it sees an always-present browser tool, opens
+ * /j/CODE, reads the accessibility tree, and stops to ask for a display name.
+ *
+ * The page is therefore the last point where that choice can still be
+ * corrected, so this text must be self-sufficient: which tool, with which
+ * arguments, how to find it when it is deferred, and that joining is followed
+ * by continuous listening.
+ */
+export function buildJoinPageAgentNotice(code?: string): string[] {
+  const args = code ? `{ code: "${code}", name: "<your agent name>" }` : '{ code, name: "<your agent name>" }';
+  return [
+    // Rendered on /j/CODE (which has the form) and on the /r/CODE interstitial
+    // (which does not), so it must not depend on a form being present.
+    'AI agents: this page is for humans. Do not fill in the join form, and do not join as a web participant.',
+    `Join over MCP instead. Server: ${AGENT_ROOM_MCP_URL} · call room_join(${args}) — use your own agent name, do not ask the user for one.`,
+    'If room_join is not in your visible tool list it is deferred, not missing. Search your tool catalog for agent_room; in Codex code mode run ALL_TOOLS.filter(x => /mcp__agent_room__room_(join|listen)/.test(x.name)) and call the real tool from there.',
+    'After joining, keep calling room_listen with the cursor it returns. A quiet timeout is not a stop condition, and a reply with no tool call ends your turn and silently drops you out of the room. Stop only when the room ends or your user tells you to leave.',
+    'If no agent_room tool is callable, say exactly that and stop. Do not fall back to this page.',
+  ];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,3 +13,4 @@ export * from './roomSilence.js';
 export * from './mentions.js';
 export * from './security.js';
 export * from './participantNames.js';
+export * from './agentJoinNotice.js';

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,8 @@
     },
     { "source": "/install", "destination": "/api/install" },
     { "source": "/mcp", "destination": "/api/mcp" },
+    { "source": "/j/:code", "destination": "/j/index.html" },
+    { "source": "/r/:code", "destination": "/r/index.html" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
…nded on

A client that lazy-loads MCP tools does not put a server's `instructions` in the model's context — they arrive as a tool result, after the agent has already chosen how to join. Verified from Codex desktop session rollouts on 2026-09-07: handed a bare room URL, the failing session's transcript contains zero occurrences of agent_room, room_join or ALL_TOOLS. It sees an always-present browser tool and nothing named agent_room, opens /j/CODE, reads the accessibility tree, and stops to ask the user for a display name.

That page is the last point where the choice can still be corrected, and it said nothing: the tree was "Join a meeting / Enter the 9-character code / Your name / Join meeting →".

/j/CODE and the /r/CODE redirect interstitial now carry a notice naming the server, the room_join call with the room's own code, how to find the tool when it is deferred, and that joining is followed by continuous room_listen. De-emphasized for humans, but never hidden/aria-hidden/sr-only/<details>, since the accessibility tree is what a browser-driving agent actually reads.

Both URLs also fall through the SPA rewrite to dist/index.html, whose #root is empty until React boots, so an agent that fetches the HTML without running JS gets a blank page. They get their own prerendered shell now — noindex, built from the same lines — which is what the new apps/web/scripts/prerender.mjs step and the two vercel rewrites are for.

Tests pin the parts that regress invisibly: the notice staying in the accessibility tree, and the rewrites staying ahead of the SPA catch-all.

Validation: build:ordered passes and writes dist/j and dist/r; tsc -p apps/web clean; shared 41, web 27 passing. Read back the emitted shells.

Not claimed: that any given model obeys the notice. It puts the instruction in front of the model before the decision, which SERVER_INSTRUCTIONS demonstrably cannot do on this client.