### PR TITLE
fix(codex): bring the listen loop up to the commercial version

### DIFF
--- a/packages/shared/src/agentJoinNotice.test.ts
+++ b/packages/shared/src/agentJoinNotice.test.ts
@@ -21,8 +21,33 @@ describe('AGENT_ROOM_ASYNC_LISTEN', () => {
     expect(AGENT_ROOM_ASYNC_LISTEN).toContain('load("arCursor")');
   });
 
-  it('breaks out when there is something to act on', () => {
-    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('d.listenStatus !== "active" || d.messages?.length');
+  // Breaking on ANY message is the same failure in a new shape: in a room with
+  // other active participants it woke the model six times in 2m27s, and the
+  // sixth wake answered in prose and ended the turn. Wake on being addressed;
+  // the server holds the rest and hands them over in one batch.
+  it('wakes on being addressed, not on room traffic', () => {
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('wakeOn: "addressed"');
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('d.messages?.some(m => (m.text ?? "").includes("@" + name))');
+    expect(AGENT_ROOM_ASYNC_LISTEN).not.toContain('|| d.messages?.length) break');
+  });
+
+  it('still breaks when the room ends or removes the agent', () => {
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('if (d.listenStatus !== "active")');
+  });
+
+  // since: 0 replays the whole room and breaks the loop on the first poll.
+  it('says to seed the cursor from room_join', () => {
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('Seed arCursor from the cursor room_join returned');
+  });
+
+  // The prose is read once at session start; by the time the loop breaks it is
+  // minutes and dozens of tool calls back. The break used to hand over a bare
+  // { messages, cursor } — the request, with nothing saying what to do with it.
+  it('carries the imperative in the break, next to the request that caused it', () => {
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('addressed: true');
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('Answer it IN THE ROOM with room_send');
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('Do not reply to your own user instead');
+    expect(AGENT_ROOM_ASYNC_LISTEN).toContain('You are out of the room. Tell your user why and stop.');
   });
 
   it('names the anti-pattern it is replacing', () => {

--- a/packages/shared/src/agentJoinNotice.ts
+++ b/packages/shared/src/agentJoinNotice.ts
@@ -48,16 +48,20 @@ export function buildJoinPageAgentNotice(code?: string): string[] {
  * ran successfully, and it is scoped to code mode so other clients ignore it.
  */
 export const AGENT_ROOM_ASYNC_LISTEN = [
-  'Codex code mode: do NOT run one room_listen per exec. That is two tool calls per 45s, it spends the turn on waiting, and the turn ends. Run the loop inside ONE backgrounded cell instead:',
+  'Codex code mode: do NOT run one room_listen per exec. That is two tool calls per 45s, it spends the turn on waiting, and the turn ends. Run the loop inside ONE backgrounded cell instead. Seed arCursor from the cursor room_join returned — starting at 0 replays the whole room and wakes you immediately:',
   '// @exec: {"yield_time_ms": 1000}',
   'while (true) {',
-  '  const r = await tools.mcp__agent_room__room_listen({ code, name, since: load("arCursor") ?? 0, timeoutMs: 45000 });',
+  '  const r = await tools.mcp__agent_room__room_listen({ code, name, since: load("arCursor") ?? 0, timeoutMs: 45000, wakeOn: "addressed" });',
   '  let d; for (const c of r.content ?? []) { if (c.type === "text") { try { d = JSON.parse(c.text); } catch { text(c.text); } } else if (c.type === "image") image(c); }',
   '  if (!d) { text(r); break; }',
   '  store("arCursor", d.cursor);',
-  '  text({ messages: d.messages, cursor: d.cursor, listenStatus: d.listenStatus });',
-  '  if (d.listenStatus !== "active" || d.messages?.length) break;',
+  '  if (d.messages?.length) text({ messages: d.messages, cursor: d.cursor });',
+  '  if (d.listenStatus !== "active") { text({ listenStatus: d.listenStatus, do: "You are out of the room. Tell your user why and stop." }); break; }',
+  '  if (d.messages?.some(m => (m.text ?? "").includes("@" + name))) {',
+  '    text({ addressed: true, do: "This was addressed to you. Answer it IN THE ROOM with room_send (and room_task if it is task work), then start this cell again. Do not reply to your own user instead — a reply with no tool call ends your turn and drops you out of the room." });',
+  '    break;',
+  '  }',
   '  await yield_control();',
   '}',
-  'The cell keeps listening in the background, so your presence holds while you do other work. Collect it with functions.wait on that cell_id (yield_time_ms up to 45000 is accepted). When it breaks with messages, act on them, room_send if useful, then start the same cell again — `load("arCursor")` picks up where it left off. Never start a second listen while a cell is still pending, and never end your turn while one is.',
+  'The cell keeps listening in the background and only breaks when the room ends, you are removed, or someone addresses you by name — room chatter accumulates in the cell instead of interrupting you. Your presence holds the whole time, so use the turn for actual work. Collect the cell with functions.wait on its cell_id (yield_time_ms up to 45000 is accepted). When it breaks, act on what it hands you — that is a request meant for you, so answer it with room_send and the room_task tools, not with a status line to your own user — then start the same cell again; `load("arCursor")` picks up where it left off. Never start a second listen while a cell is still pending, and never end your turn while one is.',
 ].join('\n');


### PR DESCRIPTION
Follow-up to #56. That one stopped Codex joining through the browser; this one stops it dropping out five minutes after it joins.

## The measurement

Told to run one `room_listen` per exec and collect the cell with `functions.wait`, Codex spends its whole turn waiting. From the 2026-09-07 rollout, every such exec yields its cell at exactly **31.0s**, and the wait to collect it costs another ~14s — two tool calls per 45 seconds, with nothing else happening in between:

```
[62]  Wall time 31.0s -> cell 6
[69]  Wall time 13.3s
```

That session got seven listens out of 5m25s and then ended its turn. The result sitting in front of it when it stopped said `listenStatus: "active"`, `stay: true`, carried an unread message from another participant, and included the whole TURN MECHANICS paragraph telling it not to reply without a tool call. It was not disobeying — there was simply no turn left.

## The shape that works

Codex had already found it. On 2026-09-06, left to itself, it wrote the loop into a single backgrounded cell:

```js
// @exec: {"yield_time_ms": 1000}
while (true) {
  const r = await tools.mcp__agent_room__room_listen({ code, name, since: load("arCursor") ?? 0, timeoutMs: 45000 });
  ...
  store("arCursor", d.cursor);
  if (d.listenStatus !== "active" || d.messages?.length) break;
  await yield_control();
}
```

One exec plus an occasional `functions.wait`. The cell keeps polling in the background, so presence holds while the turn does something else — in that session it stayed in the room through file reads, a web search, a `node --test` run and several `room_send`s.

This repo had no Codex guidance at all, so it gets that loop as runnable code: a new `CODEX ASYNC TOOLS` line in `SERVER_INSTRUCTIONS`, paid once per session rather than on every listen, plus a pointer at the **tail** of the `room_listen` description — Codex reads those with `.description.slice(-700)`, so the last 700 characters are the only part guaranteed to be seen.

This couples us to the node_repl sandbox API (`store`/`load`/`yield_control`/`text`/`image`). The snippet is the one Codex itself ran successfully, and it is scoped to "Codex code mode", so other clients ignore it.

## A correction to #56's reasoning

#56 said `SERVER_INSTRUCTIONS` do not reach Codex. That is too strong. They ride along in the `ALL_TOOLS` entries, so they *do* arrive — just only after the model searches the catalog. What #56 actually established is that they cannot steer the browser-versus-MCP choice, because that choice happens before the search. Everything after the search, including this change, does land.

## Validation

- `npm run build:ordered` passed; prerender still writes `dist/j` and `dist/r`.
- `api/_mcpTools.ts` typechecked directly — this repo has no api tsconfig, so the web build's `tsc` does not cover it.
- Shared 45, web 27 passing.

## Not claimed

That this holds a turn open indefinitely. It removes the cost that was ending turns in five minutes; how long a turn then runs needs a live check. Whether the backgrounded cell survives a `final_answer` into the next turn is **unverified** — every trace we have is within a single turn.

Acceptance: a fresh Codex session, a bare room URL, no hooks and no `~/.codex/AGENTS.md`. It should start the listen loop with `// @exec` rather than one exec per listen, and still be present after ten-plus minutes with messages arriving in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
